### PR TITLE
Repeater port priority

### DIFF
--- a/src/doc/man/svxlink.conf.5
+++ b/src/doc/man/svxlink.conf.5
@@ -1100,6 +1100,24 @@ expression matches a talkgroup that is activated on the specified logic core.
 Use CTCSS_TO_TG in a SimplexLogic or RepeaterLogic to make it emit a talkgroup
 for a specific subtone.
 Example: ACTIVATE_ON_TG=SimplexLogic:240.*,RepeaterLogic:2403|2404|123
+.TP
+.B AUDIO_MODE
+Set the audio handling mode for the link. When multiple linked logics have
+simultaneous incoming traffic (a "pile-up"), this setting determines how the
+audio is handled. Valid values are:
+.RS
+.IP FIRST 10
+(Default) The first source to transmit wins. Other sources are ignored until
+the first source stops, at which point the link rejoins any ongoing traffic.
+This is the traditional SvxLink behavior.
+.IP MIX 10
+Mix all active sources together. All users on any linked logic will hear all
+traffic from all other linked logics simultaneously. This is useful when you
+want users to be aware that another station is calling, even if someone else
+is already transmitting.
+.RE
+.IP
+Example: AUDIO_MODE=MIX
 .
 .SS Local Receiver Section
 .

--- a/src/doc/man/svxlink.conf.5
+++ b/src/doc/man/svxlink.conf.5
@@ -1115,9 +1115,21 @@ Mix all active sources together. All users on any linked logic will hear all
 traffic from all other linked logics simultaneously. This is useful when you
 want users to be aware that another station is calling, even if someone else
 is already transmitting.
+.IP DUCK 10
+Like MIX mode, but incoming link audio is reduced (ducked) when the local
+squelch is open. This allows local traffic to be heard clearly at full volume
+while still being aware of remote activity at a reduced level. Use DUCK_LEVEL_DB
+to configure the amount of reduction.
 .RE
 .IP
-Example: AUDIO_MODE=MIX
+Example: AUDIO_MODE=DUCK
+.TP
+.B DUCK_LEVEL_DB
+The amount of gain reduction (in dB) to apply to incoming link audio when
+AUDIO_MODE is set to DUCK and the local squelch is open. A negative value
+reduces the volume. Default is -12 (reduce by 12dB, approximately 1/4 volume).
+.IP
+Example: DUCK_LEVEL_DB=-18
 .
 .SS Local Receiver Section
 .

--- a/src/doc/man/svxlink.conf.5
+++ b/src/doc/man/svxlink.conf.5
@@ -1143,6 +1143,14 @@ a PRIORITY link transmission. A very negative value like -60 provides
 near-silence. Default is -60.
 .IP
 Example: PRIORITY_MUTE_DB=-40
+.TP
+.B PRIORITY_HANGTIME
+The time in milliseconds that priority preemption continues after a PRIORITY
+source stops transmitting. This prevents non-priority sources from briefly
+interrupting between priority transmissions. During hangtime, non-priority
+sources remain muted. Default is 0 (no hangtime, preemption ends immediately).
+.IP
+Example: PRIORITY_HANGTIME=2000
 .
 .SS Local Receiver Section
 .

--- a/src/doc/man/svxlink.conf.5
+++ b/src/doc/man/svxlink.conf.5
@@ -1120,9 +1120,15 @@ Like MIX mode, but incoming link audio is reduced (ducked) when the local
 squelch is open. This allows local traffic to be heard clearly at full volume
 while still being aware of remote activity at a reduced level. Use DUCK_LEVEL_DB
 to configure the amount of reduction.
+.IP PRIORITY 10
+Like MIX mode, but when a source from a PRIORITY link is transmitting, sources
+from non-PRIORITY links are reduced to PRIORITY_MUTE_DB level (near silence by
+default). This is useful for emergency broadcast systems where critical traffic
+must take precedence over normal traffic. If multiple PRIORITY sources transmit
+simultaneously, they are mixed together.
 .RE
 .IP
-Example: AUDIO_MODE=DUCK
+Example: AUDIO_MODE=PRIORITY
 .TP
 .B DUCK_LEVEL_DB
 The amount of gain reduction (in dB) to apply to incoming link audio when
@@ -1130,6 +1136,13 @@ AUDIO_MODE is set to DUCK and the local squelch is open. A negative value
 reduces the volume. Default is -12 (reduce by 12dB, approximately 1/4 volume).
 .IP
 Example: DUCK_LEVEL_DB=-18
+.TP
+.B PRIORITY_MUTE_DB
+The gain reduction (in dB) applied to non-priority sources when preempted by
+a PRIORITY link transmission. A very negative value like -60 provides
+near-silence. Default is -60.
+.IP
+Example: PRIORITY_MUTE_DB=-40
 .
 .SS Local Receiver Section
 .

--- a/src/svxlink/svxlink/LinkManager.cpp
+++ b/src/svxlink/svxlink/LinkManager.cpp
@@ -57,6 +57,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <AsyncAudioSplitter.h>
 #include <AsyncAudioSelector.h>
 #include <AsyncAudioPassthrough.h>
