### PR TITLE
Update to required packages for Docker debian-build

### DIFF
--- a/docker/debian-build/Dockerfile
+++ b/docker/debian-build/Dockerfile
@@ -27,7 +27,7 @@ MAINTAINER Tobias Blomberg <sm0svx@ssa.se>
 # Install required packages and set up the svxlink user
 RUN apt-get update && \
     apt-get -y install git cmake g++ make libsigc++-2.0-dev libgsm1-dev \
-                       libpopt-dev tcl8.5-dev libgcrypt11-dev libspeex-dev \
+                       libpopt-dev tcl8.6-dev libgcrypt20-dev libspeex-dev \
                        libasound2-dev alsa-utils vorbis-tools libqt4-dev \
                        libopus-dev librtlsdr-dev curl sudo
 #RUN apt-get -y install groff doxygen


### PR DESCRIPTION
tcl8.5-dev -> tcl8.6-dev
libgcrypt11-dev -> libgcrypt20-dev