### PR TITLE
Adding support for custom user:group

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,11 @@ set(LIBS ${LIBS} ${SIGC2_LIBRARIES})
 # Find the chown utility
 include(FindCHOWN)
 
+set(SVXLINK_USER "svxlink" CACHE STRING "Set SVXLink system user")
+set(SVXLINK_GROUP "daemon" CACHE STRING "Set SVXLink system group")
+message(STATUS "SVXLink user = ${SVXLINK_USER}")
+message(STATUS "SVXLink group = ${SVXLINK_GROUP}")
+
 # Add directories to build
 add_subdirectory(async)
 add_subdirectory(misc)

--- a/src/svxlink/modules/propagation_monitor/CMakeLists.txt
+++ b/src/svxlink/modules/propagation_monitor/CMakeLists.txt
@@ -12,7 +12,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/procmailrc.in
   )
 
 # Install targets
-install_mkdir(${SVX_SPOOL_INSTALL_DIR}/propagation_monitor svxlink.daemon)
+install_mkdir(${SVX_SPOOL_INSTALL_DIR}/propagation_monitor ${SVXLINK_USER}.${SVXLINK_GROUP})
 install(FILES Module${MODNAME}.tcl DESTINATION ${SVX_SHARE_INSTALL_DIR}/modules.d)
 install(FILES ${MODNAME}.tcl DESTINATION ${SVX_SHARE_INSTALL_DIR}/events.d)
 install_if_not_exists(${CMAKE_CURRENT_BINARY_DIR}/Module${MODNAME}.conf

--- a/src/svxlink/modules/tcl_voice_mail/CMakeLists.txt
+++ b/src/svxlink/modules/tcl_voice_mail/CMakeLists.txt
@@ -14,7 +14,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ModuleTclVoiceMail.tcl.in
   )
 
 # Install targets
-install_mkdir(${SVX_SPOOL_INSTALL_DIR}/voice_mail svxlink.daemon)
+install_mkdir(${SVX_SPOOL_INSTALL_DIR}/voice_mail ${SVXLINK_USER}.${SVXLINK_GROUP})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Module${MODNAME}.tcl
   DESTINATION ${SVX_SHARE_INSTALL_DIR}/modules.d
   )

--- a/src/svxlink/scripts/CMakeLists.txt
+++ b/src/svxlink/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Install targets
-install_mkdir(${SVX_SPOOL_INSTALL_DIR} svxlink.daemon)
+install_mkdir(${SVX_SPOOL_INSTALL_DIR} ${SVXLINK_USER}.${SVXLINK_GROUP})
 install(FILES etc/logrotate.d/svxlink etc/logrotate.d/remotetrx
   DESTINATION ${SYSCONF_INSTALL_DIR}/logrotate.d
   )

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -70,7 +70,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxlink_gpio_down.in
 
 # Install targets
 install(TARGETS svxlink DESTINATION ${BIN_INSTALL_DIR})
-install_mkdir(${SVX_SPOOL_INSTALL_DIR}/qso_recorder svxlink.daemon)
+install_mkdir(${SVX_SPOOL_INSTALL_DIR}/qso_recorder ${SVXLINK_USER}.${SVXLINK_GROUP})
 install_mkdir(${SVX_SHARE_INSTALL_DIR}/sounds)
 install_if_not_exists(${CMAKE_CURRENT_BINARY_DIR}/svxlink.conf
   ${SVX_SYSCONF_INSTALL_DIR}


### PR DESCRIPTION
I've added support for entering a custom value for username and group by replacing hardcoded value with CMake cache property.