+#include <AsyncAudioValve.h>
+#include <AsyncAudioMixer.h>
 
 
 /****************************************************************************
@@ -263,6 +265,26 @@ bool LinkManager::initialize(Async::Config &cfg,
     }
 
     cfg.getValue(link.name, "DEFAULT_ACTIVE", link.default_active);
+
+      // Parse AUDIO_MODE configuration (default: FIRST)
+    std::string audio_mode_str;
+    if (cfg.getValue(link.name, "AUDIO_MODE", audio_mode_str))
+    {
+      if (audio_mode_str == "FIRST")
+      {
+        link.audio_mode = LinkAudioMode::FIRST;
+      }
+      else if (audio_mode_str == "MIX")
+      {
+        link.audio_mode = LinkAudioMode::MIX;
+      }
+      else
+      {
+        std::cerr << "*** WARNING: Unknown AUDIO_MODE \"" << audio_mode_str
+                  << "\" in link " << link.name
+                  << ". Valid options: FIRST, MIX. Using FIRST." << std::endl;
+      }
+    }
   }
 
   if(!init_ok)
@@ -294,31 +316,52 @@ void LinkManager::addLogic(LogicBase *logic)
   sources[logic->name()].splitter = splitter;
 
     // Create a selector for the logic being added to receive audio from all
-    // other sinks.
+    // other sinks. Used in FIRST mode.
   AudioSelector *selector = new AudioSelector;
   selector->registerSink(logic->logicConIn());
+
+    // Create a mixer for MIX mode. The mixer output will be connected
+    // to the logic input when MIX mode connections are activated.
+  AudioMixer *mixer = new AudioMixer;
 
     // Register the new logic sink
   sinks[logic->name()].sink = logic->logicConIn();
   sinks[logic->name()].selector = selector;
+  sinks[logic->name()].mixer = mixer;
 
     // Now create a connection from the new logic source to each sink.
   for (SinkMap::iterator it=sinks.begin(); it != sinks.end(); ++it)
   {
+      // Passthrough for FIRST mode (selector path)
     AudioPassthrough *connector = new AudioPassthrough;
     splitter->addSink(connector, true);
     AudioSelector *other_selector = (*it).second.selector;
     other_selector->addSource(connector);
     (*it).second.connectors[logic->name()] = connector;
+
+      // Valve for MIX mode (mixer path)
+    AudioValve *valve = new AudioValve;
+    valve->setOpen(false);  // Initially closed
+    splitter->addSink(valve, true);
+    (*it).second.mixer->addSource(valve);
+    (*it).second.valves[logic->name()] = valve;
   }
 
     // Now create a connection from each existing logic source to the new sink.
   for (SourceMap::iterator it=sources.begin(); it!=sources.end(); ++it)
   {
+      // Passthrough for FIRST mode (selector path)
     AudioPassthrough *connector = new AudioPassthrough;
     (*it).second.splitter->addSink(connector, true);
     selector->addSource(connector);
     sinks[logic->name()].connectors[(*it).first] = connector;
+
+      // Valve for MIX mode (mixer path)
+    AudioValve *valve = new AudioValve;
+    valve->setOpen(false);  // Initially closed
+    (*it).second.splitter->addSink(valve, true);
+    mixer->addSource(valve);
+    sinks[logic->name()].valves[(*it).first] = valve;
   }
 
     // Create new object containing metadata for this logic core
@@ -396,6 +439,8 @@ void LinkManager::deleteLogic(LogicBase *logic)
   for (SinkMap::iterator smit=sinks.begin(); smit!=sinks.end(); ++smit)
   {
     SinkInfo &sink_info = (*smit).second;
+
+      // Remove passthrough from selector
     ConMap::iterator cmit = sink_info.connectors.find(logic->name());
     assert(cmit != sink_info.connectors.end());
     AudioPassthrough *connector = (*cmit).second;
@@ -403,13 +448,27 @@ void LinkManager::deleteLogic(LogicBase *logic)
     sink_info.connectors.erase(logic->name());
     splitter->removeSink(connector);
     //delete connector;
+
+      // Close and remove valve for mixer (can't remove from mixer, just close it)
+    ValveMap::iterator vmit = sink_info.valves.find(logic->name());
+    if (vmit != sink_info.valves.end())
+    {
+      vmit->second->setOpen(false);
+      splitter->removeSink(vmit->second);
+      delete vmit->second;
+      sink_info.valves.erase(vmit);
+    }
   }
   delete splitter;
   sources.erase(logic->name());
-  
+
     // Delete the logic sink and all connections associated with it
-  AudioSelector *selector = sinks[logic->name()].selector;
-  ConMap &cons = sinks[logic->name()].connectors;
+  SinkInfo &sink_to_delete = sinks[logic->name()];
+  AudioSelector *selector = sink_to_delete.selector;
+  AudioMixer *mixer = sink_to_delete.mixer;
+
+    // Clean up connectors (passthroughs for selector)
+  ConMap &cons = sink_to_delete.connectors;
   for (ConMap::iterator cmit = cons.begin(); cmit != cons.end(); ++cmit)
   {
     AudioPassthrough *connector = (*cmit).second;
@@ -418,7 +477,20 @@ void LinkManager::deleteLogic(LogicBase *logic)
     sources[source_name].splitter->removeSink(connector);
     //delete connector;
   }
+
+    // Clean up valves (for mixer)
+  ValveMap &valves = sink_to_delete.valves;
+  for (ValveMap::iterator vmit = valves.begin(); vmit != valves.end(); ++vmit)
+  {
+    AudioValve *valve = vmit->second;
+    valve->setOpen(false);
+    const string &source_name = vmit->first;
+    sources[source_name].splitter->removeSink(valve);
+    delete valve;
+  }
+
   delete selector;
+  delete mixer;
   sinks.erase(logic->name());
 
     // Finally remove the logic from the logic_map
@@ -516,9 +588,17 @@ string LinkManager::cmdReceived(LinkRef link, LogicBase *logic,
 
 LogicBase *LinkManager::currentTalkerFor(const std::string& logic_name)
 {
-  AudioSelector *selector = sinks[logic_name].selector;
-  AudioSource *selected = selector->selectedSource();
-  const ConMap& con_map = sinks[logic_name].connectors;
+  SinkInfo& sink = sinks[logic_name];
+
+    // In MIX mode, there's no single current talker
+  if (sink.mixer->isRegistered())
+  {
+    return nullptr;
+  }
+
+    // FIRST mode - find the selected source
+  AudioSource *selected = sink.selector->selectedSource();
+  const ConMap& con_map = sink.connectors;
   for (ConMap::const_iterator it = con_map.begin(); it != con_map.end(); ++it)
   {
     if (it->second == selected)
@@ -527,7 +607,7 @@ LogicBase *LinkManager::currentTalkerFor(const std::string& logic_name)
       return logic_map.at(it->first).logic;
     }
   }
-  return 0;
+  return nullptr;
 } /* LinkManager::currentTalkerFor */
 
 
@@ -757,6 +837,9 @@ void LinkManager::updateConnections(void)
       // Disconnect the audio path from source logic to sink logic
     sink.selector->disableAutoSelect(sink.connectors.at(src_name));
 
+      // Close the mixer valve for this connection
+    sink.valves.at(src_name)->setOpen(false);
+
       // Delete the link connect information
     current_cons.erase(*it);
   }
@@ -776,11 +859,29 @@ void LinkManager::updateConnections(void)
     const string &src_name = it->first;
     const string &sink_name = it->second;
     SinkInfo &sink = sinks.at(sink_name);
