### PR TITLE
Update qtel man page for current documentation location.

### DIFF
--- a/src/doc/man/qtel.1
+++ b/src/doc/man/qtel.1
@@ -48,10 +48,7 @@ There are no options. Start the program within a console - qtel & - or from the 
 .nh
 .ad l
 For detailed description look at
-.B http://sourceforge.net/apps/trac/svxlink/wiki/QtelUserDocs
-or at
-.B
-/usr/share/doc/svxlink/qteluserdoc.pdf
+.B https://github.com/sm0svx/svxlink/wiki/QtelUserDocs
 .
 .SH ENVIRONMENT
 .


### PR DESCRIPTION
The old link is 404, the PDF isn't in the Debian packages, and the Wiki on Github appears to be currently authoritative.