### PR TITLE
Build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: cpp
+
+sudo: required
+
+dist: trusty
+
+compiler: gcc
+
+env:
+  - QT_PACKAGES="libqt4-dev"
+  - QT_PACKAGES="qtbase5-dev qttools5-dev qttools5-dev-tools"
+
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y cmake doxygen groff libsigc++-2.0-dev libgsm1-dev libpopt-dev tcl8.5-dev libgcrypt11-dev libspeex-dev libasound2-dev libopus-dev librtlsdr-dev $QT_PACKAGES
+
+before_script:
+  - mkdir build
+  - cd build
+
+script:
+  - cmake ../src
+  - cmake --build .
+  - cmake --build . --target doc

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 SvxLink
 =======
 
+image:https://travis-ci.org/sm0svx/svxlink.svg?branch=master["Build Status", link="https://travis-ci.org/sm0svx/svxlink"]
 image:https://badges.gitter.im/Join%20Chat.svg[link="https://gitter.im/sm0svx/svxlink?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 
 SvxLink is a project that develops software targeting the ham radio community.


### PR DESCRIPTION
To check whether new pull requests break the build, we could use Travis CI to check if the build succeeds. This way we would have a clean, reproducible build environment and an immediate feedback on contributions.

To enable Travis, simply [sign up](https://travis-ci.org/auth) and enable it for `sm0svx/svxlink`. Afterwards all new pull-requests are automatically built on Travis.

With the proposed configuration the project is tested with QT4 and QT5.