-    sink.selector->enableAutoSelect(sink.connectors.at(src_name), 0);
+
+      // Get the effective audio mode for this connection
+    LinkAudioMode mode = getEffectiveMode(src_name, sink_name);
+
+    if (mode == LinkAudioMode::FIRST)
+    {
+        // FIRST mode: use selector, close mixer valve
+      sink.selector->enableAutoSelect(sink.connectors.at(src_name), 0);
+      sink.valves.at(src_name)->setOpen(false);
+    }
+    else // MIX mode
+    {
+        // MIX mode: disable selector, open mixer valve
+      sink.selector->disableAutoSelect(sink.connectors.at(src_name));
+      sink.valves.at(src_name)->setOpen(true);
+    }
 
       // Store all connections in "current_cons" (current connections)
     current_cons.insert(*it);
   }
+
+    // Update mixer routing based on active MIX connections
+  updateMixerRouting();
 } /* LinkManager::updateConnections */
 
 
@@ -1015,6 +1116,81 @@ void LinkManager::onPublishStateEvent(LogicBase *src_logic,
     }
   }
 } /* LinkManager::onPublishStateEvent */
+
+
+LinkAudioMode LinkManager::getEffectiveMode(const std::string& src_name,
+                                             const std::string& sink_name)
+{
+    // Determine if a connection should use MIX mode.
+    // MIX mode takes precedence if any active link that includes both
+    // source and sink logics uses MIX mode.
+  for (const auto& link_pair : links)
+  {
+    const Link& link = link_pair.second;
+    if (!link.is_activated)
+    {
+      continue;
+    }
+
+    bool has_src = link.logic_props.count(src_name) > 0;
+    bool has_sink = link.logic_props.count(sink_name) > 0;
+
+    if (has_src && has_sink && link.audio_mode == LinkAudioMode::MIX)
+    {
+      return LinkAudioMode::MIX;
+    }
+  }
+  return LinkAudioMode::FIRST;
+} /* LinkManager::getEffectiveMode */
+
+
+void LinkManager::updateMixerRouting(void)
+{
+    // Connect/disconnect mixer to logic input based on active MIX connections.
+    // If a sink has any open mixer valves, route the mixer output to the logic.
+    // Otherwise, route the selector output to the logic.
+  for (auto& sink_pair : sinks)
+  {
+    SinkInfo& sink = sink_pair.second;
+
+      // Check if this sink has any MIX-mode connections active (any valve open)
+    bool has_mix_connection = false;
+    for (const auto& valve_pair : sink.valves)
+    {
+      if (valve_pair.second->isOpen())
+      {
+        has_mix_connection = true;
+        break;
+      }
+    }
+
+      // Route mixer or selector to logic input
+    if (has_mix_connection)
+    {
+        // Disconnect selector, connect mixer
+      if (sink.selector->isRegistered())
+      {
+        sink.selector->unregisterSink();
+      }
+      if (!sink.mixer->isRegistered())
+      {
+        sink.mixer->registerSink(sink.sink);
+      }
+    }
+    else
+    {
+        // Disconnect mixer, connect selector
+      if (sink.mixer->isRegistered())
+      {
+        sink.mixer->unregisterSink();
+      }
+      if (!sink.selector->isRegistered())
+      {
+        sink.selector->registerSink(sink.sink);
+      }
+    }
+  }
+} /* LinkManager::updateMixerRouting */
 
 
 /*

--- a/src/svxlink/svxlink/LinkManager.cpp
+++ b/src/svxlink/svxlink/LinkManager.cpp
@@ -301,6 +301,18 @@ bool LinkManager::initialize(Async::Config &cfg,
 
       // Parse PRIORITY_MUTE_DB configuration (default: -60 dB)
     cfg.getValue(link.name, "PRIORITY_MUTE_DB", link.priority_mute_db);
+
+      // Parse PRIORITY_HANGTIME configuration (default: 0 = disabled)
+    cfg.getValue(link.name, "PRIORITY_HANGTIME", link.priority_hangtime);
+    if (link.priority_hangtime > 0)
+    {
+      link.priority_hangtime_timer = new Timer(link.priority_hangtime);
+      link.priority_hangtime_timer->setEnable(false);
+      link.priority_hangtime_timer->expired.connect(sigc::bind(
+          mem_fun(*LinkManager::instance(),
+                  &LinkManager::onPriorityHangtimeExpired),
+          &link));
+    }
   }
 
   if(!init_ok)
@@ -1268,6 +1280,9 @@ void LinkManager::onSquelchStateChanged(bool is_open, LogicBase *logic)
     // Update ducking for this logic's incoming connections
   updateDuckingForSink(logic->name(), is_open);
 
+    // Check if we need to start/stop priority hangtime timers
+  checkPriorityHangtime();
+
     // Update priority preemption for all sinks
   for (auto& sink_pair : sinks)
   {
@@ -1405,7 +1420,11 @@ void LinkManager::updatePriorityForSink(const std::string& sink_name)
   if (sink_it == sinks.end()) return;
 
   SinkInfo& sink = sink_it->second;
-  bool priority_active = isPrioritySourceActive(sink_name);
+
+    // Priority is active if a PRIORITY source is transmitting OR
+    // if we're in the hangtime period after a PRIORITY transmission
+  bool priority_active = isPrioritySourceActive(sink_name) ||
+                         isPriorityHangtimeActive(sink_name);
 
     // Check if sink logic's squelch is open (for DUCK interaction)
   bool sink_squelch_open = false;
@@ -1462,6 +1481,86 @@ void LinkManager::updatePriorityForSink(const std::string& sink_name)
     }
   }
 } /* LinkManager::updatePriorityForSink */
