### PR TITLE
Fix docblocks

### DIFF
--- a/src/async/audio/AsyncAudioFilter.h
+++ b/src/async/audio/AsyncAudioFilter.h
@@ -159,7 +159,7 @@ class AudioFilter : public AudioProcessor
 
     /**
      * @brief 	Set the output gain of the filter
-     * @param 	gain The gain to set in dB
+     * @param 	gain_db The gain to set in dB
      *
      * Use this function to apply a gain (positive) or attenuation (negative)
      * after the filter output. A gain of 6dB will amplify the signal with

--- a/src/async/audio/AsyncSigCAudioSink.h
+++ b/src/async/audio/AsyncSigCAudioSink.h
@@ -137,9 +137,9 @@ class SigCAudioSink : public AudioSink, public sigc::trackable
      * When called by the source, the sigWriteSamples function will be
      * emitted.
      */
-    virtual int writeSamples(const float *samples, int len)
+    virtual int writeSamples(const float *samples, int count)
     {
-      return sigWriteSamples(const_cast<float *>(samples), len);
+      return sigWriteSamples(const_cast<float *>(samples), count);
     }
     
     /**

--- a/src/async/audio/AsyncSigCAudioSource.h
+++ b/src/async/audio/AsyncSigCAudioSource.h
@@ -156,9 +156,9 @@ class SigCAudioSource : public AudioSource, public sigc::trackable
      * returns 0, no more samples should be written until the sigResumeOutput
      * signal have been emitted.
      */
-    int writeSamples(float *samples, int len)
+    int writeSamples(float *samples, int count)
     {
-      return sinkWriteSamples(samples, len);
+      return sinkWriteSamples(samples, count);
     }
 
     /**

--- a/src/async/core/AsyncExec.h
+++ b/src/async/core/AsyncExec.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 \endverbatim
 */
 
-/** @example Exec_demo.cpp
+/** @example AsyncExec_demo.cpp
 An example of how to use the Exec class
 */
 
@@ -126,7 +126,7 @@ class.
 This class depends on the SIGCHLD UNIX signal so it must not be used by
 another part of the application.
 
-\include Exec_demo.cpp
+\include AsyncExec_demo.cpp
 */
 class Exec : public sigc::trackable
 {

--- a/src/async/core/AsyncPty.h
+++ b/src/async/core/AsyncPty.h
@@ -1,5 +1,5 @@
 /**
-@file	 Pty.h
+@file	 AsyncPty.h
 @brief   A class that wrap up some functionality to use a PTY
 @author  Tobias Blomberg / SM0SVX
 @date	 2014-06-07

--- a/src/async/core/AsyncPtyStreamBuf.h
+++ b/src/async/core/AsyncPtyStreamBuf.h
@@ -127,6 +127,7 @@ class PtyStreamBuf : public std::streambuf
     /**
      * @brief 	Default constructor
      * @param   pty A previously created PTY object
+     * @param   buf_size The buffer size
      */
     explicit PtyStreamBuf(Pty *pty, std::size_t buf_size=256);
   
@@ -136,9 +137,8 @@ class PtyStreamBuf : public std::streambuf
     ~PtyStreamBuf(void);
   
     /**
-     * @brief 	A_brief_member_function_description
-     * @param 	param1 Description_of_param1
-     * @return	Return_value_of_this_member_function
+     * @brief 	Return the PTY this stream is attached to
+     * @return	The PTY
      */
     Pty *pty(void) const { return m_pty; }
     

--- a/src/async/core/AsyncTcpServer.h
+++ b/src/async/core/AsyncTcpServer.h
@@ -129,6 +129,7 @@ class TcpServer : public sigc::trackable
     /**
      * @brief 	Default constuctor
      * @param 	port_str A port number or service name to listen to
+     * @param 	bind_ip The IP to bind the server to
      */
     TcpServer(const std::string& port_str,
               const Async::IpAddress &bind_ip=IpAddress());

--- a/src/doc/doxygen.async.in
+++ b/src/doc/doxygen.async.in
@@ -669,7 +669,7 @@ EXCLUDE_SYMBOLS        =
 # directories that contain example code fragments that are included (see
 # the \include command).
 
-EXAMPLE_PATH           = async/demo
+EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@/async/demo
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp

--- a/src/doc/doxygen.echolib.in
+++ b/src/doc/doxygen.echolib.in
@@ -669,7 +669,7 @@ EXCLUDE_SYMBOLS        =
 # directories that contain example code fragments that are included (see
 # the \include command).
 
-EXAMPLE_PATH           = echolib
+EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@/echolib
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp


### PR DESCRIPTION
This patch fixes most of the warnings which are currently issued during the generation of the documentation. A single issue still remains: `EchoLinkProxy_demo.cpp` does not exist yet.