### PR TITLE
qtel ported to Qt6

### DIFF
--- a/src/async/demo/CMakeLists.txt
+++ b/src/async/demo/CMakeLists.txt
@@ -25,6 +25,21 @@ foreach(prog ${CPPPROGS})
 endforeach(prog)
 
 if(USE_QT)
+  # Find Qt6
+  find_package(Qt6Core QUIET)
+  if (Qt6Core_FOUND)
+    message("-- Found Qt6 version ${Qt6Core_VERSION_STRING}")    
+    find_package(Qt6Gui REQUIRED)
+    find_package(Qt6Widgets REQUIRED)
+    find_package(Qt6Network REQUIRED)
+    include_directories(${Qt6Core_INCLUDE_DIRS} ${Qt6Gui_INCLUDE_DIRS}
+                        ${Qt6Widgets_INCLUDE_DIRS} ${Qt6Network_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${Qt6Core_LIBRARIES} ${Qt6Gui_LIBRARIES}
+             ${Qt6Widgets_LIBRARIES} ${Qt6Network_LIBRARIES})
+    QT6_WRAP_CPP(QTHEADERS_MOC ${QTHEADERS})
+  endif()
+
+  if (NOT Qt6Core_FOUND)
   # Find Qt5
   find_package(Qt5Core QUIET)
   if (Qt5Core_FOUND)
@@ -44,6 +59,7 @@ if(USE_QT)
     include(${QT_USE_FILE})
     set(LIBS ${LIBS} ${QT_LIBRARIES})
     QT4_WRAP_CPP(QTHEADERS_MOC ${QTHEADERS})
+  endif()
   endif()
 
   foreach(prog ${QTPROGS})

--- a/src/async/qt/CMakeLists.txt
+++ b/src/async/qt/CMakeLists.txt
@@ -13,6 +13,24 @@ foreach(incfile ${EXPINC})
   expinc(${incfile})
 endforeach(incfile)
 
+# Find Qt6
+find_package(Qt6Core)
+if (Qt6Core_FOUND)
+  message("-- Found Qt6 version ${Qt6Core_VERSION_STRING}")
+  find_package(Qt6Gui REQUIRED)
+  find_package(Qt6Widgets REQUIRED)
+  find_package(Qt6Network REQUIRED)
+  include_directories(${Qt6Core_INCLUDE_DIRS} ${Qt6Gui_INCLUDE_DIRS}
+                      ${Qt6Widgets_INCLUDE_DIRS} ${Qt6Network_INCLUDE_DIRS})
+  set(LIBS ${LIBS} ${Qt6Core_LIBRARIES} ${Qt6Gui_LIBRARIES}
+           ${Qt6Widgets_LIBRARIES} ${Qt6Network_LIBRARIES})
+
+  # Generate targets for moc, uic and rcc
+  QT6_WRAP_CPP(QTHEADERS_MOC ${QTHEADERS})
+endif()
+
+# If not Qt6 was found, try Qt5
+if (NOT Qt6Core_FOUND)
 # Find Qt5
 find_package(Qt5Core QUIET)
 if (Qt5Core_FOUND)
@@ -33,6 +51,7 @@ if (NOT Qt5Core_FOUND)
   include(${QT_USE_FILE})
   set(LIBS ${LIBS} ${QT_LIBRARIES})
   QT4_WRAP_CPP(QTHEADERS_MOC ${QTHEADERS})
+endif()
 endif()
 
 # Build a shared library and a static library if configured

--- a/src/qtel/CMakeLists.txt
+++ b/src/qtel/CMakeLists.txt
@@ -23,6 +23,28 @@ find_package(GSM REQUIRED)
 include_directories(${GSM_INCLUDE_DIR})
 set(LIBS ${LIBS} ${GSM_LIBRARY})
 
+# Find Qt6
+find_package(Qt6Core)
+if (Qt6Core_FOUND)
+  find_package(Qt6Gui REQUIRED)
+  find_package(Qt6Widgets REQUIRED)
+  find_package(Qt6Network REQUIRED)
+  find_package(Qt6Core5Compat REQUIRED)
+  include_directories(${Qt6Core_INCLUDE_DIRS} ${Qt6Gui_INCLUDE_DIRS}
+                      ${Qt6Widgets_INCLUDE_DIRS} ${Qt6Network_INCLUDE_DIRS}
+                      ${Qt6Core5Compat_INCLUDE_DIRS})
+  set(LIBS ${LIBS} ${Qt6Core_LIBRARIES} ${Qt6Gui_LIBRARIES}
+           ${Qt6Widgets_LIBRARIES} ${Qt6Network_LIBRARIES}
+           ${Qt6Core5Compat_LIBRARIES})
+
+  # Generate targets for moc, uic and rcc
+  QT6_WRAP_CPP(QTHEADERS_MOC ${QTHEADERS})
+  QT6_WRAP_UI(FORMS_HEADERS ${FORMS})
+  QT6_ADD_RESOURCES(RESOURCES_RCC ${RESOURCES})
+endif()
+
+# If not Qt6 was found, try Qt5
+if (NOT Qt6Core_FOUND)
 # Find Qt5
 find_package(Qt5Core QUIET)
 if (Qt5Core_FOUND)
@@ -50,6 +72,7 @@ if (NOT Qt5Core_FOUND)
   QT4_WRAP_CPP(QTHEADERS_MOC ${QTHEADERS})
   QT4_WRAP_UI(FORMS_HEADERS ${FORMS})
   QT4_ADD_RESOURCES(RESOURCES_RCC ${RESOURCES})
+endif()
 endif()
 
 # We also need to add the current build directory to the include search path

--- a/src/qtel/MainWindowBase.ui
+++ b/src/qtel/MainWindowBase.ui
@@ -97,7 +97,7 @@
        </widget>
        <widget class="QTreeView" name="station_view">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>

--- a/src/qtel/MsgHandler.h
+++ b/src/qtel/MsgHandler.h
@@ -89,7 +89,7 @@ class QueueItem;
  *
  ****************************************************************************/
 
-  
+
 
 /****************************************************************************
  *
@@ -133,7 +133,7 @@ class MsgHandler : public sigc::trackable, public Async::AudioSource
      * @brief 	Destructor
      */
     ~MsgHandler(void);
-    
+
     /**
      * @brief 	Play a file
      * @param 	path The full path to the file to play
@@ -144,7 +144,7 @@ class MsgHandler : public sigc::trackable, public Async::AudioSource
      * the file is being played.
      */
     void playFile(const std::string& path, bool idle_marked=false);
-    
+
     /**
      * @brief 	Play the given number of milliseconds of silence
      * @param 	length The length in milliseconds of the silence
@@ -155,7 +155,7 @@ class MsgHandler : public sigc::trackable, public Async::AudioSource
      * the silence is being played.
      */
     void playSilence(int length, bool idle_marked=false);
-    
+
     /**
      * @brief 	Play a sinus tone
      * @param 	fq The frequency of the tone to play
@@ -169,24 +169,24 @@ class MsgHandler : public sigc::trackable, public Async::AudioSource
      * the silence is being played.
      */
     void playTone(int fq, int amp, int length, bool idle_marked=false);
-    
+
     /**
      * @brief 	Check if a message is beeing written
      * @return	Return \em true if a message is beeing written
      */
     bool isWritingMessage(void) const { return is_writing_message; }
-    
+
     /**
      * @brief 	Check if the message writer is idle (ignoring idle marked items)
      * @return	Returns \em true if the idle or else \em false
      */
     bool isIdle(void) const { return non_idle_cnt == 0; }
-    
+
     /**
      * @brief 	Clear all messages
      */
     void clear(void);
-    
+
     /**
      * @brief 	Mark the beginning of a block of messages
      *
@@ -194,29 +194,29 @@ class MsgHandler : public sigc::trackable, public Async::AudioSource
      * called. Multiple begin/end can be nested.
      */
     void begin(void);
-    
+
     /**
      * @brief 	Mark the end of a block of messages
      *
      * All the playXxx functions that have been previously queued will be
      * executed.
      */
-    void end(void);    
-    
+    void end(void);
+
     /**
      * @brief 	A signal that is emitted when all messages has been written
      */
-    sigc::signal<void>       	    allMsgsWritten;
-    
+    sigc::signal<void()>       	    allMsgsWritten;
+
     /**
      * @brief Resume audio output to the sink
-     * 
+     *
      * This function will be called when the registered audio sink is ready
      * to accept more samples.
      * This function is normally only called from a connected sink object.
      */
     virtual void resumeOutput(void);
-    
+
   protected:
     /**
      * @brief The registered sink has flushed all samples
@@ -226,7 +226,7 @@ class MsgHandler : public sigc::trackable, public Async::AudioSource
      * This function is normally only called from a connected sink object.
      */
     virtual void allSamplesFlushed(void);
-    
+
   private:
     std::list<QueueItem*>   msg_queue;
     int			    sample_rate;
@@ -235,7 +235,7 @@ class MsgHandler : public sigc::trackable, public Async::AudioSource
     QueueItem 	      	    *current;
     bool      	      	    is_writing_message;
     int       	      	    non_idle_cnt;
-    
+
     MsgHandler(const MsgHandler&);
     MsgHandler& operator=(const MsgHandler&);
     void addItemToQueue(QueueItem *item);

--- a/src/qtel/MyMessageBox.h
+++ b/src/qtel/MyMessageBox.h
@@ -139,9 +139,11 @@ class MyMessageBox : public QMessageBox
   
   public:
     MyMessageBox(const QString& caption, const QString& text)
-      : QMessageBox(caption, text, QMessageBox::Critical, QMessageBox::Ok,
-      	      	    Qt::NoButton, Qt::NoButton)
+      : QMessageBox()
     {
+      setWindowTitle(caption);
+      setText(text);
+      setIcon(QMessageBox::Critical);
       setAttribute(Qt::WA_DeleteOnClose);
     }
     
@@ -152,12 +154,12 @@ class MyMessageBox : public QMessageBox
     
   signals:
     void closed(void);
-  
-    
+
+
   protected:
-    
+
   private:
-    
+
 };  /* class MyMessageBox */
 
 