+
+
+bool LinkManager::isPriorityHangtimeActive(const std::string& sink_name)
+{
+    // Check if any PRIORITY link that includes this sink has an active
+    // hangtime timer
+  for (const auto& link_pair : links)
+  {
+    const Link& link = link_pair.second;
+    if (!link.is_activated) continue;
+    if (link.audio_mode != LinkAudioMode::PRIORITY) continue;
+    if (link.logic_props.count(sink_name) == 0) continue;
+
+      // Check if hangtime timer is enabled (running)
+    if (link.priority_hangtime_timer != nullptr &&
+        link.priority_hangtime_timer->isEnabled())
+    {
+      return true;
+    }
+  }
+  return false;
+} /* LinkManager::isPriorityHangtimeActive */
+
+
+void LinkManager::checkPriorityHangtime(void)
+{
+    // For each PRIORITY link, check if we need to start or stop the
+    // hangtime timer
+  for (auto& link_pair : links)
+  {
+    Link& link = link_pair.second;
+    if (!link.is_activated) continue;
+    if (link.audio_mode != LinkAudioMode::PRIORITY) continue;
+    if (link.priority_hangtime_timer == nullptr) continue;
+
+      // Check if any source in this PRIORITY link has squelch open
+    bool priority_source_active = false;
+    for (const auto& prop : link.logic_props)
+    {
+      const std::string& logic_name = prop.first;
+      LogicMap::iterator it = logic_map.find(logic_name);
+      if (it != logic_map.end() && it->second.squelch_open)
+      {
+        priority_source_active = true;
+        break;
+      }
+    }
+
+    if (priority_source_active)
+    {
+        // Priority source is active - stop hangtime timer if running
+        // and mark that priority was active
+      link.priority_hangtime_timer->setEnable(false);
+      link.priority_was_active = true;
+    }
+    else if (link.priority_was_active)
+    {
+        // Priority was active but is now inactive.
+        // Start hangtime timer if it's not already running.
+      if (!link.priority_hangtime_timer->isEnabled())
+      {
+        link.priority_hangtime_timer->reset();
+        link.priority_hangtime_timer->setEnable(true);
+      }
+    }
+  }
+} /* LinkManager::checkPriorityHangtime */
+
+
+void LinkManager::onPriorityHangtimeExpired(Async::Timer *t, Link *link)
+{
+  t->setEnable(false);
+  link->priority_was_active = false;
+
+    // Hangtime expired - update priority state for all sinks in this link
+  for (const auto& prop : link->logic_props)
+  {
+    updatePriorityForSink(prop.first);
+  }
+} /* LinkManager::onPriorityHangtimeExpired */
 
 
 /*

--- a/src/svxlink/svxlink/LinkManager.cpp
+++ b/src/svxlink/svxlink/LinkManager.cpp
@@ -59,6 +59,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <AsyncAudioPassthrough.h>
 #include <AsyncAudioValve.h>
 #include <AsyncAudioMixer.h>
+#include <AsyncAudioAmp.h>
 
 
 /****************************************************************************
@@ -278,13 +279,20 @@ bool LinkManager::initialize(Async::Config &cfg,
       {
         link.audio_mode = LinkAudioMode::MIX;
       }
+      else if (audio_mode_str == "DUCK")
+      {
+        link.audio_mode = LinkAudioMode::DUCK;
+      }
       else
       {
         std::cerr << "*** WARNING: Unknown AUDIO_MODE \"" << audio_mode_str
                   << "\" in link " << link.name
-                  << ". Valid options: FIRST, MIX. Using FIRST." << std::endl;
+                  << ". Valid options: FIRST, MIX, DUCK. Using FIRST." << std::endl;
       }
     }
+
+      // Parse DUCK_LEVEL_DB configuration (default: -12 dB)
+    cfg.getValue(link.name, "DUCK_LEVEL_DB", link.duck_level_db);
   }
 
   if(!init_ok)
@@ -339,12 +347,16 @@ void LinkManager::addLogic(LogicBase *logic)
     other_selector->addSource(connector);
     (*it).second.connectors[logic->name()] = connector;
 
-      // Valve for MIX mode (mixer path)
+      // Valve + Amp for MIX/DUCK mode (mixer path)
     AudioValve *valve = new AudioValve;
     valve->setOpen(false);  // Initially closed
     splitter->addSink(valve, true);
-    (*it).second.mixer->addSource(valve);
+    AudioAmp *amp = new AudioAmp;
+    amp->setGain(0);  // Normal gain initially
+    valve->registerSink(amp, true);
+    (*it).second.mixer->addSource(amp);
     (*it).second.valves[logic->name()] = valve;
+    (*it).second.amps[logic->name()] = amp;
   }
 
     // Now create a connection from each existing logic source to the new sink.
@@ -356,12 +368,16 @@ void LinkManager::addLogic(LogicBase *logic)
     selector->addSource(connector);
     sinks[logic->name()].connectors[(*it).first] = connector;
 
-      // Valve for MIX mode (mixer path)
+      // Valve + Amp for MIX/DUCK mode (mixer path)
     AudioValve *valve = new AudioValve;
     valve->setOpen(false);  // Initially closed
     (*it).second.splitter->addSink(valve, true);
-    mixer->addSource(valve);
+    AudioAmp *amp = new AudioAmp;
+    amp->setGain(0);  // Normal gain initially
+    valve->registerSink(amp, true);
+    mixer->addSource(amp);
     sinks[logic->name()].valves[(*it).first] = valve;
+    sinks[logic->name()].amps[(*it).first] = amp;
   }
 
     // Create new object containing metadata for this logic core
@@ -379,6 +395,11 @@ void LinkManager::addLogic(LogicBase *logic)
   logic_info.received_publish_state_event_con = logic->publishStateEvent.connect(
       sigc::bind<0>(
         sigc::mem_fun(*this, &LinkManager::onPublishStateEvent), logic));
+
+    // Connect squelch state signal for DUCK mode
+  logic_info.squelch_state_changed_con = logic->squelchStateChanged.connect(
+      sigc::bind(
+        sigc::mem_fun(*this, &LinkManager::onSquelchStateChanged), logic));
 
     // Add the logic core to the logic map
   logic_map.emplace(logic->name(), logic_info);
@@ -433,6 +454,10 @@ void LinkManager::deleteLogic(LogicBase *logic)
   logic_info.received_tg_update_con.disconnect();
   assert(logic_info.received_publish_state_event_con.connected());
   logic_info.received_publish_state_event_con.disconnect();
+  if (logic_info.squelch_state_changed_con.connected())
+  {
+    logic_info.squelch_state_changed_con.disconnect();
+  }
 
     // Delete the logic source splitter and all connections associated with it
   AudioSplitter *splitter = sources[logic->name()].splitter;
@@ -449,7 +474,7 @@ void LinkManager::deleteLogic(LogicBase *logic)
     splitter->removeSink(connector);
     //delete connector;
 
-      // Close and remove valve for mixer (can't remove from mixer, just close it)
+      // Close and remove valve and amp for mixer
     ValveMap::iterator vmit = sink_info.valves.find(logic->name());
     if (vmit != sink_info.valves.end())
     {
@@ -457,6 +482,14 @@ void LinkManager::deleteLogic(LogicBase *logic)
       splitter->removeSink(vmit->second);
       delete vmit->second;
       sink_info.valves.erase(vmit);
+    }
+
+      // Remove amp for mixer
+    AmpMap::iterator amit = sink_info.amps.find(logic->name());
+    if (amit != sink_info.amps.end())
+    {
+      delete amit->second;
+      sink_info.amps.erase(amit);
     }
   }
   delete splitter;
@@ -487,6 +520,13 @@ void LinkManager::deleteLogic(LogicBase *logic)
     const string &source_name = vmit->first;
     sources[source_name].splitter->removeSink(valve);
     delete valve;
+  }
+
+    // Clean up amps (for mixer DUCK mode)
+  AmpMap &amps = sink_to_delete.amps;
+  for (AmpMap::iterator amit = amps.begin(); amit != amps.end(); ++amit)
+  {
+    delete amit->second;
   }
 
   delete selector;
@@ -869,9 +909,9 @@ void LinkManager::updateConnections(void)
       sink.selector->enableAutoSelect(sink.connectors.at(src_name), 0);
       sink.valves.at(src_name)->setOpen(false);
     }
-    else // MIX mode
+    else // MIX or DUCK mode - both use mixer
     {
-        // MIX mode: disable selector, open mixer valve
+        // MIX/DUCK mode: disable selector, open mixer valve
       sink.selector->disableAutoSelect(sink.connectors.at(src_name));
       sink.valves.at(src_name)->setOpen(true);
     }
@@ -880,7 +920,7 @@ void LinkManager::updateConnections(void)
     current_cons.insert(*it);
   }
 
-    // Update mixer routing based on active MIX connections
+    // Update mixer routing based on active MIX/DUCK connections
   updateMixerRouting();
 } /* LinkManager::updateConnections */
 
