### PR TITLE
Allow svxlink/qt frontend to compile and run on freebsd

### DIFF
--- a/src/async/core/AsyncTcpServer.cpp
+++ b/src/async/core/AsyncTcpServer.cpp
@@ -202,7 +202,7 @@ TcpServer::TcpServer(const string& port_str, const Async::IpAddress &bind_ip)
   {
     addr.sin_addr = bind_ip.ip4Addr();
   }
-  if (bind(sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in)) != 0)
+  if (::bind(sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in)) != 0)
   {
     perror("bind");
     cleanup();

--- a/src/async/core/AsyncUdpSocket.cpp
+++ b/src/async/core/AsyncUdpSocket.cpp
@@ -189,8 +189,7 @@ UdpSocket::UdpSocket(uint16_t local_port, const IpAddress &bind_ip)
     {
       addr.sin_addr = bind_ip.ip4Addr();
     }
-    if(bind(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr))
-	== -1)
+    if(::bind(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) == -1)
     {
       perror("bind");
       cleanup();

--- a/src/svxlink/modules/propagation_monitor/CMakeLists.txt
+++ b/src/svxlink/modules/propagation_monitor/CMakeLists.txt
@@ -12,7 +12,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/procmailrc.in
   )
 
 # Install targets
-install_mkdir(${SVX_SPOOL_INSTALL_DIR}/propagation_monitor ${SVXLINK_USER}.${SVXLINK_GROUP})
+install_mkdir(${SVX_SPOOL_INSTALL_DIR}/propagation_monitor ${SVXLINK_USER}:${SVXLINK_GROUP})
 install(FILES Module${MODNAME}.tcl DESTINATION ${SVX_SHARE_INSTALL_DIR}/modules.d)
 install(FILES ${MODNAME}.tcl DESTINATION ${SVX_SHARE_INSTALL_DIR}/events.d)
 install_if_not_exists(${CMAKE_CURRENT_BINARY_DIR}/Module${MODNAME}.conf

--- a/src/svxlink/modules/tcl_voice_mail/CMakeLists.txt
+++ b/src/svxlink/modules/tcl_voice_mail/CMakeLists.txt
@@ -14,7 +14,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ModuleTclVoiceMail.tcl.in
   )
 
 # Install targets
-install_mkdir(${SVX_SPOOL_INSTALL_DIR}/voice_mail ${SVXLINK_USER}.${SVXLINK_GROUP})
+install_mkdir(${SVX_SPOOL_INSTALL_DIR}/voice_mail ${SVXLINK_USER}:${SVXLINK_GROUP})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Module${MODNAME}.tcl
   DESTINATION ${SVX_SHARE_INSTALL_DIR}/modules.d
   )

--- a/src/svxlink/scripts/CMakeLists.txt
+++ b/src/svxlink/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Install targets
-install_mkdir(${SVX_SPOOL_INSTALL_DIR} ${SVXLINK_USER}.${SVXLINK_GROUP})
+install_mkdir(${SVX_SPOOL_INSTALL_DIR} ${SVXLINK_USER}:${SVXLINK_GROUP})
 install(FILES etc/logrotate.d/svxlink etc/logrotate.d/remotetrx
   DESTINATION ${SYSCONF_INSTALL_DIR}/logrotate.d
   )

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -31,9 +31,9 @@ include_directories(${GCRYPT_INCLUDE_DIRS})
 add_definitions(${GCRYPT_DEFINITIONS})
 
 # Find the dl library
-find_package(DL REQUIRED)
-set(LIBS ${LIBS} ${DL_LIBRARIES})
-include_directories(${DL_INCLUDES})
+#find_package(DL REQUIRED)
+#set(LIBS ${LIBS} ${DL_LIBRARIES})
+#include_directories(${DL_INCLUDES})
 
 # Add project libraries
 set(LIBS ${LIBS} trx locationinfo asynccpp asyncaudio asynccore)
@@ -70,7 +70,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxlink_gpio_down.in
 
 # Install targets
 install(TARGETS svxlink DESTINATION ${BIN_INSTALL_DIR})
-install_mkdir(${SVX_SPOOL_INSTALL_DIR}/qso_recorder ${SVXLINK_USER}.${SVXLINK_GROUP})
+install_mkdir(${SVX_SPOOL_INSTALL_DIR}/qso_recorder ${SVXLINK_USER}:${SVXLINK_GROUP})
 install_mkdir(${SVX_SHARE_INSTALL_DIR}/sounds)
 install_if_not_exists(${CMAKE_CURRENT_BINARY_DIR}/svxlink.conf
   ${SVX_SYSCONF_INSTALL_DIR}

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -30,10 +30,10 @@ set(LIBS ${LIBS} ${GCRYPT_LIBRARIES})
 include_directories(${GCRYPT_INCLUDE_DIRS})
 add_definitions(${GCRYPT_DEFINITIONS})
 
-# Find the dl library
-#find_package(DL REQUIRED)
-#set(LIBS ${LIBS} ${DL_LIBRARIES})
-#include_directories(${DL_INCLUDES})
+# Find the dl library - only for Linux, not required for FreeBSD
+find_package(DL)
+set(LIBS ${LIBS} ${DL_LIBRARIES})
+include_directories(${DL_INCLUDES})
 
 # Add project libraries
 set(LIBS ${LIBS} trx locationinfo asynccpp asyncaudio asynccore)

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -31,9 +31,11 @@ include_directories(${GCRYPT_INCLUDE_DIRS})
 add_definitions(${GCRYPT_DEFINITIONS})
 
 # Find the dl library - only for Linux, not required for FreeBSD
-find_package(DL)
-set(LIBS ${LIBS} ${DL_LIBRARIES})
-include_directories(${DL_INCLUDES})
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  find_package(DL REQUIRED)
+  set(LIBS ${LIBS} ${DL_LIBRARIES})
+  include_directories(${DL_INCLUDES})
+endif()
 
 # Add project libraries
 set(LIBS ${LIBS} trx locationinfo asynccpp asyncaudio asynccore)


### PR DESCRIPTION
Hi! kk6vqk here! thanks for the great software!

I've brought this up on FreeBSD. There are a couple of compile issues:

* -ldl isn't required on freebsd, so making DL a REQUIRED module isn't great!
* chown requires ':' as the user/group delimiter; '.' is very deprecated;
* A couple of places needed ::bind() instead of bind() - likely a bunch of quick auditing of the network code should be done to make sure other things are ::'ed to set the scope right.

This pull request addresses these!


-adrian