--- a/src/qtel/Settings.h
+++ b/src/qtel/Settings.h
@@ -85,28 +85,28 @@ class SettingsDialog;
 
 /*
  *----------------------------------------------------------------------------
- * Macro:   
- * Purpose: 
- * Input:   
- * Output:  
- * Author:  
- * Created: 
- * Remarks: 
- * Bugs:    
+ * Macro:
+ * Purpose:
+ * Input:
+ * Output:
+ * Author:
+ * Created:
+ * Remarks:
+ * Bugs:
  *----------------------------------------------------------------------------
  */
 
 
 /*
  *----------------------------------------------------------------------------
- * Type:    
- * Purpose: 
- * Members: 
- * Input:   
- * Output:  
- * Author:  
- * Created: 
- * Remarks: 
+ * Type:
+ * Purpose:
+ * Members:
+ * Input:
+ * Output:
+ * Author:
+ * Created:
+ * Remarks:
  *----------------------------------------------------------------------------
  */
 
@@ -129,22 +129,22 @@ class SettingsDialog;
  *----------------------------------------------------------------------------
  * Class:     Settings
  * Purpose:   Settings class
- * Inherits:  
- * Input:     
- * Output:    
- * Author:    
- * Created:   
- * Remarks:   
- * Bugs:      
+ * Inherits:
+ * Input:
+ * Output:
+ * Author:
+ * Created:
+ * Remarks:
+ * Bugs:
  *----------------------------------------------------------------------------