@@ -1121,9 +1161,10 @@ void LinkManager::onPublishStateEvent(LogicBase *src_logic,
 LinkAudioMode LinkManager::getEffectiveMode(const std::string& src_name,
                                              const std::string& sink_name)
 {
-    // Determine if a connection should use MIX mode.
-    // MIX mode takes precedence if any active link that includes both
-    // source and sink logics uses MIX mode.
+    // Determine the effective audio mode for a connection.
+    // DUCK takes precedence over MIX, and both use the mixer path.
+  LinkAudioMode mode = LinkAudioMode::FIRST;
+
   for (const auto& link_pair : links)
   {
     const Link& link = link_pair.second;
@@ -1135,12 +1176,21 @@ LinkAudioMode LinkManager::getEffectiveMode(const std::string& src_name,
     bool has_src = link.logic_props.count(src_name) > 0;
     bool has_sink = link.logic_props.count(sink_name) > 0;
 
-    if (has_src && has_sink && link.audio_mode == LinkAudioMode::MIX)
+    if (has_src && has_sink)
     {
-      return LinkAudioMode::MIX;
+        // DUCK takes precedence over MIX
+      if (link.audio_mode == LinkAudioMode::DUCK)
+      {
+        return LinkAudioMode::DUCK;
+      }
+      else if (link.audio_mode == LinkAudioMode::MIX &&
+               mode != LinkAudioMode::DUCK)
+      {
+        mode = LinkAudioMode::MIX;
+      }
     }
   }
-  return LinkAudioMode::FIRST;
+  return mode;
 } /* LinkManager::getEffectiveMode */
 
 
@@ -1191,6 +1241,73 @@ void LinkManager::updateMixerRouting(void)
     }
   }
 } /* LinkManager::updateMixerRouting */
+
+
+void LinkManager::onSquelchStateChanged(bool is_open, LogicBase *logic)
+{
+    // Update ducking for this logic's incoming connections
+  updateDuckingForSink(logic->name(), is_open);
+} /* LinkManager::onSquelchStateChanged */
+
+
+void LinkManager::updateDuckingForSink(const std::string& sink_name,
+                                        bool local_squelch_open)
+{
+  SinkMap::iterator sink_it = sinks.find(sink_name);
+  if (sink_it == sinks.end())
+  {
+    return;
+  }
+
+  SinkInfo& sink = sink_it->second;
+
+  for (auto& amp_pair : sink.amps)
+  {
+    const std::string& src_name = amp_pair.first;
+    AudioAmp* amp = amp_pair.second;
+
+      // Check if this connection uses DUCK mode
+    LinkAudioMode mode = getEffectiveMode(src_name, sink_name);
+
+    if (mode == LinkAudioMode::DUCK)
+    {
+      if (local_squelch_open)
+      {
+          // Duck incoming audio when local squelch is open
+        float duck_level = getEffectiveDuckLevel(src_name, sink_name);
+        amp->setGain(duck_level);
+      }
+      else
+      {
+          // Restore normal gain when local squelch closes
+        amp->setGain(0);
+      }
+    }
+  }
+} /* LinkManager::updateDuckingForSink */
+
+
+float LinkManager::getEffectiveDuckLevel(const std::string& src_name,
+                                          const std::string& sink_name)
+{
+  float duck_level = -12.0f;  // Default
+
+  for (const auto& link_pair : links)
+  {
+    const Link& link = link_pair.second;
+    if (!link.is_activated) continue;
+
+    bool has_src = link.logic_props.count(src_name) > 0;
+    bool has_sink = link.logic_props.count(sink_name) > 0;
+
+    if (has_src && has_sink && link.audio_mode == LinkAudioMode::DUCK)
+    {
+      duck_level = link.duck_level_db;
+      break;
+    }
+  }
+  return duck_level;
+} /* LinkManager::getEffectiveDuckLevel */
 
 
 /*

--- a/src/svxlink/svxlink/LinkManager.cpp
+++ b/src/svxlink/svxlink/LinkManager.cpp
@@ -283,16 +283,24 @@ bool LinkManager::initialize(Async::Config &cfg,
       {
         link.audio_mode = LinkAudioMode::DUCK;
       }
+      else if (audio_mode_str == "PRIORITY")
+      {
+        link.audio_mode = LinkAudioMode::PRIORITY;
+      }
       else
       {
         std::cerr << "*** WARNING: Unknown AUDIO_MODE \"" << audio_mode_str
                   << "\" in link " << link.name
-                  << ". Valid options: FIRST, MIX, DUCK. Using FIRST." << std::endl;
+                  << ". Valid options: FIRST, MIX, DUCK, PRIORITY. Using FIRST."
+                  << std::endl;
       }
     }
 
       // Parse DUCK_LEVEL_DB configuration (default: -12 dB)
     cfg.getValue(link.name, "DUCK_LEVEL_DB", link.duck_level_db);
+
+      // Parse PRIORITY_MUTE_DB configuration (default: -60 dB)
+    cfg.getValue(link.name, "PRIORITY_MUTE_DB", link.priority_mute_db);
   }
 
   if(!init_ok)
@@ -909,9 +917,9 @@ void LinkManager::updateConnections(void)
       sink.selector->enableAutoSelect(sink.connectors.at(src_name), 0);
       sink.valves.at(src_name)->setOpen(false);
     }
-    else // MIX or DUCK mode - both use mixer
+    else // MIX, DUCK, or PRIORITY mode - all use mixer
     {
-        // MIX/DUCK mode: disable selector, open mixer valve
+        // MIX/DUCK/PRIORITY mode: disable selector, open mixer valve
       sink.selector->disableAutoSelect(sink.connectors.at(src_name));
       sink.valves.at(src_name)->setOpen(true);
     }
@@ -920,7 +928,7 @@ void LinkManager::updateConnections(void)
     current_cons.insert(*it);
   }
 
-    // Update mixer routing based on active MIX/DUCK connections
+    // Update mixer routing based on active MIX/DUCK/PRIORITY connections
   updateMixerRouting();
 } /* LinkManager::updateConnections */
 
