### PR TITLE
Added control pty for echolink module

### DIFF
--- a/src/svxlink/modules/echolink/ModuleEchoLink.h
+++ b/src/svxlink/modules/echolink/ModuleEchoLink.h
@@ -75,6 +75,7 @@ namespace Async
   class AudioSplitter;
   class AudioValve;
   class AudioSelector;
+  class Pty;
 };
 namespace EchoLink
 {
@@ -220,6 +221,8 @@ class ModuleEchoLink : public Module
     void squelchOpen(bool is_open);
     int audioFromRx(float *samples, int count);
     void allMsgsWritten(void);
+    void commandHandler(const void *buf, size_t count); // WIM
+    Async::Pty                      *pty;
 
     void onStatusChanged(EchoLink::StationData::Status status);
     void onStationListUpdated(void);


### PR DESCRIPTION
This pty (ECHOLINK_PTY) let's one disconnect clients.
Sending the word 'KILL' will disconnect the current talker, if there is one.
Sending <CALL>:D will disconnect the client associated with the <CALL> call sign.
The purpose of this is to allow the operator to disconnect users that forget to un-key their transmit.
