### PR TITLE
Adding config variables for CW playout

### DIFF
--- a/src/doc/man/svxlink.conf.5
+++ b/src/doc/man/svxlink.conf.5
@@ -171,6 +171,18 @@ load. This tells SvxLink which modules to actually load on startup.
 .B CALLSIGN
 Specify the callsign that should be announced on the radio interface.
 .TP
+.B CW_AMP
+Specify the amplitude of the CW that should be used during any cw traffic, 
+typically announcements.
+.TP
+.B CW_PITCH
+Specify the pitch (frequency) of the CW that should be used during any cw 
+traffic, typically announcements.
+.TP
+.B CW_WPM
+Specify the Words Per Minute of the CW that should be used during any cw traffic, 
+typically announcements.
+.TP
 .B SHORT_IDENT_INTERVAL
 The number of minutes between short identifications. The purpose of the short
 identification is to just announce that the station is on the air. Typically just the

--- a/src/svxlink/svxlink/CW.tcl
+++ b/src/svxlink/svxlink/CW.tcl
@@ -77,47 +77,50 @@ array set letters {
 
 # Private function
 proc calculateTimings {} {
-  variable short_len;
-  variable long_len [expr $short_len * 3];
-  variable char_spacing $short_len;
-  variable letter_spacing [expr $short_len * 3];
-  variable word_spacing [expr $short_len * 7];
+  global cw_wpm
+  global cw_amp
+  global cw_pitch
+  variable amplitude $cw_amp
+  variable fq $cw_pitch
+  
+  variable short_len [expr 60000 / (50 * $cw_wpm)]
+  variable long_len [expr $short_len * 3]
+  variable char_spacing $short_len
+  variable letter_spacing [expr $short_len * 3]
+  variable word_spacing [expr $short_len * 7]
 }
 
 
 #
 # Set the CW speed in words per minute
 #
-proc setWpm {wpm} {
-  variable short_len [expr 60000 / (50 * $wpm)];
-  calculateTimings;
-}
+#proc setWpm {wpm} {
+#  variable short_len [expr 60000 / (50 * $wpm)];
+#  calculateTimings;
+#}
 
 
 #
 # Set the CW speed in characters per minute
 #
-proc setCpm {cpm} {
-  variable short_len [expr 60000 / (10 * $cpm)];
-  calculateTimings;
-}
-
+#proc setCpm {cpm} {
+#  variable short_len [expr 60000 / (10 * $cpm)];
+#  calculateTimings;
+#}
 
 #
 # Set the pitch (frequency), in Hz, of the CW audio.
 #
-proc setPitch {new_fq} {
-  variable fq $new_fq;
-}
-
+#proc setPitch {new_fq} {
+#  variable fq $new_fq;
+#}
 
 #
 # Set the amplitude in per mille (0-1000) of full amplitude.
 #
-proc setAmplitude {new_amplitude} {
-  variable amplitude $new_amplitude;
-}
-
+#proc setAmplitude {new_amplitude} {
+#  variable amplitude $new_amplitude;
+#}
 
 #
 # Play the given CW text
@@ -156,10 +159,11 @@ proc play {txt} {
   }
 }
 
-
 # Set defaults
-setPitch 800;
-setAmplitude 500;
-setCpm 100;
+#setPitch 800;
+#setAmplitude 500;
+#setCpm 100;
 
+#load values from config
+calculateTimings
 }