@@ -1178,13 +1186,18 @@ LinkAudioMode LinkManager::getEffectiveMode(const std::string& src_name,
 
     if (has_src && has_sink)
     {
-        // DUCK takes precedence over MIX
-      if (link.audio_mode == LinkAudioMode::DUCK)
+        // PRIORITY takes highest precedence, then DUCK, then MIX
+      if (link.audio_mode == LinkAudioMode::PRIORITY)
       {
-        return LinkAudioMode::DUCK;
+        return LinkAudioMode::PRIORITY;
+      }
+      else if (link.audio_mode == LinkAudioMode::DUCK &&
+               mode != LinkAudioMode::PRIORITY)
+      {
+        mode = LinkAudioMode::DUCK;
       }
       else if (link.audio_mode == LinkAudioMode::MIX &&
-               mode != LinkAudioMode::DUCK)
+               mode != LinkAudioMode::PRIORITY && mode != LinkAudioMode::DUCK)
       {
         mode = LinkAudioMode::MIX;
       }
@@ -1245,8 +1258,21 @@ void LinkManager::updateMixerRouting(void)
 
 void LinkManager::onSquelchStateChanged(bool is_open, LogicBase *logic)
 {
+    // Update squelch state tracking
+  LogicMap::iterator it = logic_map.find(logic->name());
+  if (it != logic_map.end())
+  {
+    it->second.squelch_open = is_open;
+  }
+
     // Update ducking for this logic's incoming connections
   updateDuckingForSink(logic->name(), is_open);
+
+    // Update priority preemption for all sinks
+  for (auto& sink_pair : sinks)
+  {
+    updatePriorityForSink(sink_pair.first);
+  }
 } /* LinkManager::onSquelchStateChanged */
 
 
@@ -1308,6 +1334,134 @@ float LinkManager::getEffectiveDuckLevel(const std::string& src_name,
   }
   return duck_level;
 } /* LinkManager::getEffectiveDuckLevel */
+
+
+bool LinkManager::isSourceFromPriorityLink(const std::string& src_name,
+                                            const std::string& sink_name)
+{
+    // Check if this source-sink pair is in a PRIORITY mode link
+  for (const auto& link_pair : links)
+  {
+    const Link& link = link_pair.second;
+    if (!link.is_activated) continue;
+    if (link.audio_mode != LinkAudioMode::PRIORITY) continue;
+
+    if (link.logic_props.count(src_name) > 0 &&
+        link.logic_props.count(sink_name) > 0)
+    {
+      return true;
+    }
+  }
+  return false;
+} /* LinkManager::isSourceFromPriorityLink */
+
+
+bool LinkManager::isPrioritySourceActive(const std::string& sink_name)
+{
+    // Check if any PRIORITY source is currently transmitting to this sink
+  SinkMap::iterator sink_it = sinks.find(sink_name);
+  if (sink_it == sinks.end()) return false;
+
+  for (const auto& amp_pair : sink_it->second.amps)
+  {
+    const std::string& src_name = amp_pair.first;
+
+      // Check if this source's squelch is open
+    LogicMap::iterator it = logic_map.find(src_name);
+    if (it == logic_map.end() || !it->second.squelch_open) continue;
+
+      // Check if this source is from a PRIORITY link to this sink
+    if (isSourceFromPriorityLink(src_name, sink_name))
+    {
+      return true;
+    }
+  }
+  return false;
+} /* LinkManager::isPrioritySourceActive */
+
+
+float LinkManager::getEffectivePriorityMuteLevel(const std::string& src_name,
+                                                  const std::string& sink_name)
+{
+  for (const auto& link_pair : links)
+  {
+    const Link& link = link_pair.second;
+    if (!link.is_activated) continue;
+
+      // Find any PRIORITY link that includes this sink
+    if (link.audio_mode == LinkAudioMode::PRIORITY &&
+        link.logic_props.count(sink_name) > 0)
+    {
+      return link.priority_mute_db;
+    }
+  }
+  return -60.0f;
+} /* LinkManager::getEffectivePriorityMuteLevel */
+
+
+void LinkManager::updatePriorityForSink(const std::string& sink_name)
+{
+  SinkMap::iterator sink_it = sinks.find(sink_name);
+  if (sink_it == sinks.end()) return;
+
+  SinkInfo& sink = sink_it->second;
+  bool priority_active = isPrioritySourceActive(sink_name);
+
+    // Check if sink logic's squelch is open (for DUCK interaction)
+  bool sink_squelch_open = false;
+  LogicMap::iterator sink_logic_it = logic_map.find(sink_name);
+  if (sink_logic_it != logic_map.end())
+  {
+    sink_squelch_open = sink_logic_it->second.squelch_open;
+  }
+
+    // Handle all connections (both FIRST mode via selector and mixer-based modes)
+  for (auto& con_pair : sink.connectors)
+  {
+    const std::string& src_name = con_pair.first;
+    LinkAudioMode mode = getEffectiveMode(src_name, sink_name);
+    bool is_priority_src = isSourceFromPriorityLink(src_name, sink_name);
+
+    if (mode == LinkAudioMode::FIRST)
+    {
+        // FIRST mode: use selector enable/disable for priority preemption
+      if (priority_active && !is_priority_src)
+      {
+          // Disable this source in the selector when preempted by priority
+        sink.selector->disableAutoSelect(con_pair.second);
+      }
+      else
+      {
+          // Re-enable in selector (normal operation)
+        sink.selector->enableAutoSelect(con_pair.second, 0);
+      }
+    }
+    else
+    {
+        // MIX/DUCK/PRIORITY mode: use amp gain for priority preemption
+      AudioAmp* amp = sink.amps.at(src_name);
+
+        // Determine base gain level (may be ducked if sink squelch is open)
+      float base_gain = 0;
+      if (sink_squelch_open && (mode == LinkAudioMode::DUCK || mode == LinkAudioMode::PRIORITY))
+      {
+        base_gain = getEffectiveDuckLevel(src_name, sink_name);
+      }
+
+      if (priority_active && !is_priority_src)
+      {
+          // A PRIORITY source is active and this is NOT a priority source - mute it
+        float mute_level = getEffectivePriorityMuteLevel(src_name, sink_name);
+        amp->setGain(mute_level);
+      }
+      else
+      {
+          // No priority preemption (or this IS the priority source) - use base gain
+        amp->setGain(base_gain);
+      }
+    }
+  }
+} /* LinkManager::updatePriorityForSink */
 
 
 /*

--- a/src/svxlink/svxlink/LinkManager.h
+++ b/src/svxlink/svxlink/LinkManager.h
@@ -76,6 +76,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 namespace Async
 {
   class AudioPassthrough;
+  class AudioValve;
+  class AudioMixer;
 };
 class LogicBase;
 
@@ -109,6 +111,14 @@ class LogicBase;
  * Exported Global Types
  *
  ****************************************************************************/
