### PR TITLE
Switched from ::abs to std::fabs

### DIFF
--- a/src/async/audio/AsyncAudioDeviceAlsa.cpp
+++ b/src/async/audio/AsyncAudioDeviceAlsa.cpp
@@ -548,7 +548,7 @@ bool AudioDeviceAlsa::initParams(snd_pcm_t *pcm_handle)
     return false;
   }
 
-  if (::abs(real_rate - sample_rate) > 100)
+  if (std::fabs(real_rate - sample_rate) > 100)
   {
     cerr << "*** ERROR: The sample rate could not be set to "
          << sample_rate << "Hz for ALSA device \"" << dev_name << "\". "


### PR DESCRIPTION
Was getting a build error on arch linux.
As of issue: https://github.com/sm0svx/svxlink/issues/287
And my issue: https://github.com/sm0svx/svxlink/issues/284

From what I understand the compiler was trying to use the C version of abs as opposed to the C++ version.
It seems to compile fine after the change.