- */   
+ */
 class Settings : public sigc::trackable
 {
   public:
     static Settings *instance(void);
-  
+
     ~Settings(void);
-    
+
     void showDialog(void);
     void readSettings(void);
     const QString& callsign(void) const { return m_callsign; }
@@ -152,7 +152,7 @@ class Settings : public sigc::trackable
     const QString& name(void) const { return m_name; }
     const QString& location(void) const { return m_location; }
     const QString& info(void) const { return m_info; }
-    
+
     const QString& directoryServers(void) const { return m_directory_servers; }
     int listRefreshTime(void) const { return m_list_refresh_time; }
     bool startAsBusy(void) const { return m_start_as_busy; }
@@ -161,21 +161,21 @@ class Settings : public sigc::trackable
     const QString& proxyServer(void) const { return m_proxy_server; }
     uint16_t proxyPort(void) const { return m_proxy_port; }
     const QString& proxyPassword(void) const { return m_proxy_password; }
-    
+
     const QString& micAudioDevice(void) const { return m_mic_audio_device; }
     const QString& spkrAudioDevice(void) const { return m_spkr_audio_device; }
     bool useFullDuplex(void) const { return m_use_full_duplex; }
     const QString& connectSound(void) const { return m_connect_sound; }
     int cardSampleRate(void) const { return m_card_sample_rate; }
-    
+
     const QString& chatEncoding(void) const
     {
       return encodings[m_chat_encoding].name;
     }
-    
+
     void setBookmarks(const QStringList &bookmarks);
     const QStringList& bookmarks(void) const { return m_bookmarks; }
-    
+
     QSize mainWindowSize(void) const { return m_main_window_size; }
     void setMainWindowSize(QSize size);
     QList<int> vSplitterSizes() const { return m_vsplitter_sizes; }
@@ -186,19 +186,19 @@ class Settings : public sigc::trackable
     void setStationViewColSizes(QList<int> sizes);
     QList<int> incomingViewColSizes() const { return m_incm_view_col_sizes; }
     void setIncomingViewColSizes(QList<int> sizes);
-    
+
     void setVoxParams(bool enabled, int threshold_db, int delay_ms);
     bool voxEnabled(void) const { return m_vox_enabled; }
     int voxThreshold(void) const { return m_vox_threshold; }
     int voxDelay(void) const { return m_vox_delay; }
-    
+
     void setConnectToIp(const QString &host);
     const QString& connectToIp(void) const { return m_connect_to_ip; }
-    
-    sigc::signal<void> configurationUpdated;
-    
+
+    sigc::signal<void()> configurationUpdated;
+
   protected:
-    
+
   private:
     class Encoding
     {
@@ -210,16 +210,16 @@ class Settings : public sigc::trackable
     };
 
     static Settings *       the_instance;
-    
+
     SettingsDialog *        dialog;
     QVector<Encoding>       encodings;
-    
+
     QString   	            m_callsign;
     QString   	            m_password;
     QString   	            m_name;
     QString   	            m_location;
     QString   	            m_info;
-    
+
     QString   	            m_directory_servers;
     int       	            m_list_refresh_time;
     bool      	            m_start_as_busy;
@@ -234,25 +234,25 @@ class Settings : public sigc::trackable
     bool      	            m_use_full_duplex;
     QString   	            m_connect_sound;
     int                     m_card_sample_rate;
-    
+
     int		            m_chat_encoding;
 
     QStringList             m_bookmarks;
-    
+
     QSize     	            m_main_window_size;
     QList<int>              m_vsplitter_sizes;
     QList<int>              m_hsplitter_sizes;
     QList<int>		    m_stn_view_col_sizes;
     QList<int>		    m_incm_view_col_sizes;
-    
+
     bool      	            m_vox_enabled;
     int       	            m_vox_threshold;
     int       	            m_vox_delay;
-    
+
     QString   	            m_connect_to_ip;
-    
+
     Settings(void);
-    
+
 };  /* class Settings */
 
 

