### PR TITLE
Bugfix for sending metar info twice although requesting it one time

### DIFF
--- a/src/svxlink/modules/metarinfo/ModuleMetarInfo.cpp
+++ b/src/svxlink/modules/metarinfo/ModuleMetarInfo.cpp
@@ -997,6 +997,8 @@ void ModuleMetarInfo::onData(std::string metarinput, size_t count)
   }
 
   handleMetar(metar);
+
+  html = "";
 } /* onDataReceived */
 
 


### PR DESCRIPTION
Hi Tobias,
this should solve the problem that a Metarinfo is announcing twice when requested only on time in some rare cases. The problem was that the string html keeps all of the received xml data from the aviationserver until a new connection has been established. A single space in a delayed message from aviation server is sufficient to give out the same announcement again. Now is deleted immediately when given out.
73s de Adi / DL1HRC