### PR TITLE
Fixes to build with FreeBSD/clang...

### DIFF
--- a/src/async/audio/AsyncAudioDeviceOSS.cpp
+++ b/src/async/audio/AsyncAudioDeviceOSS.cpp
@@ -41,6 +41,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <sys/soundcard.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 #include <cassert>
 #include <cstring>

--- a/src/echolib/EchoLinkDirectoryCon.cpp
+++ b/src/echolib/EchoLinkDirectoryCon.cpp
@@ -206,11 +206,7 @@ int DirectoryCon::write(const void *data, unsigned len)
     }
     else
     {
-#ifdef ECOMM
       errno = EIO;
-#else
-      errno = EIO;
-#endif
       return -1;
     }
   }

--- a/src/echolib/EchoLinkDirectoryCon.cpp
+++ b/src/echolib/EchoLinkDirectoryCon.cpp
@@ -206,7 +206,11 @@ int DirectoryCon::write(const void *data, unsigned len)
     }
     else
     {
-      errno = ECOMM;
+#ifdef ECOMM
+      errno = EIO;
+#else
+      errno = EIO;
+#endif
       return -1;
     }
   }

--- a/src/echolib/EchoLinkDispatcher.h
+++ b/src/echolib/EchoLinkDispatcher.h
@@ -222,13 +222,6 @@ class Dispatcher : public sigc::trackable
       CtrlInputHandler	cih;
       AudioInputHandler aih;
     } ConData;
-    struct ipaddr_lt
-    {
-      bool operator()(const Async::IpAddress& a1, const Async::IpAddress& a2)
-      {
-	return a1 < a2;
-      }
-    };
     typedef std::map<Async::IpAddress, ConData> ConMap;
     
     static const int  	DEFAULT_PORT_BASE = 5198;

--- a/src/echolib/EchoLinkDispatcher.h
+++ b/src/echolib/EchoLinkDispatcher.h
@@ -229,7 +229,7 @@ class Dispatcher : public sigc::trackable
 	return a1 < a2;
       }
     };
-    typedef std::map<Async::IpAddress, ConData, ipaddr_lt> ConMap;
+    typedef std::map<Async::IpAddress, ConData> ConMap;
     
     static const int  	DEFAULT_PORT_BASE = 5198;
     

--- a/src/locationinfo/LocationInfo.cpp
+++ b/src/locationinfo/LocationInfo.cpp
@@ -483,7 +483,7 @@ int LocationInfo::calculateRange(const Cfg &cfg)
   }
 
   double tmp = sqrt(2.0 * loc_cfg.height * sqrt((loc_cfg.power / 10.0) *
-                        pow10(loc_cfg.gain / 10.0) / 2)) * range_factor;
+                        pow(10, loc_cfg.gain / 10.0) / 2)) * range_factor;
 
   return lrintf(tmp);
 

--- a/src/svxlink/devcal/CMakeLists.txt
+++ b/src/svxlink/devcal/CMakeLists.txt
@@ -1,5 +1,10 @@
+# Find the popt library
+find_package(Popt REQUIRED)
+include_directories(${POPT_INCLUDE_DIRS})
+add_definitions(${POPT_DEFINITIONS})
+
 add_executable(devcal devcal.cpp)
-target_link_libraries(devcal asyncaudio asynccpp trx popt)
+target_link_libraries(devcal asyncaudio asynccpp trx ${POPT_LIBRARIES})
 set_target_properties(devcal PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${RUNTIME_OUTPUT_DIRECTORY}
 )

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -22,7 +22,7 @@ CHECK_SYMBOL_EXISTS(HIDIOCGRAWINFO linux/hidraw.h HAS_HIDRAW_SUPPORT)
 if (HAS_HIDRAW_SUPPORT)
   set (LIBSRC ${LIBSRC} PttHidraw.cpp SquelchHidraw.cpp)
 else (HAS_HIDRAW_SUPPORT)