--- a/src/qtel/SettingsDialogBase.ui
+++ b/src/qtel/SettingsDialogBase.ui
@@ -693,4 +693,7 @@ Message</string>
    </hints>
   </connection>
  </connections>
+ <slots>
+u <slot>browseConnectSound()</slot>
+ </slots>
 </ui>

--- a/src/qtel/qtel.cpp
+++ b/src/qtel/qtel.cpp
@@ -161,8 +161,8 @@ int main(int argc, char **argv)
       int button = QMessageBox::critical(0, "Bad configuration",
 	  "There are one or more configuration items that have not been "
 	  "filled in. Please fill in the missing items.",
-	  "Configure", "Quit");
-      if (button == 1)
+	QMessageBox::Abort, QMessageBox::Ok);
+      if (button == QMessageBox::Abort)
       {
       	return 1;
       }

--- a/src/qtel/qtel.cpp
+++ b/src/qtel/qtel.cpp
@@ -61,7 +61,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <EchoLinkDirectory.h>
 #include <EchoLinkDispatcher.h>
 
-	
+
 /****************************************************************************
  *
  * Local Includes
@@ -90,7 +90,7 @@ using namespace EchoLink;
 
 #define PROGRAM_NAME "qtel"
 
-	
+
 
 /****************************************************************************
  *
@@ -105,7 +105,7 @@ using namespace EchoLink;
  * Global Variables
  *
  ****************************************************************************/
