### PR TITLE
This change is to support the CM119A audio chip used in the lastest D…

### DIFF
--- a/src/svxlink/trx/PttHidraw.cpp
+++ b/src/svxlink/trx/PttHidraw.cpp
@@ -184,6 +184,10 @@ bool PttHidraw::initialize(Async::Config &cfg, const std::string name)
     {
       cout << "CM119";
     }
+    else if (hiddevinfo.product == 0x0013)
+    {
+      cout << "CM119A";
+    }
     else
     {
       cout << "unknown";

--- a/src/svxlink/trx/SquelchHidraw.cpp
+++ b/src/svxlink/trx/SquelchHidraw.cpp
@@ -220,6 +220,10 @@ bool SquelchHidraw::initialize(Async::Config& cfg, const std::string& rx_name)
     {
       cout << "CM119";
     }
+    else if (hiddevinfo.product == 0x0013)
+    {
+      cout << "CM119A";
+    }
     else
     {
       cout << "unknown";


### PR DESCRIPTION
This adds Hidraw support for PTT & Squelch on current DMK Engineering URI dongles with the CM119A audio chips