-  add_definitions(-DNO_HID)
+  add_definitions(-DHAS_HIDRAW_SUPPORT)
 endif (HAS_HIDRAW_SUPPORT)
 
 # Which other libraries this library depends on

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -18,7 +18,7 @@ set(LIBSRC
   WbRxRtlTcp.cpp SigLevDet.cpp SigLevDetDdr.cpp
 )
 include (CheckSymbolExists)
-CHECK_SYMBOL_EXISTS(HIDIOCGRAWINFO linux/hidraw HAS_HIDRAW_SUPPORT)
+CHECK_SYMBOL_EXISTS(HIDIOCGRAWINFO linux/hidraw.h HAS_HIDRAW_SUPPORT)
 if (HAS_HIDRAW_SUPPORT)
   set (LIBSRC ${LIBSRC} PttHidraw.cpp SquelchHidraw.cpp)
 else (HAS_HIDRAW_SUPPORT)

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -14,10 +14,16 @@ set(LIBSRC
   SigLevDetTone.cpp Sel5Decoder.cpp SwSel5Decoder.cpp
   SquelchEvDev.cpp Macho.cpp SquelchGpio.cpp Ptt.cpp
   PttGpio.cpp PttSerialPin.cpp PttPty.cpp
-  PtyDtmfDecoder.cpp PttHidraw.cpp SquelchHidraw.cpp
-  LocalRxBase.cpp Ddr.cpp RtlTcp.cpp WbRxRtlTcp.cpp
-  SigLevDet.cpp SigLevDetDdr.cpp
+  PtyDtmfDecoder.cpp LocalRxBase.cpp Ddr.cpp RtlTcp.cpp
+  WbRxRtlTcp.cpp SigLevDet.cpp SigLevDetDdr.cpp
 )