+
+/**
+ * @brief Audio mode for link connections
+ *
+ * FIRST: First source to transmit wins (current behavior)
+ * MIX: Mix all active sources together
+ */
+enum class LinkAudioMode { FIRST, MIX };
 
 
 /****************************************************************************
@@ -296,7 +306,8 @@ class LinkManager : public sigc::trackable
     struct Link
     {
       Link(void)
-        : default_active(false), is_activated(false), timeout_timer(0) {}
+        : default_active(false), is_activated(false), timeout_timer(0),
+          audio_mode(LinkAudioMode::FIRST) {}
       ~Link(void) { delete timeout_timer; }
 
       std::string   name;
@@ -306,6 +317,7 @@ class LinkManager : public sigc::trackable
       bool          default_active;
       bool          is_activated;
       Async::Timer  *timeout_timer;
+      LinkAudioMode audio_mode;
     };
     typedef std::map<std::string, Link> LinkMap;
     typedef std::set<std::pair<std::string, std::string> > LogicConSet;
@@ -315,11 +327,14 @@ class LinkManager : public sigc::trackable
       Async::AudioSplitter    *splitter;
     };
     typedef std::map<std::string, Async::AudioPassthrough *> ConMap;
+    typedef std::map<std::string, Async::AudioValve *> ValveMap;
     struct SinkInfo
     {
       Async::AudioSink      *sink;
-      Async::AudioSelector  *selector;
-      ConMap                connectors;
+      Async::AudioSelector  *selector;      // Used in FIRST mode
+      Async::AudioMixer     *mixer;         // Used in MIX mode
+      ConMap                connectors;     // Passthroughs for selector
+      ValveMap              valves;         // Valves for mixer
     };
     typedef std::map<std::string, SourceInfo> SourceMap;
     typedef std::map<std::string, SinkInfo>   SinkMap;
@@ -364,6 +379,9 @@ class LinkManager : public sigc::trackable
     void onReceivedTgUpdated(LogicBase *src_logic, uint32_t tg);
     void onPublishStateEvent(LogicBase *src_logic,
         const std::string& event_name, const std::string& msg);
+    LinkAudioMode getEffectiveMode(const std::string& src_name,
+                                   const std::string& sink_name);
+    void updateMixerRouting(void);
 
 };  /* class LinkManager */
 

--- a/src/svxlink/svxlink/LinkManager.h
+++ b/src/svxlink/svxlink/LinkManager.h
@@ -311,8 +311,13 @@ class LinkManager : public sigc::trackable
       Link(void)
         : default_active(false), is_activated(false), timeout_timer(0),
           audio_mode(LinkAudioMode::FIRST), duck_level_db(-12.0f),
-          priority_mute_db(-60.0f) {}
-      ~Link(void) { delete timeout_timer; }
+          priority_mute_db(-60.0f), priority_hangtime(0),
+          priority_hangtime_timer(0), priority_was_active(false) {}
+      ~Link(void)
+      {
+        delete timeout_timer;
+        delete priority_hangtime_timer;
+      }
 
       std::string   name;
       LogicPropMap  logic_props;
@@ -324,6 +329,9 @@ class LinkManager : public sigc::trackable
       LinkAudioMode audio_mode;
       float         duck_level_db;
       float         priority_mute_db;
+      int           priority_hangtime;        // Hangtime in ms (0 = disabled)
+      Async::Timer  *priority_hangtime_timer; // Active during priority hangtime
+      bool          priority_was_active;      // Track if priority was active
     };
     typedef std::map<std::string, Link> LinkMap;
     typedef std::set<std::pair<std::string, std::string> > LogicConSet;
@@ -398,10 +406,13 @@ class LinkManager : public sigc::trackable
                                 const std::string& sink_name);
     void updatePriorityForSink(const std::string& sink_name);
     bool isPrioritySourceActive(const std::string& sink_name);
+    bool isPriorityHangtimeActive(const std::string& sink_name);
     float getEffectivePriorityMuteLevel(const std::string& src_name,
                                         const std::string& sink_name);
     bool isSourceFromPriorityLink(const std::string& src_name,
                                   const std::string& sink_name);
+    void checkPriorityHangtime(void);
+    void onPriorityHangtimeExpired(Async::Timer *t, Link *link);
 
 };  /* class LinkManager */
 

--- a/src/svxlink/svxlink/LinkManager.h
+++ b/src/svxlink/svxlink/LinkManager.h
@@ -78,6 +78,7 @@ namespace Async
   class AudioPassthrough;
   class AudioValve;
   class AudioMixer;
+  class AudioAmp;
 };
 class LogicBase;
 
@@ -117,8 +118,9 @@ class LogicBase;
  *
  * FIRST: First source to transmit wins (current behavior)
  * MIX: Mix all active sources together
+ * DUCK: Like MIX but incoming link audio is reduced when local squelch is open
  */
