### PR TITLE
Replace TX0 request with RX0 on client stream completion

### DIFF
--- a/src/svxlink/modules/frn/QsoFrn.cpp
+++ b/src/svxlink/modules/frn/QsoFrn.cpp
@@ -422,7 +422,7 @@ void QsoFrn::flushSamples(void)
       sendVoiceData(send_buffer, send_buffer_cnt);
       send_buffer_cnt = 0;
     }
-    sendRequest(RQ_TX0);
+    sendRequest(RQ_RX0);
   }
   sourceAllSamplesFlushed();
 }


### PR DESCRIPTION
Seems that FRN stock client sends RX0 command on client squelch close / audio stream completion, but not TX0 as in specification. This one liner makes this change.