### PR TITLE
fix missing macro error on manpage

### DIFF
--- a/src/doc/man/ModuleFrn.conf.5
+++ b/src/doc/man/ModuleFrn.conf.5
@@ -69,7 +69,7 @@ Your callsign and user name used during registration, for example "1234, Bob".
 In case of PC only user, this is 'PC Only'.
 In case of a crosslink this is 'Crosslink'.
 In case of a gateway this is the frequancy in full Mhz and kHz separated by a
-'.' (dot), followed by the mode 'FM', 'AM' or 'DIG', followed by a space and 
+ '.' (dot), followed by the mode 'FM', 'AM' or 'DIG', followed by a space and
 the squelch type 'CTC', 'DSC' or 'NONE' followed by the CTC frequency or ID 
 code.
 


### PR DESCRIPTION
From Debian packaging. Somehow, the dot looks like a macro even with quotes. A space fixes it.
