### PR TITLE
Implement fallback to FRN backup server

### DIFF
--- a/src/doc/man/ModuleFrn.conf.5
+++ b/src/doc/man/ModuleFrn.conf.5
@@ -33,6 +33,14 @@ http://freeradionetwork.eu web page.
 .TP
 .B PORT
 FRN server port number
+.TP
+.B SERVER_BACKUP
+Free Radio Network (FRN) backup server hostname or ip address. When connectivity
+to main SERVER is not possible connection will fallback to this server.
+.TP
+.B PORT_BACKUP
+FRN backup server port number
+.
 .TP 
 .B VERSION
 Identify itself as a FRN client with this version.

--- a/src/svxlink/modules/frn/ModuleFrn.conf
+++ b/src/svxlink/modules/frn/ModuleFrn.conf
@@ -5,8 +5,16 @@ ID=7
 TIMEOUT=300
 
 # Details http://freeradionetwork.eu/frnprotocol.htm
+
+# main server
 SERVER=127.0.0.1
 PORT=10024
+
+# backup server
+SERVER_BACKUP=127.0.0.2
+PORT_BACKUP=10025
+
+# login details
 VERSION=2014000
 EMAIL_ADDRESS=your@example.com
 DYN_PASSWORD=12345
@@ -18,5 +26,6 @@ COUNTRY=Antarctica
 CITY_CITY_PART="City - Street"
 NET=Test
 
+# debugging
 #FRN_DEBUG=1
 #DISABLE_RF=1

--- a/src/svxlink/modules/frn/QsoFrn.h
+++ b/src/svxlink/modules/frn/QsoFrn.h
@@ -194,7 +194,7 @@ class QsoFrn
     /**
      * @brief Method to put QSO to live
      */
-    void connect(void);
+    void connect(bool is_backup=false);
 
     /**
      * @brief Disconnect QSO from server, put it to disconnected state
@@ -533,9 +533,10 @@ class QsoFrn
     static const int    RX_TIMEOUT_TIME         = 1000;
     static const int    KEEPALIVE_TIMEOUT_TIME  = 5000;
 
-    static const int    MAX_CONNECT_RETRY_CNT   = 5;
-    static const int    RECONNECT_TIMEOUT_TIME  = 2000;
-    static const int    RECONNECT_BACKOFF       = 5;
+    static const int    MAX_CONNECT_RETRY_CNT   = 10;
+    static const int    RECONNECT_TIMEOUT_TIME  = 5*1000;
+    static const int    RECONNECT_MAX_TIMEOUT   = 2*60*1000;
+    const float         RECONNECT_BACKOFF       = 1.2f;
 
     bool                init_ok;
 
@@ -556,10 +557,14 @@ class QsoFrn
     bool                is_receiving_voice;
     bool                is_rf_disabled;
     int                 reconnect_timeout_ms;
+    std::string         server;
+    std::string         port;
 
     bool                opt_frn_debug;
     std::string         opt_server;
     std::string         opt_port;
+    std::string         opt_server_backup;
+    std::string         opt_port_backup;
     std::string         opt_version;
     std::string         opt_email_address;
     std::string         opt_dyn_password;


### PR DESCRIPTION
This pull request adds two additional optional variables so user can specify fallback free radio network server. When connectivity to main server fails it will fallback to this backup server and vise versa.