### PR TITLE
Qtel: Add developer name to AppStream metadata

### DIFF
--- a/src/qtel/org.svxlink.Qtel.metainfo.xml
+++ b/src/qtel/org.svxlink.Qtel.metainfo.xml
@@ -5,6 +5,7 @@
   <project_license>GPL-2.0</project_license>
 
   <name>Qtel</name>
+  <developer_name>Tobias Blomberg</developer_name>
   <summary>EchoLink Client</summary>
   <description>
     <p>


### PR DESCRIPTION
This is now required by many AppStream parsers.