-enum class LinkAudioMode { FIRST, MIX };
+enum class LinkAudioMode { FIRST, MIX, DUCK };
 
 
 /****************************************************************************
@@ -307,7 +309,7 @@ class LinkManager : public sigc::trackable
     {
       Link(void)
         : default_active(false), is_activated(false), timeout_timer(0),
-          audio_mode(LinkAudioMode::FIRST) {}
+          audio_mode(LinkAudioMode::FIRST), duck_level_db(-12.0f) {}
       ~Link(void) { delete timeout_timer; }
 
       std::string   name;
@@ -318,6 +320,7 @@ class LinkManager : public sigc::trackable
       bool          is_activated;
       Async::Timer  *timeout_timer;
       LinkAudioMode audio_mode;
+      float         duck_level_db;
     };
     typedef std::map<std::string, Link> LinkMap;
     typedef std::set<std::pair<std::string, std::string> > LogicConSet;
@@ -328,13 +331,15 @@ class LinkManager : public sigc::trackable
     };
     typedef std::map<std::string, Async::AudioPassthrough *> ConMap;
     typedef std::map<std::string, Async::AudioValve *> ValveMap;
+    typedef std::map<std::string, Async::AudioAmp *> AmpMap;
     struct SinkInfo
     {
       Async::AudioSink      *sink;
       Async::AudioSelector  *selector;      // Used in FIRST mode
-      Async::AudioMixer     *mixer;         // Used in MIX mode
+      Async::AudioMixer     *mixer;         // Used in MIX/DUCK mode
       ConMap                connectors;     // Passthroughs for selector
       ValveMap              valves;         // Valves for mixer
+      AmpMap                amps;           // Gain control for DUCK mode
     };
     typedef std::map<std::string, SourceInfo> SourceMap;
     typedef std::map<std::string, SinkInfo>   SinkMap;
@@ -345,6 +350,7 @@ class LinkManager : public sigc::trackable
       sigc::connection  idle_state_changed_con;
       sigc::connection  received_tg_update_con;
       sigc::connection  received_publish_state_event_con;
+      sigc::connection  squelch_state_changed_con;
       bool              is_muted;
     };
     typedef std::map<std::string, LogicInfo> LogicMap;
@@ -382,6 +388,10 @@ class LinkManager : public sigc::trackable
     LinkAudioMode getEffectiveMode(const std::string& src_name,
                                    const std::string& sink_name);
     void updateMixerRouting(void);
+    void onSquelchStateChanged(bool is_open, LogicBase *logic);
+    void updateDuckingForSink(const std::string& sink_name, bool local_squelch_open);
+    float getEffectiveDuckLevel(const std::string& src_name,
+                                const std::string& sink_name);
 
 };  /* class LinkManager */
 

--- a/src/svxlink/svxlink/LinkManager.h
+++ b/src/svxlink/svxlink/LinkManager.h
@@ -119,8 +119,9 @@ class LogicBase;
  * FIRST: First source to transmit wins (current behavior)
  * MIX: Mix all active sources together
  * DUCK: Like MIX but incoming link audio is reduced when local squelch is open
+ * PRIORITY: Like MIX but preempts non-PRIORITY links when transmitting
  */
-enum class LinkAudioMode { FIRST, MIX, DUCK };
+enum class LinkAudioMode { FIRST, MIX, DUCK, PRIORITY };
 
 
 /****************************************************************************
@@ -309,7 +310,8 @@ class LinkManager : public sigc::trackable
     {
       Link(void)
         : default_active(false), is_activated(false), timeout_timer(0),
-          audio_mode(LinkAudioMode::FIRST), duck_level_db(-12.0f) {}
+          audio_mode(LinkAudioMode::FIRST), duck_level_db(-12.0f),
+          priority_mute_db(-60.0f) {}
       ~Link(void) { delete timeout_timer; }
 
       std::string   name;
@@ -321,6 +323,7 @@ class LinkManager : public sigc::trackable
       Async::Timer  *timeout_timer;
       LinkAudioMode audio_mode;
       float         duck_level_db;
+      float         priority_mute_db;
     };
     typedef std::map<std::string, Link> LinkMap;
     typedef std::set<std::pair<std::string, std::string> > LogicConSet;
@@ -345,13 +348,14 @@ class LinkManager : public sigc::trackable
     typedef std::map<std::string, SinkInfo>   SinkMap;
     struct LogicInfo
     {
-      LogicInfo(LogicBase* logic) : logic(logic), is_muted(false) {}
+      LogicInfo(LogicBase* logic) : logic(logic), is_muted(false), squelch_open(false) {}
       LogicBase         *logic;
       sigc::connection  idle_state_changed_con;
       sigc::connection  received_tg_update_con;
       sigc::connection  received_publish_state_event_con;
       sigc::connection  squelch_state_changed_con;
       bool              is_muted;
+      bool              squelch_open;
     };
     typedef std::map<std::string, LogicInfo> LogicMap;
 
@@ -392,6 +396,12 @@ class LinkManager : public sigc::trackable
     void updateDuckingForSink(const std::string& sink_name, bool local_squelch_open);
     float getEffectiveDuckLevel(const std::string& src_name,
                                 const std::string& sink_name);
+    void updatePriorityForSink(const std::string& sink_name);
+    bool isPrioritySourceActive(const std::string& sink_name);
+    float getEffectivePriorityMuteLevel(const std::string& src_name,
+                                        const std::string& sink_name);
+    bool isSourceFromPriorityLink(const std::string& src_name,
+                                  const std::string& sink_name);
 
 };  /* class LinkManager */
 

--- a/src/svxlink/svxlink/Logic.cpp
+++ b/src/svxlink/svxlink/Logic.cpp
@@ -1075,6 +1075,8 @@ void Logic::squelchOpen(bool is_open)
 {
   //std::cout << "### Logic::squelchOpen: is_open=" << is_open << std::endl;
 
+  squelchStateChanged(is_open);
+
   if (active_module != 0)
   {
     active_module->squelchOpen(is_open);

--- a/src/svxlink/svxlink/LogicBase.h
+++ b/src/svxlink/svxlink/LogicBase.h
@@ -283,6 +283,12 @@ class LogicBase : public Async::Plugin, public sigc::trackable
     sigc::signal<void(bool)> idleStateChanged;
 
     /**
+     * @brief   A signal emitted when the squelch state changes
+     * @param   is_open \em True if squelch is open, \em false if closed
+     */
+    sigc::signal<void(bool)> squelchStateChanged;
+
+    /**
      * @brief   A signal that is emitted when the received talk group changes
      * @param   tg The new talk group
      */


### PR DESCRIPTION
This attempts to implement #732 by adding the following features:

- Local mixing, which rebroadcasts all inputs
- Ducking, which configures a link to be added to the local mixing with a lower, configurable audio level
- Priority, which preempts all other transmissions
- Priority hang time, which prevents another transmission from breaking through during brief breaks of a priority transmission

This has been implemented without testing at this point, so I've marked this as a draft PR. It compiles.