### PR TITLE
Introduce new squelch method SQL_INTERNAL

### DIFF
--- a/src/doc/man/svxlink.conf.5
+++ b/src/doc/man/svxlink.conf.5
@@ -891,7 +891,7 @@ SvxLink to keep the audio device open from application start to exit.
 .TP
 .B SQL_DET
 Specify the type of squelch detector to use. Possible values are: VOX, CTCSS,
-SERIAL, EVDEV, SIGLEV, PTY, GPIO, HIDRAW or COMBINE.
+SERIAL, EVDEV, SIGLEV, PTY, GPIO, HIDRAW, INTERNAL or COMBINE.
 
 The VOX squelch detector determines if there is a signal
 present by calculating a mean value of the sound samples. The VOX squelch
@@ -951,6 +951,9 @@ configurations. This may be good if there is one script handling all functions.
 
 The HIDRAW squelch supports human interface devices (HID), USB devices
 like CM108 soundcard e.g. used in the URI Echolink adapter made by DMK.
+
+The INTERNAL squelch ca be used fron other logic instances for further
+implementations.
 
 The COMBINE squelch make it possible to combine multiple squelch types using a
 logical expression. The expression is set up using the SQL_COMBINE

--- a/src/svxlink/trx/Squelch.cpp
+++ b/src/svxlink/trx/Squelch.cpp
@@ -60,6 +60,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #ifdef HAS_HIDRAW_SUPPORT
 #include "SquelchHidraw.h"
 #endif
+#include "SquelchInternal.h"
 #include "Squelch.h"
 
 
@@ -138,6 +139,7 @@ Squelch* createSquelch(const std::string& sql_name)
 #ifdef HAS_HIDRAW_SUPPORT
   static SquelchSpecificFactory<SquelchHidraw> hidraw_factory;
 #endif
+  static SquelchSpecificFactory<SquelchInternal> internal_factory;
   static SquelchSpecificFactory<SquelchCombine> combine_factory;
 
   return SquelchFactory::createNamedObject(sql_name);

--- a/src/svxlink/trx/SquelchInternal.h
+++ b/src/svxlink/trx/SquelchInternal.h
@@ -1,0 +1,175 @@
+/**
+@file	 SquelchInternal.h
+@brief   A squelch detector that provide an internal squelch criteria
+@author  Tobias Blomberg / SM0SVX & Adi Bier / DL1HRC
+@date	 2020-07-27
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2004-2020  Tobias Blomberg / SM0SVX
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#ifndef SQUELCH_INTERNAL_INCLUDED
+#define SQUELCH_INTERNAL_INCLUDED
+
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "Squelch.h"
+
+
+/****************************************************************************
+ *
+ * Forward declarations
+ *
+ ****************************************************************************/
+
+
+
+/****************************************************************************
+ *
+ * Namespace
+ *
+ ****************************************************************************/
+
+using namespace sigc;
+
+
+/****************************************************************************
+ *
+ * Forward declarations of classes inside of the declared namespace
+ *
+ ****************************************************************************/
+
+
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief	External squelch detector over an internal method
+@author Tobias Blomberg / SM0SVX & Adi Bier / DL1HRC
+@date   2020-07-28
+This squelch detector read the state of the squelch through a Internal device. This
+can be used internal from other logic instances to generate synthetic squelch
+criterias.
+*/
+class SquelchInternal : public Squelch
+{
+  public:
+      /// The name of this class when used by the object factory
+    static constexpr const char* OBJNAME = "INTERNAL";
+
+    /**
+     * @brief 	Default constuctor
+     */
+    SquelchInternal(void) {}
+
+    /**
+     * @brief 	Destructor
+     */
+    ~SquelchInternal(void) {}
+
+    /**
+     * @brief 	Initialize the squelch detector
+     * @param 	cfg A previsously initialized config object
+     * @param 	rx_name The name of the RX (config section name)
+     * @return	Returns \em true on success or else \em false
+     */
+    bool initialize(Async::Config& cfg, const std::string& rx_name)
+    {
+      if (!Squelch::initialize(cfg, rx_name))
+      {
+        return false;
+      }
+      return true;
+    }
+
+    /**
+     * @brief	Provide an internal method to control the sql
+     * @param	the state of sql (true/false)
+     */
+    void setSql(bool is_open)
+    {
+      setSignalDetected(is_open);
+    }
+    /* sqtSql */
+
+  protected:
+    /**
+     * @brief 	Process the incoming samples in the squelch detector
+     * @param 	samples A buffer containing samples
+     * @param 	count The number of samples in the buffer
+     * @return	Return the number of processed samples
+     */
+    int processSamples(const float *samples, int count)
+    {
+      return count;
+    }
+
+  private:
+
+    SquelchInternal(const SquelchInternal&);
+    SquelchInternal& operator=(const SquelchInternal&);
+
+};  /* class SquelchInternal */
+
+
+//} /* namespace */
+
+#endif /* SQUELCH_INTERNAL_INCLUDED */
+
+
+/*
+ * This file has not been truncated
+ */


### PR DESCRIPTION
Hi Tobias,
would be nice if you can check the new sql method SQL_INTERNAL.
It provides the method sqtSql(bool is_open) which can be used internally to generate a synthetic SQL criterion. An application would be, for example, if the opening and closing of the Sql (or rather the talkgroup) is carried out by a stream of information via an additional interface (PEI), which contains much more information than just the sql state and must be processed in a separate logic instance connected to a tetra modem / radio.
From this stream of information (e.g. "+CTICN: 1,0,0,5,09011638300023404,1,1,0,1,1,5,09011638300000001,0") the open / close criterion is determined, among other things, and sent to the squelch handler passed, which in turn enables or blocks the audio path.
73's de Adi / DL1HRC