+include (CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(HIDIOCGRAWINFO linux/hidraw HAS_HIDRAW_SUPPORT)
+if (HAS_HIDRAW_SUPPORT)
+  set (LIBSRC ${LIBSRC} PttHidraw.cpp SquelchHidraw.cpp)
+else (HAS_HIDRAW_SUPPORT)
+  add_definitions(-DNO_HID)
+endif (HAS_HIDRAW_SUPPORT)
 
 # Which other libraries this library depends on
 #set(LIBS ${LIBS} asynccore)

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -21,7 +21,6 @@ include (CheckSymbolExists)
 CHECK_SYMBOL_EXISTS(HIDIOCGRAWINFO linux/hidraw.h HAS_HIDRAW_SUPPORT)
 if (HAS_HIDRAW_SUPPORT)
   set (LIBSRC ${LIBSRC} PttHidraw.cpp SquelchHidraw.cpp)
-else (HAS_HIDRAW_SUPPORT)
   add_definitions(-DHAS_HIDRAW_SUPPORT)
 endif (HAS_HIDRAW_SUPPORT)
 

--- a/src/svxlink/trx/LocalRxBase.cpp
+++ b/src/svxlink/trx/LocalRxBase.cpp
@@ -84,7 +84,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Emphasis.h"
 #include "SquelchPty.h"
 #include "SquelchOpen.h"
+#ifndef NO_HID
 #include "SquelchHidraw.h"
+#endif
 
 
 /****************************************************************************
@@ -449,10 +451,12 @@ bool LocalRxBase::initialize(void)
   {
     squelch_det = new SquelchPty;
   }
+#ifndef NO_HID
   else if (sql_det_str == "HIDRAW")
   {
     squelch_det = new SquelchHidraw;
   }
+#endif
   else
   {
     cerr << "*** ERROR: Unknown squelch type specified in config variable "

--- a/src/svxlink/trx/LocalRxBase.cpp
+++ b/src/svxlink/trx/LocalRxBase.cpp
@@ -84,7 +84,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Emphasis.h"
 #include "SquelchPty.h"
 #include "SquelchOpen.h"
-#ifndef NO_HID
+#ifdef HAS_HIDRAW_SUPPORT
 #include "SquelchHidraw.h"
 #endif
 
@@ -451,7 +451,7 @@ bool LocalRxBase::initialize(void)
   {
     squelch_det = new SquelchPty;
   }
-#ifndef NO_HID
+#ifdef HAS_HIDRAW_SUPPORT
   else if (sql_det_str == "HIDRAW")
   {
     squelch_det = new SquelchHidraw;

--- a/src/svxlink/trx/NetTrxMsg.h
+++ b/src/svxlink/trx/NetTrxMsg.h
@@ -176,8 +176,8 @@ class MsgProtoVer : public Msg
     MsgProtoVer(void)
       : Msg(TYPE, sizeof(MsgProtoVer)), m_major(MAJOR),
         m_minor(MINOR) {}
-    uint16_t major_ver(void) const { return m_major; }
-    uint16_t minor_ver(void) const { return m_minor; }
+    uint16_t majorVer(void) const { return m_major; }
+    uint16_t minorVer(void) const { return m_minor; }
   
   private:
     uint16_t m_major;

--- a/src/svxlink/trx/NetTrxMsg.h
+++ b/src/svxlink/trx/NetTrxMsg.h
@@ -176,8 +176,8 @@ class MsgProtoVer : public Msg
     MsgProtoVer(void)
       : Msg(TYPE, sizeof(MsgProtoVer)), m_major(MAJOR),
         m_minor(MINOR) {}
-    uint16_t major(void) const { return m_major; }
-    uint16_t minor(void) const { return m_minor; }
+    uint16_t major_ver(void) const { return m_major; }
+    uint16_t minor_ver(void) const { return m_minor; }
   
   private:
     uint16_t m_major;

--- a/src/svxlink/trx/NetTrxTcpClient.cpp
+++ b/src/svxlink/trx/NetTrxTcpClient.cpp
@@ -328,8 +328,8 @@ void NetTrxTcpClient::handleMsg(Msg *msg)
       {
         MsgProtoVer *ver_msg = reinterpret_cast<MsgProtoVer *>(msg);
         if ((msg->size() != sizeof(MsgProtoVer)) ||
-            (ver_msg->major_ver() != MsgProtoVer::MAJOR) ||
-            (ver_msg->minor_ver() != MsgProtoVer::MINOR))
+            (ver_msg->majorVer() != MsgProtoVer::MAJOR) ||
+            (ver_msg->minorVer() != MsgProtoVer::MINOR))
         {
           cerr << "*** ERROR: Incompatible protocol version. Disconnecting from "
                << remoteHost().toString() << ":" << remotePort() << "...\n";
@@ -337,8 +337,8 @@ void NetTrxTcpClient::handleMsg(Msg *msg)
           return;
         }
         cout << remoteHost().toString() << ":" << remotePort()
-             << ": RemoteTrx protocol version " << ver_msg->major_ver() << "."
-             << ver_msg->minor_ver() << endl;
+             << ": RemoteTrx protocol version " << ver_msg->majorVer() << "."
+             << ver_msg->minorVer() << endl;
         state = STATE_AUTH_WAIT;
       }
       else

--- a/src/svxlink/trx/NetTrxTcpClient.cpp
+++ b/src/svxlink/trx/NetTrxTcpClient.cpp
@@ -328,8 +328,8 @@ void NetTrxTcpClient::handleMsg(Msg *msg)
       {
         MsgProtoVer *ver_msg = reinterpret_cast<MsgProtoVer *>(msg);
         if ((msg->size() != sizeof(MsgProtoVer)) ||
-            (ver_msg->major() != MsgProtoVer::MAJOR) ||
-            (ver_msg->minor() != MsgProtoVer::MINOR))
+            (ver_msg->major_ver() != MsgProtoVer::MAJOR) ||
+            (ver_msg->minor_ver() != MsgProtoVer::MINOR))
         {
           cerr << "*** ERROR: Incompatible protocol version. Disconnecting from "
                << remoteHost().toString() << ":" << remotePort() << "...\n";
@@ -337,8 +337,8 @@ void NetTrxTcpClient::handleMsg(Msg *msg)
           return;
         }
         cout << remoteHost().toString() << ":" << remotePort()
-             << ": RemoteTrx protocol version " << ver_msg->major() << "."
-             << ver_msg->minor() << endl;
+             << ": RemoteTrx protocol version " << ver_msg->major_ver() << "."
+             << ver_msg->minor_ver() << endl;
         state = STATE_AUTH_WAIT;
       }
       else

--- a/src/svxlink/trx/Ptt.cpp
+++ b/src/svxlink/trx/Ptt.cpp
@@ -54,7 +54,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "PttSerialPin.h"
 #include "PttGpio.h"
 #include "PttPty.h"
+#ifndef NO_HID
 #include "PttHidraw.h"
+#endif
 
 
 
@@ -136,7 +138,9 @@ Ptt *PttFactoryBase::createNamedPtt(Config& cfg, const string& name)
   PttSerialPin::Factory serial_ptt_factory;
   PttGpio::Factory gpio_ptt_factory;
   PttPty::Factory pty_ptt_factory;
+#ifndef NO_HID
   PttHidraw::Factory hidraw_ptt_factory;
+#endif
   
   string ptt_type;
   if (!cfg.getValue(name, "PTT_TYPE", ptt_type) || ptt_type.empty())

--- a/src/svxlink/trx/Ptt.cpp
+++ b/src/svxlink/trx/Ptt.cpp
@@ -54,7 +54,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "PttSerialPin.h"
 #include "PttGpio.h"
 #include "PttPty.h"
-#ifndef NO_HID
+#ifdef HAS_HIDRAW_SUPPORT
 #include "PttHidraw.h"
 #endif
 
@@ -138,7 +138,7 @@ Ptt *PttFactoryBase::createNamedPtt(Config& cfg, const string& name)
   PttSerialPin::Factory serial_ptt_factory;
   PttGpio::Factory gpio_ptt_factory;
   PttPty::Factory pty_ptt_factory;
-#ifndef NO_HID
+#ifdef HAS_HIDRAW_SUPPORT
   PttHidraw::Factory hidraw_ptt_factory;
 #endif
   

--- a/src/svxlink/trx/SwDtmfDecoder.cpp
+++ b/src/svxlink/trx/SwDtmfDecoder.cpp
@@ -175,14 +175,14 @@ bool SwDtmfDecoder::initialize(void)
   {
     int cfg_fwd_twist = atoi(value.c_str());
     if (cfg_fwd_twist >= 0)
-      normal_twist = exp10f(cfg_fwd_twist/10.0f);
+      normal_twist = powf(10,cfg_fwd_twist/10.0f);
   }
   
   if (cfg().getValue(name(), "DTMF_MAX_REV_TWIST", value))
   {
     int cfg_rev_twist = atoi(value.c_str());
     if (cfg_rev_twist >= 0)
-      reverse_twist = exp10f(cfg_rev_twist/10.0f);
+      reverse_twist = powf(10,cfg_rev_twist/10.0f);
   }
   
   return true;

--- a/src/svxlink/trx/ToneDetector.cpp
+++ b/src/svxlink/trx/ToneDetector.cpp
@@ -335,7 +335,7 @@ void ToneDetector::setDetectPeakThresh(float thresh)
 {
   if (thresh > 0.0f)
   {
-    det_par->peak_thresh = exp10f(thresh/10.0f);
+    det_par->peak_thresh = powf(10, thresh/10.0f);
   }
   else
   {
@@ -348,7 +348,7 @@ void ToneDetector::setUndetectPeakThresh(float thresh)
 {
   if (thresh > 0.0f)
   {
-    undet_par->peak_thresh = exp10f(thresh/10.0f);
+    undet_par->peak_thresh = powf(10, thresh/10.0f);
   }
   else
   {


### PR DESCRIPTION
Include stdlib.h where needed
If ECOMM isn't defined (it's non-standard) set errno to EIO
Clang doesn't work using class methods in private typdefs.  Luckily,
less<T> works properly in this case, so we don't need to specify a
comparison expression.
exp10f(x) is non-standard.  Use pow(10, x) instead.
Detect (and disable if not present) HID support.
Use find_package(Popt...) for devcal.