### PR TITLE
Add CMake install target for devcal

### DIFF
--- a/src/svxlink/devcal/CMakeLists.txt
+++ b/src/svxlink/devcal/CMakeLists.txt
@@ -18,3 +18,6 @@ set_target_properties(devcal PROPERTIES
 #set_target_properties(noisegen PROPERTIES
 #  RUNTIME_OUTPUT_DIRECTORY ${RUNTIME_OUTPUT_DIRECTORY}
 #)
+
+# Install targets
+install(TARGETS devcal DESTINATION ${BIN_INSTALL_DIR})


### PR DESCRIPTION
From Debian packaging. Devcal will ship in the upcoming Debian package, but it wasn't being installed.
