### PR TITLE
Fix gpio setup script

### DIFF
--- a/src/svxlink/svxlink/svxlink_gpio_up.in
+++ b/src/svxlink/svxlink/svxlink_gpio_up.in
@@ -54,10 +54,10 @@ gpio_setup()
   local direction="${DIRECTION}"
   if [ "${ACTIVE_LEVEL}" = "high" ]; then
     local active_low="0"
-    [ "${DIRECTION}" = "out" ] && direction="low"
+    [ "${DIRECTION}" = "out" ] && direction="out"
   else
     local active_low="1"
-    [ "${DIRECTION}" = "out" ] && direction="high"
+    [ "${DIRECTION}" = "out" ] && direction="out"
   fi
 
   local pin_path="${GPIO_PATH}/${PIN}"
@@ -113,7 +113,7 @@ gpio_setup()
   fi
   if $changed || [ "$(cat "${direction_path}")" != "${DIRECTION}" ]; then
     if ! echo "${direction}" > "${direction_path}"; then
-      error "Failed to set active_low state of GPIO pin \"${direction_path}\""
+      error "Failed to set direction path of GPIO pin \"${direction_path}\""
     fi
   fi
 }


### PR DESCRIPTION
The GPIO setup script contains typos obviously as it tries to set GPIO direction to "low" or "high" which are not valid directions for GPIO. Also the error message was corrected (possibly copy and paste mistake here).