--- a/src/svxlink/svxlink/CW.tcl
+++ b/src/svxlink/svxlink/CW.tcl
@@ -77,9 +77,9 @@ array set letters {
 
 # Private function
 proc calculateTimings {} {
-  global cw_wpm
-  global cw_amp
-  global cw_pitch
+  variable cw_wpm
+  variable cw_amp
+  variable cw_pitch
   variable amplitude $cw_amp
   variable fq $cw_pitch
   
@@ -94,34 +94,50 @@ proc calculateTimings {} {
 #
 # Set the CW speed in words per minute
 #
-#proc setWpm {wpm} {
-#  variable short_len [expr 60000 / (50 * $wpm)];
-#  calculateTimings;
-#}
+proc setWpm {wpm} {
+  set cw_wpm $wpm
+  calculateTimings;
+}
 
 
 #
 # Set the CW speed in characters per minute
 #
-#proc setCpm {cpm} {
-#  variable short_len [expr 60000 / (10 * $cpm)];
-#  calculateTimings;
-#}
+proc setCpm {cpm} {
+  # Convert in-line from CPM to WPM
+  set cw_wpm [expr $cpm % 5]
+  calculateTimings;
+}
+
 
 #
 # Set the pitch (frequency), in Hz, of the CW audio.
 #
-#proc setPitch {new_fq} {
-#  variable fq $new_fq;
-#}
+proc setPitch {new_fq} {
+  variable fq $new_fq;
+}
+
 
 #
 # Set the amplitude in per mille (0-1000) of full amplitude.
 #
-#proc setAmplitude {new_amplitude} {
-#  variable amplitude $new_amplitude;
-#}
+proc setAmplitude {new_amplitude} {
+  variable amplitude $new_amplitude;
+}
 
+#
+# Load the values from the config file
+#
+proc cwLoadDefaults {
+  variable Logic::CFG_CW_AMP
+  variable Logic::CFG_CW_WPM
+  variable Logic::CFG_CW_PITCH
+  set cw_amp CFG_CW_AMP
+  set cw_wpm CFG_CW_WPM
+  set cw_pitch CFG_CW_PITCH
+  calculateTimings;
+}
+  
 #
 # Play the given CW text
 #
@@ -159,11 +175,6 @@ proc play {txt} {
   }
 }
 
-# Set defaults
-#setPitch 800;
-#setAmplitude 500;
-#setCpm 100;
-
 #load values from config
-calculateTimings
+cwLoadDefaults
 }

--- a/src/svxlink/svxlink/CW.tcl
+++ b/src/svxlink/svxlink/CW.tcl
@@ -132,9 +132,21 @@ proc cwLoadDefaults {
   variable Logic::CFG_CW_AMP
   variable Logic::CFG_CW_WPM
   variable Logic::CFG_CW_PITCH
-  set cw_amp CFG_CW_AMP
-  set cw_wpm CFG_CW_WPM
-  set cw_pitch CFG_CW_PITCH
+  if { [info exists CFG_CW_AMP]} {
+    set cw_amp $CFG_CW_AMP
+  } else {
+    set cw_amp 500
+  }
+  if { [info exists CFG_CW_WPM]} {
+    set cw_wpm $CFG_CW_WPM
+  } else {
+    set cw_wpm 20
+  }
+  if { [info exists CFG_CW_PITCH]} {
+    set cw_pitch $CFG_CW_PITCH
+  } else {
+    set cw_pitch 800
+  }
   calculateTimings;
 }
   

--- a/src/svxlink/svxlink/Logic.cpp
+++ b/src/svxlink/svxlink/Logic.cpp
@@ -170,9 +170,7 @@ Logic::Logic(Config &cfg, const string& name)
     tx_ctcss_mask(0),
     currently_set_tx_ctrl_mode(Tx::TX_OFF), is_online(true),
     dtmf_digit_handler(0),                  state_pty(0),
-    dtmf_ctrl_pty(0),m_cw_amp("200"),
-	m_cw_wpm("25"),							
-	m_cw_pitch("600")
+    dtmf_ctrl_pty(0)
 {
   rgr_sound_timer.expired.connect(sigc::hide(
         mem_fun(*this, &Logic::sendRgrSound)));
@@ -249,21 +247,7 @@ bool Logic::initialize(void)
     cleanup();
     return false;
   }
-
-  // Variable to set CW frequency
-  if (cfg().getValue(name(), "CW_PITCH", m_cw_pitch))
-  {
-  }   
-
-  // Variable to set CW WPM
-  if (cfg().getValue(name(), "CW_WPM", m_cw_wpm))
-  {
-  }  
   
-  // Variable to set CW amp
-  if (cfg().getValue(name(), "CW_AMP", m_cw_amp))
-  {
-  }  
   
   int exec_cmd_on_sql_close = -1;
   if (cfg().getValue(name(), "EXEC_CMD_ON_SQL_CLOSE", exec_cmd_on_sql_close))
@@ -609,10 +593,6 @@ bool Logic::initialize(void)
   event_handler->playDtmf.connect(mem_fun(*this, &Logic::playDtmf));
   event_handler->injectDtmf.connect(mem_fun(*this, &Logic::injectDtmf));
   event_handler->setVariable("mycall", m_callsign);
-  // configure variables to allow user to configure CW tone settings
-  event_handler->setVariable("cw_amp", m_cw_amp);
-  event_handler->setVariable("cw_pitch", m_cw_pitch);
-  event_handler->setVariable("cw_wpm", m_cw_wpm);
   char str[256];
   sprintf(str, "%.1f", report_ctcss);
   event_handler->setVariable("report_ctcss", str);

--- a/src/svxlink/svxlink/Logic.cpp
+++ b/src/svxlink/svxlink/Logic.cpp
@@ -170,7 +170,9 @@ Logic::Logic(Config &cfg, const string& name)
     tx_ctcss_mask(0),
     currently_set_tx_ctrl_mode(Tx::TX_OFF), is_online(true),
     dtmf_digit_handler(0),                  state_pty(0),
-    dtmf_ctrl_pty(0)
+    dtmf_ctrl_pty(0),m_cw_amp("200"),
+	m_cw_wpm("25"),							
+	m_cw_pitch("600")
 {
   rgr_sound_timer.expired.connect(sigc::hide(
         mem_fun(*this, &Logic::sendRgrSound)));
@@ -248,6 +250,21 @@ bool Logic::initialize(void)
     return false;
   }
 
+  // Variable to set CW frequency
+  if (cfg().getValue(name(), "CW_PITCH", m_cw_pitch))
+  {
+  }   
+
+  // Variable to set CW WPM
+  if (cfg().getValue(name(), "CW_WPM", m_cw_wpm))
+  {
+  }  
+  
+  // Variable to set CW amp
+  if (cfg().getValue(name(), "CW_AMP", m_cw_amp))
+  {
+  }  
+  
   int exec_cmd_on_sql_close = -1;
   if (cfg().getValue(name(), "EXEC_CMD_ON_SQL_CLOSE", exec_cmd_on_sql_close))
   {
@@ -592,6 +609,10 @@ bool Logic::initialize(void)
   event_handler->playDtmf.connect(mem_fun(*this, &Logic::playDtmf));
   event_handler->injectDtmf.connect(mem_fun(*this, &Logic::injectDtmf));
   event_handler->setVariable("mycall", m_callsign);
+  // configure variables to allow user to configure CW tone settings
+  event_handler->setVariable("cw_amp", m_cw_amp);
+  event_handler->setVariable("cw_pitch", m_cw_pitch);
+  event_handler->setVariable("cw_wpm", m_cw_wpm);
   char str[256];
   sprintf(str, "%.1f", report_ctcss);
   event_handler->setVariable("report_ctcss", str);

--- a/src/svxlink/svxlink/Logic.h
+++ b/src/svxlink/svxlink/Logic.h
@@ -243,6 +243,9 @@ class Logic : public LogicBase
     Module    	      	      	    *active_module;
     std::list<Module*>	      	    modules;
     std::string       	      	    m_callsign;
+	std::string 					m_cw_pitch;
+	std::string 					m_cw_wpm;
+	std::string 					m_cw_amp;
     std::list<std::string>    	    cmd_queue;
     Async::Timer      	      	    exec_cmd_on_sql_close_timer;
     Async::Timer      	      	    rgr_sound_timer;

--- a/src/svxlink/svxlink/Logic.h
+++ b/src/svxlink/svxlink/Logic.h
@@ -243,9 +243,6 @@ class Logic : public LogicBase
     Module    	      	      	    *active_module;
     std::list<Module*>	      	    modules;
     std::string       	      	    m_callsign;
-	std::string 					m_cw_pitch;
-	std::string 					m_cw_wpm;
-	std::string 					m_cw_amp;
     std::list<std::string>    	    cmd_queue;
     Async::Timer      	      	    exec_cmd_on_sql_close_timer;
     Async::Timer      	      	    rgr_sound_timer;


### PR DESCRIPTION
changing the behavior of the CW function to use configuration variables
so they can be configured on a channel by channel basis.

Disables the ability to set them other places in the code such as
locale.tcl, code is left in place but commented out for easy reverting
for users who use custom logic overrides