### PR TITLE
Added a control pty for the voter

### DIFF
--- a/src/svxlink/trx/Rx.h
+++ b/src/svxlink/trx/Rx.h
@@ -163,6 +163,12 @@ class Rx : public sigc::trackable, public Async::AudioSource
     virtual void setVerbose(bool verbose) { m_verbose = verbose; }
 
     /**
+     * @brief   Set the enabled state of the receiver
+     * @param   eneabled Set to \em false to disable receiver
+     */
+    virtual void setEnabled(bool);
+
+    /**
      * @brief 	Set the mute state for this receiver
      * @param 	mute_state The mute state to set for this receiver
      */
@@ -278,7 +284,9 @@ class Rx : public sigc::trackable, public Async::AudioSource
   private:
     std::string   m_name;
     bool          m_verbose;
+    bool          m_enabled;
     bool      	  m_sql_open;
+    bool      	  m_sql_open_hidden;
     Async::Config m_cfg;
     Async::Timer  *m_sql_tmo_timer;
     

--- a/src/svxlink/trx/Rx.h
+++ b/src/svxlink/trx/Rx.h
@@ -132,6 +132,18 @@ class Rx : public sigc::trackable, public Async::AudioSource
       MUTE_ALL      //! Mute everything. Also close the audio device.
     } MuteState;
 
+    /**
+     * @brief 	Set the enabled status, close squelch if disabled
+     * @param   state The status
+     */
+    void setEnabled(bool status);
+
+    /**
+     * @brief 	Get the enabled state
+     * @return   The status
+     */
+    bool isEnabled(void);
+
     static std::string muteStateToString(MuteState mute_state);
 
     /**
@@ -163,17 +175,11 @@ class Rx : public sigc::trackable, public Async::AudioSource
     virtual void setVerbose(bool verbose) { m_verbose = verbose; }
 
     /**
-     * @brief   Set the enabled state of the receiver
-     * @param   eneabled Set to \em false to disable receiver
-     */
-    virtual void setEnabled(bool);
-
-    /**
      * @brief 	Set the mute state for this receiver
      * @param 	mute_state The mute state to set for this receiver
      */
     virtual void setMuteState(MuteState new_mute_state) = 0;
-    
+
     /**
      * @brief 	Check the squelch status
      * @return	Return \em true if the squelch is open or else \em false
@@ -284,11 +290,11 @@ class Rx : public sigc::trackable, public Async::AudioSource
   private:
     std::string   m_name;
     bool          m_verbose;
-    bool          m_enabled;
     bool      	  m_sql_open;
     bool      	  m_sql_open_hidden;
     Async::Config m_cfg;
     Async::Timer  *m_sql_tmo_timer;
+    bool          m_is_enabled;
     
     void sqlTimeout(Async::Timer *t);
     

--- a/src/svxlink/trx/Voter.h
+++ b/src/svxlink/trx/Voter.h
@@ -68,6 +68,7 @@ namespace Async
 {
   class Timer;
   class AudioSelector;
+  class Pty;
 };
 
 
@@ -198,6 +199,9 @@ class Voter : public Rx
     static CONSTEXPR unsigned MIN_REVOTE_INTERVAL            = 100;
     static CONSTEXPR unsigned MAX_REVOTE_INTERVAL            = 60000;
     static CONSTEXPR unsigned MAX_RX_SWITCH_DELAY            = 3000;
+    void commandHandler(const void *buf, size_t count); // WIM
+    void disableSat(char *name);
+    void enableSat(char *name);
     
     class SatRx;
 
@@ -418,7 +422,9 @@ class Voter : public Rx
     void unmuteAll(void);
     void resetAll(void);
     void printSquelchState(void);
+    void printOperationalState(void);
     SatRx *findBestRx(void) const;
+    Async::Pty                      *voter_pty;
 
 };  /* class Voter */
 

--- a/src/svxlink/trx/Voter.h
+++ b/src/svxlink/trx/Voter.h
@@ -199,10 +199,8 @@ class Voter : public Rx
     static CONSTEXPR unsigned MIN_REVOTE_INTERVAL            = 100;
     static CONSTEXPR unsigned MAX_REVOTE_INTERVAL            = 60000;
     static CONSTEXPR unsigned MAX_RX_SWITCH_DELAY            = 3000;
-    void commandHandler(const void *buf, size_t count); // WIM
-    void disableSat(char *name);
-    void enableSat(char *name);
-    
+	void commandHandler(const void *buf, size_t count);
+	void setRxStatus(char *name, bool status);
     class SatRx;
 
     TOPSTATE(Top)
@@ -422,9 +420,9 @@ class Voter : public Rx
     void unmuteAll(void);
     void resetAll(void);
     void printSquelchState(void);
-    void printOperationalState(void);
+    void setRxStatus(void);
     SatRx *findBestRx(void) const;
-    Async::Pty                      *voter_pty;
+	Async::Pty *voter_pty;
 
 };  /* class Voter */
 


### PR DESCRIPTION
This let's the operator control the connected RXes, ie. enable/disable them.
For this, RXes get a new flag m_enabled, get-able by isEnabled, set-able by setEnabled.
The Voter has been changed on multiple locations in the code to accomodate this.
The state_pty now has an extra character marking for the disabled state: '#'
The m_sql_open_hidden was put in to 'follow' the squelch state while in disabled state.
 This allows the code to set the correct sqluelch state on re-enable.