- 
+
 
 
 /****************************************************************************
@@ -133,23 +133,23 @@ using namespace EchoLink;
  * Output:    Return 0 on success, else non-zero.
  * Author:    Tobias Blomberg
  * Created:   2003-03-09
- * Remarks:   
- * Bugs:      
+ * Remarks:
+ * Bugs:
  *----------------------------------------------------------------------------
  */
 int main(int argc, char **argv)
 {
   QtApplication app(argc, argv);
-  
+
   QTranslator translator;
-  translator.load(QString("qtel_%1").arg(QLocale::system().name()),
+  (void)translator.load(QString("qtel_%1").arg(QLocale::system().name()),
       SHARE_INSTALL_PREFIX "/qtel/translations");
   app.installTranslator(&translator);
 
   QCoreApplication::setOrganizationName("SvxLink");
   QCoreApplication::setOrganizationDomain("svxlink.org");
   QCoreApplication::setApplicationName("Qtel");
-	
+
   Settings *settings = Settings::instance();
   bool cfg_ok = false;
   while (!cfg_ok)
@@ -172,13 +172,13 @@ int main(int argc, char **argv)
       cfg_ok = true;
     }
   }
-   
+
   MainWindow mainWindow;
   mainWindow.show();
   app.exec();
-  
+
   delete Settings::instance();
-  
+
   return 0;
 }
 

--- a/src/qtel/translations/CMakeLists.txt
+++ b/src/qtel/translations/CMakeLists.txt
@@ -4,7 +4,10 @@ set(TRANSLATIONS
   qtel_hu.ts qtel_ja.ts qtel_fr.ts qtel_es.ts
   )
 
-if (Qt5Core_FOUND)
+if (Qt6Core_FOUND)
+    find_package(Qt6LinguistTools REQUIRED)
+  QT6_ADD_TRANSLATION(TRANSLATIONS_QM ${TRANSLATIONS})
+elseif (Qt5Core_FOUND)
   find_package(Qt5LinguistTools REQUIRED)
   QT5_ADD_TRANSLATION(TRANSLATIONS_QM ${TRANSLATIONS})
 elseif (QT4_FOUND)


### PR DESCRIPTION
Based on the SigC++3 branch I ported `qtel` away from qt5 to qt6 (seee Issue#686 and # 695). First tests are successful.

I am not sure if we should keep the autodetection of QT4 and QT5 libraries in the CMakeLists.txt files (see commit at https://github.com/dl1jbe/svxlink/commit/71b85685cd18c7e7e98e12b0b3cd6204cd4c1907). 
Maybe it is time to drop them.