### PR TITLE
Fix bug in voter causing muting on rx switch

### DIFF
--- a/src/svxlink/ChangeLog
+++ b/src/svxlink/ChangeLog
@@ -23,6 +23,9 @@
 * New squelch detector type, OPEN, which keeps the squelch open at all times.
   Used at calibration for example.
 
+* Bugfix: The receiver voter had a bug which caused incoming audio to be
+  muted if a receiver switch occurred in the middle of an identification.
+
 
 
  1.4.0 -- 02 aug 2014

--- a/src/svxlink/trx/Voter.cpp
+++ b/src/svxlink/trx/Voter.cpp
@@ -971,6 +971,7 @@ int Voter::ActiveRxSelected::sqlRxId(void)
 
 void Voter::ActiveRxSelected::changeActiveSrx(SatRx *srx)
 {
+  voter().selector->selectSource(srx);
   activeSrx()->setMuteState(MUTE_CONTENT);
   box().active_srx = srx;
   if (muteState() == Rx::MUTE_NONE)

--- a/src/versions
+++ b/src/versions
@@ -11,7 +11,7 @@ LIBASYNC=1.3.0
 LIBASYNC_RPM_RELEASE=1
 
 # SvxLink versions
-SVXLINK=1.4.99.0
+SVXLINK=1.4.99.1
 SVXLINK_RPM_RELEASE=1
 MODULE_HELP=1.0.0
 MODULE_PARROT=1.1.0
@@ -24,7 +24,7 @@ MODULE_DTMF_REPEATER=1.0.0
 MODULE_METARINFO=1.0.0
 
 # Version for the RemoteTrx application
-REMOTE_TRX=1.1.99.0
+REMOTE_TRX=1.1.99.1
 REMOTE_TRX_RELEASE=1
 
 # Version for the signal level calibration utility


### PR DESCRIPTION
This PR fixes #97. The receiver voter had a bug which caused incoming audio to be muted if a receiver switch occurred in the middle of an identification.
