### PR TITLE
Remove obsolete systemd targets

### DIFF
--- a/src/svxlink/systemd/remotetrx.service.in
+++ b/src/svxlink/systemd/remotetrx.service.in
@@ -3,7 +3,7 @@
 [Unit]
 Description=SvxLink remote transceiver repeater control software
 Requires=svxlink_gpio_setup.service
-After=network.target remote-fs.target syslog.target time.target
+After=network.target remote-fs.target time.target
 After=svxlink_gpio_setup.service
 
 [Service]

--- a/src/svxlink/systemd/svxlink.service.in
+++ b/src/svxlink/systemd/svxlink.service.in
@@ -3,7 +3,7 @@
 [Unit]
 Description=SvxLink repeater control software
 Requires=svxlink_gpio_setup.service
-After=network.target remote-fs.target syslog.target time.target
+After=network.target remote-fs.target time.target
 After=svxlink_gpio_setup.service
 
 [Service]


### PR DESCRIPTION
At least on Debian, syslog is now socket driven and starts up on demand.