### PR TITLE
Adds a pluggable database configuration backend

### DIFF
--- a/examples/db.conf
+++ b/examples/db.conf
@@ -1,0 +1,63 @@
+# SVXLink Database Configuration
+# This file determines which configuration backend to use
+# see doc/README_DBCONFIG.md for more information
+#
+# Place this file in one of the following locations:
+# - ~/.svxlink/db.conf (user-specific)
+# - /etc/svxlink/db.conf (system-wide)
+# 
+# If this file is not found, each application will default to the traditional
+# file-based configuration using its own config file by convention:
+# - svxlink binary → svxlink.conf
+# - svxreflector binary → svxreflector.conf
+# - remotetrx binary → remotetrx.conf
+
+[DATABASE]
+# Backend type, currently supported: file, sqlite, mysql, postgresql
+TYPE=file
+
+# Configuration source - format depends on backend type:
+#
+# For file backend:
+#   SOURCE=/path/to/config.conf
+#
+# For SQLite backend:
+#   SOURCE=/path/to/database.db
+#
+# For MySQL/MariaDB backend:
+#   SOURCE=mysql://username:password@hostname:port/database
+#
+# For PostgreSQL backend:
+#   SOURCE=postgresql://username:password@hostname:port/database
+
+SOURCE=/etc/svxlink/svxlink.conf
+
+# TABLE_PREFIX: Optional parameter to add a common prefix before the binary name
+# By DEFAULT (TABLE_PREFIX not set), each binary automatically uses its own prefix:
+# - svxlink binary → svxlink_ (automatic)
+# - svxreflector binary → svxreflector_ (automatic)
+# - remotetrx binary → remotetrx_ (automatic)
+#
+# If you set TABLE_PREFIX, it will be PREPENDED to the binary name for isolation.
+# Example: TABLE_PREFIX=prod_
+# - svxlink binary → prod_svxlink_
+# - svxreflector binary → prod_svxreflector_
+# - remotetrx binary → prod_remotetrx_
+#
+# Multiple applications can share the same database with a single
+# db.conf file - each will ALWAYS have its own isolated prefix!
+#
+# Common use cases for TABLE_PREFIX:
+# - Environment separation: prod_, test_, dev_
+# - Host identification: server1_, server2_
+# - Custom organization: myapp_
+#
+# Resulting tables (if TABLE_PREFIX=prod_):
+#   prod_svxlink_config, prod_svxreflector_config, prod_remotetrx_config
+#
+# Without TABLE_PREFIX:
+#   svxlink_config, svxreflector_config, remotetrx_config
+#
+
+#TABLE_PREFIX=prod_
+

--- a/examples/db.conf.file
+++ b/examples/db.conf.file
@@ -1,0 +1,9 @@
+# SVXLink Database Configuration - File Backend
+# This configuration uses the traditional INI file backend
+
+[DATABASE]
+# Backend type: file, sqlite, mysql, postgresql
+TYPE=file
+
+# For file backend, SOURCE is the path to the INI configuration file
+SOURCE=/etc/svxlink/svxlink.conf

--- a/examples/db.conf.mysql
+++ b/examples/db.conf.mysql
@@ -1,0 +1,16 @@
+# SVXLink Database Configuration - MySQL/MariaDB Backend
+# This configuration uses a MySQL or MariaDB database
+
+[DATABASE]
+# Backend type: file, sqlite, mysql, postgresql
+TYPE=mysql
+
+# For MySQL backend, SOURCE is the connection URL
+# Format: mysql://username:password@hostname:port/database
+# 
+# Before using this configuration:
+# 1. Create the database: CREATE DATABASE svxlink_config;
+# 2. Create a user: CREATE USER 'svxlink'@'localhost' IDENTIFIED BY 'your_password';
+# 3. Grant privileges: GRANT ALL PRIVILEGES ON svxlink_config.* TO 'svxlink'@'localhost';
+# 4. Replace 'your_password' below with the actual password
+SOURCE=mysql://svxlink:your_password@localhost:3306/svxlink_config

--- a/examples/db.conf.postgresql
+++ b/examples/db.conf.postgresql
@@ -1,0 +1,16 @@
+# SVXLink Database Configuration - PostgreSQL Backend
+# This configuration uses a PostgreSQL database
+
+[DATABASE]
+# Backend type: file, sqlite, mysql, postgresql
+TYPE=postgresql
+
+# For PostgreSQL backend, SOURCE is the connection URL
+# Format: postgresql://username:password@hostname:port/database
+# 
+# Before using this configuration:
+# 1. Create the database: CREATE DATABASE svxlink_config;
+# 2. Create a user: CREATE USER svxlink WITH PASSWORD 'your_password';
+# 3. Grant privileges: GRANT ALL PRIVILEGES ON DATABASE svxlink_config TO svxlink;
+# 4. Replace 'your_password' below with the actual password
+SOURCE=postgresql://svxlink:your_password@localhost:5432/svxlink_config

--- a/examples/db.conf.sqlite
+++ b/examples/db.conf.sqlite
@@ -1,0 +1,10 @@
+# SVXLink Database Configuration - SQLite Backend
+# This configuration uses a local SQLite database file
+
+[DATABASE]
+# Backend type: file, sqlite, mysql, postgresql
+TYPE=sqlite
+
+# For SQLite backend, SOURCE is the path to the database file
+# The database and tables will be created automatically if they don't exist
+SOURCE=/var/lib/svxlink/config.db

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,12 @@
 ##############################################################################
 cmake_minimum_required(VERSION 3.7...3.30)
 project(svxlink C CXX)
+
+# AsyncConfigBackend requires C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)   # use -std=c++17, not -std=gnu++17
+
 if(BUILD_TESTS)
   enable_testing()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,9 @@
 ##############################################################################
 cmake_minimum_required(VERSION 3.7...3.30)
 project(svxlink C CXX)
-#enable_testing()
+if(BUILD_TESTS)
+  enable_testing()
+endif()
 
 # The path to the project global include directory
 set(PROJECT_INCLUDE_DIR ${PROJECT_BINARY_DIR}/include)
@@ -45,6 +47,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 # Optional parts
 option(USE_QT "Build Qt applications and libs" ON)
 option(BUILD_STATIC_LIBS "Build static libraries in addition to dynamic" OFF)
+option(BUILD_TESTS "Build the test suite (requires Catch2)" OFF)
 
 # The sample rate used internally in SvxLink
 if(NOT DEFINED INTERNAL_SAMPLE_RATE)
@@ -337,6 +340,24 @@ add_subdirectory(svxlink)
 if(USE_QT)
   add_subdirectory(qtel)
 endif(USE_QT)
+
+# Tests — added AFTER all source subdirectories so that all library targets
+# (asynccore etc.) and their directory-level COMPILE_DEFINITIONS are already
+# known when the test CMakeLists files are processed.
+if(BUILD_TESTS)
+  find_package(Catch2 3 QUIET)
+  if(NOT Catch2_FOUND)
+    find_package(Catch2 QUIET)
+  endif()
+  if(NOT Catch2_FOUND)
+    message(FATAL_ERROR
+      "BUILD_TESTS=ON but Catch2 was not found.\n"
+      "Install Catch2 v2 or v3 (e.g. 'apt install catch2' / 'brew install catch2')\n"
+      "or set BUILD_TESTS=OFF to build without tests.")
+  endif()
+  message(STATUS "Catch2 found — building tests")
+  add_subdirectory(${CMAKE_SOURCE_DIR}/../tests ${CMAKE_BINARY_DIR}/tests)
+endif()
 
 # Experimental CPack package building
 set(CPACK_SET_DESTDIR "ON")

--- a/src/async/core/AsyncConfig.cpp
+++ b/src/async/core/AsyncConfig.cpp
@@ -1,18 +1,18 @@
 /**
 @file	 AsyncConfig.cpp
-@brief   A class for reading "INI-foramtted" configuration files
+@brief   A class for configuration handling
 @author  Tobias Blomberg / SM0SVX
 @date	 2004-03-17
 
-This file contains a class that is used to read configuration files that is
-in the famous MS Windows INI file format. An example of a configuration file
-is shown below.
+This file contains a class that is used to supply and save configuration data
+to a backend which can be a file, a database, etc. The backend can be
+implemented by extending AsyncConfigBackend.
 
 \include test.cfg
 
 \verbatim
 Async - A library for programming event driven applications
-Copyright (C) 2003-2025 Tobias Blomberg / SM0SVX
+Copyright (C) 2003-2026 Tobias Blomberg / SM0SVX
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -41,10 +41,16 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <unistd.h>
 #include <errno.h>
 #include <ctype.h>
+#include <dirent.h>
+#include <sys/stat.h>
 
 #include <iostream>
+#include <fstream>
 #include <cassert>
 #include <cstring>
+#include <cstdlib>
+#include <map>
+#include <vector>
 
 
 /****************************************************************************
@@ -62,6 +68,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ****************************************************************************/
 
 #include "AsyncConfig.h"
+#include "AsyncConfigBackend.h"
+#include "AsyncConfigSource.h"
 
 
 
@@ -73,6 +81,17 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 using namespace std;
 using namespace Async;
+
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+#ifndef SVX_SYSCONF_INSTALL_DIR
+#define SVX_SYSCONF_INSTALL_DIR "/etc"
+#endif
 
 
 /****************************************************************************
@@ -128,97 +147,556 @@ Config::~Config(void)
 } /* Config::~Config */
 
 
-bool Config::open(const string& name)
+bool Config::open(const string& default_config_name)
 {
-  errno = 0;
+  return openWithFallback("", "", default_config_name);
+} /* Config::open */
 
-  FILE *file = fopen(name.c_str(), "r");
-  if (file == NULL)
+bool Config::openFromDbConfig(const string& db_conf_path)
+{
+  if (!openFromDbConfigInternal(db_conf_path, "svxlink.conf", "svxlink_"))
+  {
+    cerr << "*** FATAL ERROR: Cannot initialize configuration from "
+         << db_conf_path << endl;
+    exit(1);
+  }
+  loadCfgDir();
+  return true;
+} /* Config::openFromDbConfig */
+
+bool Config::openFromDbConfigInternal(const std::string& db_conf_path,
+                                       const std::string& default_config_name,
+                                       const std::string& default_table_prefix)
+{
+  DbConf conf;
+  if (!parseDbConfFile(db_conf_path, conf))
+  {
+    cerr << "*** ERROR: Could not parse database configuration file: "
+         << db_conf_path << endl;
+    return false;
+  }
+
+  applyTablePrefix(conf, default_table_prefix);
+  m_main_config_file = (conf.type == "file") ? conf.source : db_conf_path;
+
+  ConfigBackendPtr backend = createAndConfigureBackend(conf, default_config_name);
+  if (!backend)
+  {
+    cerr << "*** ERROR: Failed to create backend from: " << db_conf_path << endl;
+    return false;
+  }
+
+  setBackend(std::move(backend));
+  return true;
+} /* Config::openFromDbConfigInternal */
+
+bool Config::openDirect(const string& source)
+{
+  // Create the appropriate backend using the factory
+  m_backend = createConfigBackend(source);
+  if (m_backend == nullptr)
+  {
+    cerr << "*** ERROR: Failed to create configuration backend for: " << source << endl;
+    return false;
+  }
+
+  // Store the main config file path for CFG_DIR resolution
+  if (source.find("file://") == 0)
+  {
+    m_main_config_file = source.substr(7); // Remove "file://" prefix
+  }
+  else
+  {
+    m_main_config_file = ""; // Database backend - no single file
+  }
+
+  // For database backends ensure the schema exists before any use.
+  // FileConfigBackend::initializeTables() is a no-op so this is safe for all
+  // backend types.
+  if (!m_backend->initializeTables())
+  {
+    cerr << "*** ERROR: Failed to initialize backend tables for: " << source << endl;
+    m_backend.reset();
+    return false;
+  }
+
+  finalizeBackendSetup();
+  return true;
+} /* Config::openDirect */
+
+
+void Config::loadCfgDir(void)
+{
+  if (getBackendType() != "file") return;
+
+  string cfg_dir;
+  if (!getValue("GLOBAL", "CFG_DIR", cfg_dir)) return;
+
+  if (cfg_dir[0] != '/')
+  {
+    auto slash_pos = m_main_config_file.rfind('/');
+    cfg_dir = (slash_pos != string::npos)
+                  ? m_main_config_file.substr(0, slash_pos) + "/" + cfg_dir
+                  : "./" + cfg_dir;
+  }
+
+  DIR *dir = opendir(cfg_dir.c_str());
+  if (dir == nullptr)
+  {
+    cerr << "*** ERROR: Could not read from directory specified by "
+         << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
+    exit(1);
+  }
+
+  struct dirent *dirent;
+  while ((dirent = readdir(dir)) != nullptr)
+  {
+    char *dot = strrchr(dirent->d_name, '.');
+    if (dot == nullptr || dirent->d_name[0] == '.' || strcmp(dot, ".conf") != 0)
+      continue;
+    string cfg_filename = cfg_dir + "/" + dirent->d_name;
+    cout << "Loading additional configuration: " << cfg_filename << endl;
+    if (!openDirect("file://" + cfg_filename))
+    {
+      cerr << "*** ERROR: Could not open configuration file: "
+           << cfg_filename << endl;
+      exit(1);
+    }
+  }
+
+  if (closedir(dir) == -1)
+  {
+    cerr << "*** ERROR: Error closing directory specified by "
+         << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
+    exit(1);
+  }
+} /* Config::loadCfgDir */
+
+
+void Config::setBackend(ConfigBackendPtr backend)
+{
+  m_backend = std::move(backend);
+  finalizeBackendSetup();
+} /* Config::setBackend */
+
+
+std::string Config::findConfigFile(const std::string& config_dir,
+                                    const std::string& filename)
+{
+  vector<string> search_paths;
+
+  if (!config_dir.empty())
+  {
+    search_paths.push_back(config_dir + "/" + filename);
+  }
+
+  const char* home = getenv("HOME");
+  if (home != nullptr)
+  {
+    search_paths.push_back(string(home) + "/.svxlink/" + filename);
+  }
+
+  search_paths.push_back("/etc/svxlink/" + filename);
+  search_paths.push_back(string(SVX_SYSCONF_INSTALL_DIR) + "/" + filename);
+
+  for (const string& path : search_paths)
+  {
+    struct stat st;
+    if (stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode) &&
+        access(path.c_str(), R_OK) == 0)
+    {
+      return path;
+    }
+  }
+
+  return "";
+} /* Config::findConfigFile */
+
+
+bool Config::parseDbConfFile(const std::string& file_path, DbConf& conf)
+{
+  ifstream file(file_path);
+  if (!file.is_open())
   {
     return false;
   }
 
-  bool success = parseCfgFile(file);
+  cout << "Reading database configuration from: " << file_path << endl;
 
-  fclose(file);
-  file = NULL;
+  string line;
+  bool in_database_section = false;
 
-  return success;
+  while (getline(file, line))
+  {
+    size_t start = line.find_first_not_of(" \t\r\n");
+    if (start == string::npos) continue;
+    size_t end = line.find_last_not_of(" \t\r\n");
+    line = line.substr(start, end - start + 1);
 
-} /* Config::open */
+    if (line[0] == '#' || line[0] == ';') continue;
+
+    if (line[0] == '[' && line.back() == ']')
+    {
+      in_database_section = (line.substr(1, line.size() - 2) == "DATABASE");
+      continue;
+    }
+
+    if (in_database_section)
+    {
+      size_t eq_pos = line.find('=');
+      if (eq_pos != string::npos)
+      {
+        string key = line.substr(0, eq_pos);
+        string value = line.substr(eq_pos + 1);
+        key.erase(0, key.find_first_not_of(" \t"));
+        key.erase(key.find_last_not_of(" \t") + 1);
+        value.erase(0, value.find_first_not_of(" \t"));
+        value.erase(value.find_last_not_of(" \t") + 1);
+
+        if      (key == "TYPE")   conf.type   = value;
+        else if (key == "SOURCE") conf.source = value;
+        else if (key == "TABLE_PREFIX") conf.table_prefix = value;
+        else if (key == "ENABLE_CHANGE_NOTIFICATIONS")
+          conf.enable_change_notifications =
+              (value == "1" || value == "true" || value == "TRUE" ||
+               value == "yes"  || value == "YES");
+        else if (key == "POLL_INTERVAL")
+          conf.poll_interval_seconds = static_cast<unsigned int>(stoul(value));
+      }
+    }
+  }
+
+  if (conf.type.empty() || conf.source.empty())
+  {
+    cerr << "*** ERROR: Invalid db.conf - missing TYPE or SOURCE in [DATABASE] section" << endl;
+    return false;
+  }
+
+  cout << "Database configuration: TYPE=" << conf.type
+       << ", SOURCE=" << conf.source;
+  if (!conf.table_prefix.empty())
+    cout << ", TABLE_PREFIX=" << conf.table_prefix;
+  cout << endl;
+
+  return true;
+} /* Config::parseDbConfFile */
+
+
+void Config::applyTablePrefix(DbConf& conf, const std::string& default_prefix)
+{
+  if (default_prefix.empty()) return;
+
+  if (conf.table_prefix.empty())
+  {
+    conf.table_prefix = default_prefix;
+    cout << "Using automatic table prefix: " << conf.table_prefix << endl;
+  }
+  else
+  {
+    conf.table_prefix = conf.table_prefix + default_prefix;
+    cout << "Using table prefix: " << conf.table_prefix
+         << " (from db.conf + binary name)" << endl;
+  }
+} /* Config::applyTablePrefix */
+
+
+ConfigBackendPtr Config::createAndConfigureBackend(const DbConf& conf,
+                                                    const std::string& default_config_file)
+{
+  if (!ConfigSource::isBackendAvailable(conf.type))
+  {
+    cerr << "*** ERROR: Backend '" << conf.type
+         << "' is not available (not compiled in)" << endl;
+    cerr << "Available backends: " << ConfigBackendFactory::validFactories() << endl;
+    return nullptr;
+  }
+
+  string source_url;
+  if (conf.type == "file")
+    source_url = conf.source;
+  else if (conf.type == "sqlite")
+    source_url = "sqlite://" + conf.source;
+  else
+    source_url = conf.source;
+
+  ConfigBackendPtr backend = createConfigBackend(source_url);
+  if (!backend)
+  {
+    cerr << "*** ERROR: Failed to create " << conf.type << " backend" << endl;
+    return nullptr;
+  }
+
+  if (!conf.table_prefix.empty())
+    backend->setTablePrefix(conf.table_prefix);
+
+  if (backend->getBackendType() != "file")
+  {
+    if (!initializeDatabase(backend.get(), default_config_file))
+    {
+      cerr << "*** ERROR: Failed to initialize database backend" << endl;
+      return nullptr;
+    }
+  }
+
+  backend->enableChangeNotifications(conf.enable_change_notifications);
+  if (conf.enable_change_notifications && conf.poll_interval_seconds > 0)
+  {
+    backend->startAutoPolling(conf.poll_interval_seconds * 1000);
+    cout << "Auto-polling enabled with interval: "
+         << conf.poll_interval_seconds << " seconds" << endl;
+  }
+
+  cout << "Successfully initialized " << backend->getBackendType()
+       << " configuration backend: " << backend->getBackendInfo() << endl;
+
+  return backend;
+} /* Config::createAndConfigureBackend */
+
+
+bool Config::initializeDatabase(ConfigBackend* backend,
+                                 const std::string& default_config_file)
+{
+  if (!backend) return false;
+
+  if (!backend->initializeTables())
+  {
+    cerr << "*** ERROR: Failed to initialize database tables" << endl;
+    return false;
+  }
+
+  list<string> sections = backend->listSections();
+  if (!sections.empty())
+  {
+    cout << "Database already initialized with " << sections.size()
+         << " sections" << endl;
+    if (!backend->finalizeInitialization())
+      cerr << "*** WARNING: Failed to finalize database initialization" << endl;
+    return true;
+  }
+
+  cout << "Database is empty, initializing..." << endl;
+
+  bool was_enabled = backend->changeNotificationsEnabled();
+  if (was_enabled) backend->enableChangeNotifications(false);
+
+  if (populateFromExistingFiles(backend, default_config_file))
+  {
+    cout << "Database initialized from existing configuration files" << endl;
+  }
+  else
+  {
+    cout << "*** WARNING: Database is empty and no existing configuration files found. "
+            "The application may need to seed defaults." << endl;
+  }
+
+  if (!backend->finalizeInitialization())
+    cerr << "*** WARNING: Failed to finalize database initialization" << endl;
+
+  if (was_enabled) backend->enableChangeNotifications(true);
+
+  sections = backend->listSections();
+  if (sections.empty())
+  {
+    cerr << "*** ERROR: Failed to initialize database" << endl;
+    return false;
+  }
+
+  cout << "Database initialized successfully with " << sections.size()
+       << " sections" << endl;
+  return true;
+} /* Config::initializeDatabase */
+
+
+bool Config::populateFromExistingFiles(ConfigBackend* backend,
+                                        const std::string& config_file_name)
+{
+  if (!backend) return false;
+
+  string config_file = findConfigFile("", config_file_name);
+  if (config_file.empty()) return false;
+
+  cout << "Found existing configuration file: " << config_file << endl;
+  cout << "Loading existing configuration to populate database..." << endl;
+
+  ConfigBackendPtr file_backend = createConfigBackend("file://" + config_file);
+  if (!file_backend)
+  {
+    cerr << "*** WARNING: Could not create file backend for " << config_file << endl;
+    return false;
+  }
+
+  list<string> sections = file_backend->listSections();
+  for (const string& section : sections)
+  {
+    list<string> tags = file_backend->listSection(section);
+    for (const string& tag : tags)
+    {
+      string value;
+      if (file_backend->getValue(section, tag, value))
+      {
+        if (!backend->setValue(section, tag, value))
+          cerr << "*** WARNING: Failed to set " << section << "/" << tag
+               << " in database" << endl;
+      }
+    }
+  }
+
+  string cfg_dir;
+  if (file_backend->getValue("GLOBAL", "CFG_DIR", cfg_dir))
+  {
+    if (cfg_dir[0] != '/')
+    {
+      auto slash_pos = config_file.rfind('/');
+      cfg_dir = (slash_pos != string::npos)
+                    ? config_file.substr(0, slash_pos + 1) + cfg_dir
+                    : "./" + cfg_dir;
+    }
+
+    cout << "Processing CFG_DIR: " << cfg_dir << endl;
+
+    DIR* dir = opendir(cfg_dir.c_str());
+    if (dir != nullptr)
+    {
+      struct dirent* de;
+      while ((de = readdir(dir)) != nullptr)
+      {
+        char* dot = strrchr(de->d_name, '.');
+        if (dot == nullptr || de->d_name[0] == '.' || strcmp(dot, ".conf") != 0)
+          continue;
+
+        string cfg_file_path = cfg_dir + "/" + de->d_name;
+        cout << "Loading additional config file: " << cfg_file_path << endl;
+
+        ConfigBackendPtr extra = createConfigBackend("file://" + cfg_file_path);
+        if (extra)
+        {
+          list<string> add_sections = extra->listSections();
+          for (const string& section : add_sections)
+          {
+            list<string> add_tags = extra->listSection(section);
+            for (const string& tag : add_tags)
+            {
+              string value;
+              if (extra->getValue(section, tag, value))
+              {
+                if (!backend->setValue(section, tag, value))
+                  cerr << "*** WARNING: Failed to set " << section << "/" << tag
+                       << " from " << cfg_file_path << endl;
+              }
+            }
+          }
+        }
+        else
+        {
+          cerr << "*** WARNING: Could not load additional config file: "
+               << cfg_file_path << endl;
+        }
+      }
+      closedir(dir);
+    }
+    else
+    {
+      cerr << "*** WARNING: Could not open CFG_DIR: " << cfg_dir << endl;
+    }
+  }
+
+  return true;
+} /* Config::populateFromExistingFiles */
+
+
+bool Config::importFromConfigFile(const std::string& config_filename)
+{
+  return populateFromExistingFiles(m_backend.get(), config_filename);
+} /* Config::importFromConfigFile */
+
+
+std::string Config::getMainConfigFile(void) const
+{
+  return m_main_config_file;
+} /* Config::getMainConfigFile */
+
+std::string Config::getBackendType(void) const
+{
+  if (m_backend != nullptr)
+  {
+    return m_backend->getBackendType();
+  }
+  return "";
+} /* Config::getBackendType */
 
 
 bool Config::getValue(const std::string& section, const std::string& tag,
                       std::string& value, bool missing_ok) const
 {
-  Sections::const_iterator sec_it = sections.find(section);
-  if (sec_it == sections.end())
+  // First try to get from in-memory (for subscriptions)
+  Sections::const_iterator sec_it = m_sections.find(section);
+  if (sec_it != m_sections.end())
   {
-    return missing_ok;
+    Values::const_iterator val_it = sec_it->second.find(tag);
+    if (val_it != sec_it->second.end())
+    {
+      value = val_it->second.val;
+      return true;
+    }
   }
 
-  Values::const_iterator val_it = sec_it->second.find(tag);
-  if (val_it == sec_it->second.end())
+  // If not in memory, try to get from backend
+  if (m_backend != nullptr && m_backend->isOpen())
   {
-    return missing_ok;
+    if (m_backend->getValue(section, tag, value))
+    {
+      return true;
+    }
   }
 
-  value = val_it->second.val;
-  return true;
+  return missing_ok;
 } /* Config::getValue */
 
 
 bool Config::getValue(const std::string& section, const std::string& tag,
                       char& value, bool missing_ok) const
 {
-  Sections::const_iterator sec_it = sections.find(section);
-  if (sec_it == sections.end())
+  string str_value;
+  if (!getValue(section, tag, str_value, missing_ok))
   {
     return missing_ok;
   }
 
-  Values::const_iterator val_it = sec_it->second.find(tag);
-  if (val_it == sec_it->second.end())
-  {
-    return missing_ok;
-  }
-
-  if (val_it->second.val.size() != 1)
+  if (str_value.size() != 1)
   {
     return false;
   }
 
-  value = val_it->second.val[0];
+  value = str_value[0];
   return true;
 } /* Config::getValue */
 
 
 const string &Config::getValue(const string& section, const string& tag) const
 {
-  static const string empty_strng;
+  static string cached_value;
   
-  Sections::const_iterator sec_it = sections.find(section);
-  if (sec_it == sections.end())
+  if (getValue(section, tag, cached_value, true))
   {
-    return empty_strng;
+    return cached_value;
   }
-
-  Values::const_iterator val_it = sec_it->second.find(tag);
-  if (val_it == sec_it->second.end())
-  {
-    return empty_strng;
-  }
-
-  return val_it->second.val;
+  
+  static const string empty_string;
+  return empty_string;
 } /* Config::getValue */
 
 
 list<string> Config::listSections(void)
 {
-  list<string> section_list;
-  for (Sections::const_iterator it=sections.begin(); it!=sections.end(); ++it)
+  if (m_backend != nullptr && m_backend->isOpen())
   {
-    section_list.push_back((*it).first);
+    return m_backend->listSections();
+  }
+  
+  list<string> section_list;
+  for (Sections::const_iterator it = m_sections.begin(); it != m_sections.end(); ++it)
+  {
+    section_list.push_back(it->first);
   }
   return section_list;
 } /* Config::listSections */
@@ -226,34 +704,45 @@ list<string> Config::listSections(void)
 
 list<string> Config::listSection(const string& section)
 {
+  if (m_backend != nullptr && m_backend->isOpen())
+  {
+    return m_backend->listSection(section);
+  }
+  
   list<string> tags;
   
-  if (sections.count(section) == 0)
+  if (m_sections.count(section) == 0)
   {
     return tags;
   }
   
-  Values& values = sections[section];
-  Values::iterator it = values.begin();
-  for (it=values.begin(); it!=values.end(); ++it)
+  const Values& values = m_sections.at(section);
+  for (Values::const_iterator it = values.begin(); it != values.end(); ++it)
   {
     tags.push_back(it->first);
   }
   
   return tags;
-  
 } /* Config::listSection */
 
 
 void Config::setValue(const std::string& section, const std::string& tag,
                       const std::string& value)
 {
-  Values &values = sections[section];
-  if (value != values[tag].val)
+  // Update in-memory 
+  Values &values = m_sections[section];
+  bool value_changed = (value != values[tag].val);
+  
+  if (value_changed)
   {
     values[tag].val = value;
-    valueUpdated(section, tag);
-    for (const auto& func : values[tag].subs)
+    
+    // Sync to backend
+    syncToBackend(section, tag);
+    
+    // Emit signals and call subscribers
+    valueUpdated(section, tag, value);
+    for (auto& [id, func] : values[tag].subs)
     {
       func(value);
     }
@@ -292,255 +781,255 @@ void Config::setValue(const std::string& section, const std::string& tag,
  *
  ****************************************************************************/
 
-
-/*
- *----------------------------------------------------------------------------
- * Method:    
- * Purpose:   
- * Input:     
- * Output:    
- * Author:    
- * Created:   
- * Remarks:   
- * Bugs:      
- *----------------------------------------------------------------------------
- */
-bool Config::parseCfgFile(FILE *file)
+void Config::loadFromBackend(void)
 {
-  char line[16384];
-  int line_no = 0;
-  string current_sec;
-  string current_tag;
-  
-  while (fgets(line, sizeof(line), file) != 0)
+  if (m_backend == nullptr || !m_backend->isOpen())
   {
-    ++line_no;
-    char *l = trimSpaces(line);
-    //printf("%s\n", l);
-    switch (l[0])
+    return;
+  }
+
+  // Load all sections and their tags/values into memory
+  list<string> sections = m_backend->listSections();
+  for (const string& section : sections)
+  {
+    list<string> tags = m_backend->listSection(section);
+    for (const string& tag : tags)
     {
-      case 0: 	  // Ignore empty rows and
-      case '#':   // rows starting with a #-character == comments
-      	break;
-      
-      case '[':
+      string value;
+      if (m_backend->getValue(section, tag, value))
       {
-      	char *sec = parseSection(l);
-	if ((sec == 0) || (sec[0] == 0))
-	{
-	  cerr << "*** ERROR: Configuration file parse error. Illegal section "
-	      	  "name syntax on line " << line_no << endl;
-	  return false;
-	}
-	//printf("New section=%s\n", sec);
-	current_sec = sec;
-	current_tag = "";
-	if (sections.count(current_sec) == 0)
-	{
-	  sections[current_sec];	// Create a new empty section
-	  //cerr << "*** ERROR: Configuration file parse error: Section "
-	  //    	  "previously defined on line " << line_no << endl;
-	  //return false;
-	}
-      	break;
-      }
-      
-      case '"':
-      {
-      	char *val = parseValue(l);
-	if (val == 0)
-	{
-	  cerr << "*** ERROR: Configuration file parse error. Illegal value "
-	      	  "syntax on line " << line_no << endl;
-	  return false;
-	}
-	//printf("Continued line=\"%s\"", val);
-	
-	if (current_tag.empty())
-	{
-	  cerr << "*** ERROR: Configuration file parse error. Line "
-	      	  "continuation without previous value on line "
-	       << line_no << endl;
-	  return false;
-	}
-	assert(!current_sec.empty());
-	
-	Values &values = sections[current_sec];
-	string& value = values[current_tag].val;
-	value += val;
-	break;
-      }
-      
-      default:
-      {
-      	string tag, value;
-      	if (!parseValueLine(l, tag, value))
-	{
-	  cerr << "*** ERROR: Configuration file parse error. Illegal value "
-	      	  "line syntax on line " << line_no << endl;
-	  return false;
-	}
-	//printf("tag=\"%s\"  value=\"%s\"\n", tag.c_str(), value.c_str());
-	
-	if (current_sec.empty())
-	{
-	  cerr << "*** ERROR: Configuration file parse error. Value without "
-	      	  "section on line " << line_no << endl;
-	  return false;
-	}
-	Values &values = sections[current_sec];
-	current_tag = tag;
-	values[current_tag].val = value;
-      	break;
+        m_sections[section][tag].val = value;
       }
     }
   }
-  
-  return true;
-  
-} /* Config::parseCfgFile */
+} /* Config::loadFromBackend */
 
-
-char *Config::trimSpaces(char *line)
+void Config::syncToBackend(const std::string& section, const std::string& tag)
 {
-  char *begin = line;
-  while ((*begin != 0) && isspace(*begin))
+  if (m_backend == nullptr || !m_backend->isOpen())
   {
-    ++begin;
+    return;
   }
-  
-  char *end = begin + strlen(begin);
-  while ((end != begin) && (isspace(*end) || (*end == 0)))
+
+  // Temporarily disable notifications so we don't fire twice!
+  bool was_enabled = m_backend->changeNotificationsEnabled();
+  if (was_enabled)
   {
-    *end-- = 0;
+    m_backend->enableChangeNotifications(false);
   }
-  
-  return begin;
-  
-} /* Config::trimSpaces */
 
-
-char *Config::parseSection(char *line)
-{
-  return parseDelimitedString(line, '[', ']');
-} /* Config::parseSection */
-
-
-char *Config::parseDelimitedString(char *str, char begin_tok, char end_tok)
-{
-  if (str[0] != begin_tok)
+  // Get the value from in-memory
+  Sections::const_iterator sec_it = m_sections.find(section);
+  if (sec_it != m_sections.end())
   {
-    return 0;
-  }
-  
-  char *end = str + strlen(str) - 1;
-  if (*end != end_tok)
-  {
-    return 0;
-  }
-  *end = 0;
-  
-  /*
-  if (end == str+1)
-  {
-    return 0;
-  }
-  */
-  
-  return str + 1;
-  
-} /* Config::parseDelimitedString */
-
-
-bool Config::parseValueLine(char *line, string& tag, string& value)
-{
-  char *eq = strchr(line, '=');
-  if (eq == 0)
-  {
-    return false;
-  }
-  *eq = 0;
-  
-  tag = trimSpaces(line);
-  char *val = parseValue(eq + 1);
-  if (val == 0)
-  {
-    return false;
-  }
-  
-  value = val;
-  
-  return true;
-  
-} /* Config::parseValueLine */
-
-
-char *Config::parseValue(char *value)
-{
-  value = trimSpaces(value);
-  if (value[0] == '"')
-  {
-    value = parseDelimitedString(value, '"', '"');
-  }
-  
-  if (value == 0)
-  {
-    return 0;
-  }
-  
-  return translateEscapedChars(value);
-  
-} /* Config::parseValue */
-
-
-char *Config::translateEscapedChars(char *val)
-{
-  char *head = val;
-  char *tail = head;
-  
-  while (*head != 0)
-  {
-    if (*head == '\\')
+    Values::const_iterator val_it = sec_it->second.find(tag);
+    if (val_it != sec_it->second.end())
     {
-      ++head;
-      switch (*head)
+      if (!m_backend->setValue(section, tag, val_it->second.val))
       {
-      	case 'n':
-	  *tail = '\n';
-	  break;
-	  
-      	case 'r':
-	  *tail = '\r';
-	  break;
-	  
-      	case 't':
-	  *tail = '\t';
-	  break;
-	  
-      	case '\\':
-	  *tail = '\\';
-	  break;
-	  
-      	case '"':
-	  *tail = '"';
-	  break;
-	  
-      	default:
-	  return 0;
+        cerr << "*** WARNING: Failed to sync configuration change to backend: "
+             << section << "/" << tag << endl;
+      }
+    }
+  }
+
+  // Restore notifications if they were enabled
+  if (was_enabled)
+  {
+    m_backend->enableChangeNotifications(true);
+  }
+} /* Config::syncToBackend */
+
+ConfigBackend* Config::getBackend(void)
+{
+  return m_backend.get();
+} /* Config::getBackend */
+
+void Config::reload(void)
+{
+  if (m_backend == nullptr || !m_backend->isOpen())
+  {
+    return;
+  }
+
+  // For database backends, check for external changes first
+  if (m_backend->getBackendType() != "file")
+  {
+    m_backend->checkForExternalChanges();
+  }
+
+  // Reload all sections and tags
+  auto sections = m_backend->listSections();
+  for (const auto& section : sections)
+  {
+    auto tags = m_backend->listSection(section);
+    for (const auto& tag : tags)
+    {
+      std::string new_value;
+      if (m_backend->getValue(section, tag, new_value))
+      {
+        // Update memory; auto-creates entry for newly-seen sections/tags
+        auto& cached = m_sections[section][tag];
+        if (cached.val != new_value)
+        {
+          cached.val = new_value;
+          for (auto& [id, sub] : cached.subs)
+          {
+            sub(new_value);
+          }
+          valueUpdated(section, tag, new_value);
+        }
+      }
+    }
+  }
+} /* Config::reload */
+
+void Config::onBackendValueChanged(const std::string& section,
+                                    const std::string& tag,
+                                    const std::string& value)
+{
+  //std::cout << "[DEBUG Config] onBackendValueChanged called: [" << section << "]" << tag 
+  //          << " = '" << value << "'" << std::endl;
+
+  // Update in-memory
+  m_sections[section][tag].val = value;
+
+  // Trigger subscriptions
+  auto sec_it = m_sections.find(section);
+  if (sec_it != m_sections.end())
+  {
+    auto val_it = sec_it->second.find(tag);
+    if (val_it != sec_it->second.end())
+    {
+      //std::cout << "[DEBUG Config] Found " << val_it->second.subs.size() 
+      //          << " subscription(s) for [" << section << "]" << tag << std::endl;
+      for (auto& [id, sub] : val_it->second.subs)
+      {
+        sub(value);
       }
     }
     else
     {
-      *tail = *head;
+      //std::cout << "[DEBUG Config] Tag not found in memory: [" << section << "]" << tag << std::endl;
     }
-    ++head;
-    ++tail;
   }
-  *tail = 0;
-  
-  return val;
-  
-} /* Config::translateEscapedChars */
+  else
+  {
+    //std::cout << "[DEBUG Config] Section not found in memory: [" << section << "]" << std::endl;
+  }
+
+  // Emit valueUpdated signal
+  valueUpdated(section, tag, value);
+} /* Config::onBackendValueChanged */
+
+void Config::connectBackendSignals(void)
+{
+  if (m_backend != nullptr)
+  {
+    m_backend->valueChanged.connect(
+        sigc::mem_fun(*this, &Config::onBackendValueChanged));
+  }
+} /* Config::connectBackendSignals */
+
+void Config::finalizeBackendSetup(void)
+{
+  if (m_backend == nullptr)
+  {
+    return;
+  }
+
+  // Disable notifications during initial config load to avoid spurious signals
+  bool was_enabled = m_backend->changeNotificationsEnabled();
+  if (was_enabled)
+  {
+    m_backend->enableChangeNotifications(false);
+  }
+
+  // Load all configuration data into memory for subscription support
+  loadFromBackend();
+
+  // Re-enable notifications before connecting signals
+  if (was_enabled)
+  {
+    m_backend->enableChangeNotifications(true);
+  }
+
+  // Connect backend signals for external change detection
+  connectBackendSignals();
+} /* Config::finalizeBackendSetup */
+
+bool Config::openWithFallback(const std::string& cmdline_config,
+                               const std::string& cmdline_dbconfig,
+                               const std::string& default_config_name)
+{
+  m_last_error.clear();
+
+  // Derive table prefix from config name: svxlink.conf → svxlink_
+  std::string default_table_prefix;
+  size_t dot_pos = default_config_name.find('.');
+  if (dot_pos != std::string::npos)
+    default_table_prefix = default_config_name.substr(0, dot_pos) + "_";
+
+  // First check for --config option
+  if (!cmdline_config.empty())
+  {
+    if (!openDirect("file://" + cmdline_config))
+    {
+      m_last_error = "Failed to open configuration file: " + cmdline_config;
+      return false;
+    }
+    loadCfgDir();
+    return true;
+  }
+
+  // Next check for --dbconfig option
+  if (!cmdline_dbconfig.empty())
+  {
+    if (!openFromDbConfigInternal(cmdline_dbconfig, default_config_name,
+                                   default_table_prefix))
+    {
+      m_last_error = "Failed to open database configuration: " + cmdline_dbconfig;
+      return false;
+    }
+    loadCfgDir();
+    return true;
+  }
+
+  // search standard locations for db.conf
+  string db_conf_path = findConfigFile("", "db.conf");
+  if (!db_conf_path.empty())
+  {
+    if (!openFromDbConfigInternal(db_conf_path, default_config_name,
+                                   default_table_prefix))
+    {
+      m_last_error = "Found db.conf at " + db_conf_path + " but failed to load it";
+      return false;
+    }
+    loadCfgDir();
+    return true;
+  }
+
+  // search standard locations for default config file
+  string config_path = findConfigFile("", default_config_name);
+  if (!config_path.empty())
+  {
+    if (!openDirect("file://" + config_path))
+    {
+      m_last_error = "Found configuration at " + config_path + " but failed to load it";
+      return false;
+    }
+    loadCfgDir();
+    return true;
+  }
+
+  m_last_error = "No configuration found. Searched for:\n"
+                 "  - db.conf in: ~/.svxlink/, /etc/svxlink/, "
+                 + std::string(SVX_SYSCONF_INSTALL_DIR) + "\n"
+                 "  - " + default_config_name
+                 + " in: ~/.svxlink/, /etc/svxlink/, "
+                 + std::string(SVX_SYSCONF_INSTALL_DIR);
+  return false;
+} /* Config::openWithFallback */
 
 
 /*

--- a/src/async/core/AsyncConfig.cpp
+++ b/src/async/core/AsyncConfig.cpp
@@ -411,15 +411,7 @@ ConfigBackendPtr Config::createAndConfigureBackend(const DbConf& conf,
     return nullptr;
   }
 
-  string source_url;
-  if (conf.type == "file")
-    source_url = conf.source;
-  else if (conf.type == "sqlite")
-    source_url = "sqlite://" + conf.source;
-  else
-    source_url = conf.source;
-
-  ConfigBackendPtr backend = createConfigBackend(source_url);
+  ConfigBackendPtr backend = createConfigBackendByType(conf.type, conf.source);
   if (!backend)
   {
     cerr << "*** ERROR: Failed to create " << conf.type << " backend" << endl;

--- a/src/async/core/AsyncConfig.cpp
+++ b/src/async/core/AsyncConfig.cpp
@@ -51,6 +51,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <cstdlib>
 #include <map>
 #include <vector>
+#include <stdexcept>
 
 
 /****************************************************************************
@@ -196,7 +197,7 @@ bool Config::openDirect(const string& source)
   m_backend = createConfigBackend(source);
   if (m_backend == nullptr)
   {
-    cerr << "*** ERROR: Failed to create configuration backend for: " << source << endl;
+    cerr << "*** ERROR: Failed to create configuration backend" << endl;
     return false;
   }
 
@@ -361,7 +362,17 @@ bool Config::parseDbConfFile(const std::string& file_path, DbConf& conf)
               (value == "1" || value == "true" || value == "TRUE" ||
                value == "yes"  || value == "YES");
         else if (key == "POLL_INTERVAL")
-          conf.poll_interval_seconds = static_cast<unsigned int>(stoul(value));
+        {
+          try
+          {
+            conf.poll_interval_seconds = static_cast<unsigned int>(stoul(value));
+          }
+          catch (const std::exception&)
+          {
+            cerr << "*** ERROR: Invalid POLL_INTERVAL in db.conf: " << value << endl;
+            return false;
+          }
+        }
       }
     }
   }
@@ -372,8 +383,7 @@ bool Config::parseDbConfFile(const std::string& file_path, DbConf& conf)
     return false;
   }
 
-  cout << "Database configuration: TYPE=" << conf.type
-       << ", SOURCE=" << conf.source;
+  cout << "Database configuration: TYPE=" << conf.type;
   if (!conf.table_prefix.empty())
     cout << ", TABLE_PREFIX=" << conf.table_prefix;
   cout << endl;

--- a/src/async/core/AsyncConfig.h
+++ b/src/async/core/AsyncConfig.h
@@ -599,11 +599,86 @@ class Config
     } /* Config::getValue */
 
     /**
-     * @brief   Opaque subscription handle returned by subscribeValue / subscribeOptionalValue
-     *
-     * Pass this to unsubscribeValue() to remove a specific callback.
+     * @brief   Opaque subscription ID (internal use / unsubscribeValue).
      */
     using SubId = std::size_t;
+
+    /**
+     * @brief   Subscription handle returned by subscribeValue / subscribeOptionalValue
+     *
+     * Holds a live subscription.  When destroyed (or reset() is called) the
+     * subscription is automatically removed from the Config so that the stored
+     * std::function — and therefore any code in a plugin library that was
+     * captured by the callback — is destroyed while that library is still
+     * loaded.  This prevents the use-after-dlclose crash that occurs when
+     * Config::~Config tries to destroy subscriber callbacks whose _M_manager
+     * lives in an already-unloaded shared library.
+     *
+     * Store one Subscription per subscribeValue / subscribeOptionalValue call
+     * as a member variable of the subscribing class.  The Subscription is
+     * move-only; it cannot be copied!
+     */
+    class Subscription
+    {
+    public:
+      Subscription() = default;
+
+      ~Subscription() { reset(); }
+
+      Subscription(Subscription&& other) noexcept
+        : m_cfg(other.m_cfg),
+          m_section(std::move(other.m_section)),
+          m_tag(std::move(other.m_tag)),
+          m_id(other.m_id)
+      {
+        other.m_cfg = nullptr;
+      }
+
+      Subscription& operator=(Subscription&& other) noexcept
+      {
+        if (this != &other)
+        {
+          reset();
+          m_cfg     = other.m_cfg;
+          m_section = std::move(other.m_section);
+          m_tag     = std::move(other.m_tag);
+          m_id      = other.m_id;
+          other.m_cfg = nullptr;
+        }
+        return *this;
+      }
+
+      Subscription(const Subscription&)            = delete;
+      Subscription& operator=(const Subscription&) = delete;
+
+      /** Cancel the subscription immediately. */
+      void reset()
+      {
+        if (m_cfg != nullptr)
+        {
+          m_cfg->unsubscribeValue(m_section, m_tag, m_id);
+          m_cfg = nullptr;
+        }
+      }
+
+      bool valid() const { return m_cfg != nullptr; }
+
+    private:
+      friend class Config;
+
+      Config*     m_cfg    = nullptr;
+      std::string m_section;
+      std::string m_tag;
+      SubId       m_id{};
+
+      Subscription(Config* cfg, std::string sec, std::string tag, SubId id)
+        : m_cfg(cfg),
+          m_section(std::move(sec)),
+          m_tag(std::move(tag)),
+          m_id(id)
+      {
+      }
+    }; /* class Subscription */
 
     /**
      * @brief Subscribe to the given configuration variable (char*)
@@ -622,8 +697,8 @@ class Config
      * string (char*).
      */
     template <typename F=std::function<void(const char*)>>
-    SubId subscribeValue(const std::string& section, const std::string& tag,
-                         const char* def, F func)
+    Subscription subscribeValue(const std::string& section, const std::string& tag,
+                                const char* def, F func)
     {
       return subscribeValue(section, tag, std::string(def),
           [=](const std::string& str_val) -> void
@@ -649,8 +724,8 @@ class Config
      * non-container type (e.g. std::string, int, bool etc).
      */
     template <typename Rsp, typename F=std::function<void(const Rsp&)>>
-    SubId subscribeValue(const std::string& section, const std::string& tag,
-                         const Rsp& def, F func)
+    Subscription subscribeValue(const std::string& section, const std::string& tag,
+                                const Rsp& def, F func)
     {
       Value& v = getValueP(section, tag, def);
       SubId id = v.next_id++;
@@ -663,7 +738,7 @@ class Config
             func(tmp);
           };
       v.subs[id](v.val);
-      return id;
+      return Subscription(this, section, tag, id);
     } /* subscribeValue */
 
     /**
@@ -685,7 +760,7 @@ class Config
      * auto-created when missing.
      */
     template <typename F=std::function<void(const std::string&)>>
-    SubId subscribeOptionalValue(const std::string& section, const std::string& tag, F func)
+    Subscription subscribeOptionalValue(const std::string& section, const std::string& tag, F func)
     {
       Value& v = m_sections[section][tag];
       SubId id = v.next_id++;
@@ -694,7 +769,7 @@ class Config
       {
         v.subs[id](v.val);
       }
-      return id;
+      return Subscription(this, section, tag, id);
     } /* subscribeOptionalValue */
 
     /**
@@ -715,8 +790,8 @@ class Config
      */
     template <template <typename, typename> class Container,
               typename Rsp, typename F=std::function<void(const Rsp&)>>
-    SubId subscribeValue(const std::string& section, const std::string& tag,
-                         const Container<Rsp, std::allocator<Rsp>>& def, F func)
+    Subscription subscribeValue(const std::string& section, const std::string& tag,
+                                const Container<Rsp, std::allocator<Rsp>>& def, F func)
     {
       Value& v = getValueP(section, tag, def);
       SubId id = v.next_id++;
@@ -742,7 +817,7 @@ class Config
             func(std::move(c));
           };
       v.subs[id](v.val);
-      return id;
+      return Subscription(this, section, tag, id);
     } /* Config::subscribeValue */
 
     /**

--- a/src/async/core/AsyncConfig.h
+++ b/src/async/core/AsyncConfig.h
@@ -1,18 +1,18 @@
 /**
 @file	 AsyncConfig.h
-@brief   A class for reading "INI-foramtted" configuration files
+@brief   A class for configuration handling
 @author  Tobias Blomberg
 @date	 2004-03-17
 
-This file contains a class that is used to read configuration files that is
-in the famous MS Windows INI file format. An example of a configuration file
-is shown below.
+This file contains a class that is used to supply and save configuration data
+to a backend which can be a file, a database, etc. The backend can be
+implemented by extending AsyncConfigBackend.
 
 \include test.cfg
 
 \verbatim
 Async - A library for programming event driven applications
-Copyright (C) 2004-2025 Tobias Blomberg / SM0SVX
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -72,6 +72,7 @@ An example of how to use the Config class
  *
  ****************************************************************************/
 
+#include "AsyncConfigBackend.h"
 
 
 /****************************************************************************
@@ -142,6 +143,16 @@ class Config
      * @brief 	Default constuctor
      */
     Config(void) {}
+
+    /**
+     * @brief 	Copy constructor (deleted - Config is not copyable)
+     */
+    Config(const Config&) = delete;
+
+    /**
+     * @brief 	Assignment operator (deleted - Config is not assignable)
+     */
+    Config& operator=(const Config&) = delete;
   
     /**
      * @brief 	Destructor
@@ -149,15 +160,126 @@ class Config
     ~Config(void);
   
     /**
-     * @brief 	Open the given config file
-     * @param 	name The name of the configuration file to open
+     * @brief   Open configuration searching standard locations
+     * @param   default_config_name Config filename to search for (default: "svxlink.conf")
+     * @return  Returns \em true on success or else \em false.
+     *
+     * Convenience wrapper around openWithFallback() with empty CLI overrides.
+     * Searches standard locations for db.conf first, then for default_config_name.
+     * Use getLastError() for error details on failure.
+     *
+     * For direct file opening use openDirect("file:///path/to/file.conf") instead.
+     */
+    bool open(const std::string& default_config_name = "svxlink.conf");
+
+    /**
+     * @brief 	Open configuration using specific db.conf file
+     * @param 	db_conf_path The full path to the db.conf file to use
      * @return	Returns \em true on success or else \em false.
      *
-     * This function will read the given configuration file into memory.
-     * If this function return false and errno != 0, the errno variable may
-     * give a hint what the problem was.
+     * This function directly uses the specified db.conf file for backend
+     * selection instead of searching in standard locations.
      */
-    bool open(const std::string& name);
+    bool openFromDbConfig(const std::string& db_conf_path);
+
+    /**
+     * @brief 	Open configuration with explicit source 
+     * @param 	source The configuration source (file path, database URL, etc.)
+     * @return	Returns \em true on success or else \em false.
+     *
+     * This directly opens a configuration source.
+     * For new applications, prefer the parameterless open() method that
+     * uses db.conf for backend selection.
+     */
+    bool openDirect(const std::string& source);
+
+    /**
+     * @brief 	Get the main configuration file path
+     * @return	Returns the path to the main configuration file, or empty if using database backend
+     *
+     * This method returns the path to the main configuration file that was loaded.
+     * For file backend, this is the path to the main .conf file.
+     * For database backends, this returns an empty string since there's no single file.
+     */
+    std::string getMainConfigFile(void) const;
+
+    /**
+     * @brief   Get the configuration backend type
+     * @return  Returns the backend type string ("file", "sqlite", "mysql", "postgresql")
+     *
+     * This method returns the type of configuration backend currently in use.
+     */
+    std::string getBackendType(void) const;
+
+    /**
+     * @brief   Get direct access to the configuration backend
+     * @return  Pointer to the ConfigBackend or nullptr if not open
+     *
+     * This provides direct access to the backend for advanced operations
+     * like enabling change notifications or starting auto-polling.
+     */
+    ConfigBackend* getBackend(void);
+
+    /**
+     * @brief   Reload the configuration from its source
+     *
+     * This method forces a reload of all configuration values from the backend.
+     * For database backends, it calls checkForExternalChanges() first.
+     * After reloading, it triggers all subscribeValue callbacks for values that changed.
+     */
+    void reload(void);
+
+    /**
+     * @brief   Import configuration from an installed example config file
+     * @param   config_filename Filename to search for (e.g., "svxlink.conf")
+     * @return  \em true if the file was found and imported, \em false otherwise
+     *
+     * Searches the standard locations (~/.svxlink/, /etc/svxlink/,
+     * SVX_SYSCONF_INSTALL_DIR) for @a config_filename, opens it as a file
+     * backend, and copies every section/key/value (including any CFG_DIR
+     * sub-files) into the currently active backend.
+     *
+     * Intended as a one-time database initialisation helper. The caller
+     * should verify that the active backend is not a file backend and that
+     * it is empty before calling this method.
+     */
+    bool importFromConfigFile(const std::string& config_filename);
+
+    /**
+     * @brief   Smart configuration initialization with fallback
+     * @param   cmdline_config    Path from --config CLI option (empty if not given)
+     * @param   cmdline_dbconfig  Path from --dbconfig CLI option (empty if not given)
+     * @param   default_config_name Default config filename (e.g., "svxlink.conf")
+     * @return  \em true on success, \em false on failure
+     *
+     * Implements the full configuration initialization cascade:
+     * 1. --config given  → openDirect() with that file
+     * 2. --dbconfig given → open backend described by that db.conf
+     * 3. Search standard locations for db.conf, use if found
+     * 4. Search standard locations for default_config_name, use if found
+     * 5. Fail — call getLastError() for details
+     *
+     * On success, use getMainConfigFile() and getBackendType() for diagnostics.
+     *
+     * Example:
+     * @code
+     * Async::Config cfg;
+     * if (!cfg.openWithFallback(config_arg, dbconfig_arg, "svxlink.conf")) {
+     *   cerr << "*** ERROR: " << cfg.getLastError() << endl;
+     *   exit(1);
+     * }
+     * cout << "Loaded from: " << cfg.getMainConfigFile() << endl;
+     * @endcode
+     */
+    bool openWithFallback(const std::string& cmdline_config,
+                          const std::string& cmdline_dbconfig,
+                          const std::string& default_config_name);
+
+    /**
+     * @brief   Get the last error message from a failed open call
+     * @return  Human-readable error description, or empty string if no error
+     */
+    std::string getLastError(void) const { return m_last_error; }
     
     /**
      * @brief 	Return the string value of the given configuration variable
@@ -231,7 +353,7 @@ class Config
       std::string str_val;
       if (!getValue(section, tag, str_val))
       {
-	return missing_ok;
+	      return missing_ok;
       }
       std::stringstream ssval(str_val);
       Rsp tmp;
@@ -242,7 +364,7 @@ class Config
       }
       if (ssval.fail() || !ssval.eof())
       {
-	return false;
+	      return false;
       }
       rsp = tmp;
       return true;
@@ -277,7 +399,7 @@ class Config
       std::string str_val;
       if (!getValue(section, tag, str_val))
       {
-	return missing_ok;
+	      return missing_ok;
       }
       if (str_val.empty())
       {
@@ -459,7 +581,7 @@ class Config
       std::string str_val;
       if (!getValue(section, tag, str_val))
       {
-	return missing_ok;
+	      return missing_ok;
       }
       std::stringstream ssval(str_val);
       Rsp tmp;
@@ -470,11 +592,18 @@ class Config
       }
       if (ssval.fail() || !ssval.eof() || (tmp < min) || (tmp > max))
       {
-	return false;
+	      return false;
       }
       rsp = tmp;
       return true;
     } /* Config::getValue */
+
+    /**
+     * @brief   Opaque subscription handle returned by subscribeValue / subscribeOptionalValue
+     *
+     * Pass this to unsubscribeValue() to remove a specific callback.
+     */
+    using SubId = std::size_t;
 
     /**
      * @brief Subscribe to the given configuration variable (char*)
@@ -493,10 +622,10 @@ class Config
      * string (char*).
      */
     template <typename F=std::function<void(const char*)>>
-    void subscribeValue(const std::string& section, const std::string& tag,
-                        const char* def, F func)
+    SubId subscribeValue(const std::string& section, const std::string& tag,
+                         const char* def, F func)
     {
-      subscribeValue(section, tag, std::string(def),
+      return subscribeValue(section, tag, std::string(def),
           [=](const std::string& str_val) -> void
           {
             func(str_val.c_str());
@@ -520,21 +649,53 @@ class Config
      * non-container type (e.g. std::string, int, bool etc).
      */
     template <typename Rsp, typename F=std::function<void(const Rsp&)>>
-    void subscribeValue(const std::string& section, const std::string& tag,
-                        const Rsp& def, F func)
+    SubId subscribeValue(const std::string& section, const std::string& tag,
+                         const Rsp& def, F func)
     {
       Value& v = getValueP(section, tag, def);
-      v.subs.push_back(
-          [=](const std::string& str_val) -> void
+      SubId id = v.next_id++;
+      v.subs[id] = [=](const std::string& str_val) -> void
           {
             std::stringstream ssval(str_val);
             ssval.imbue(std::locale(ssval.getloc(), new empty_ctype));
             Rsp tmp;
             ssval >> tmp;
             func(tmp);
-          });
-      v.subs.back()(v.val);
+          };
+      v.subs[id](v.val);
+      return id;
     } /* subscribeValue */
+
+    /**
+     * @brief Subscribe to an optional configuration variable (no auto-create)
+     * @param section The name of the section where the configuration
+     *                variable is located
+     * @param tag     The name of the configuration variable to get
+     * @param func    The function to call when the config var changes
+     *
+     * This function is used to subscribe to the changes of the specified
+     * configuration variable. Unlike subscribeValue, this function does NOT
+     * create the variable if it doesn't exist.
+     *
+     * - If the variable exists: the callback is called immediately with the value
+     * - If the variable doesn't exist: no callback is made initially
+     * - When the variable is added later: the callback is triggered
+     *
+     * This is useful for optional configuration values that should not be
+     * auto-created when missing.
+     */
+    template <typename F=std::function<void(const std::string&)>>
+    SubId subscribeOptionalValue(const std::string& section, const std::string& tag, F func)
+    {
+      Value& v = m_sections[section][tag];
+      SubId id = v.next_id++;
+      v.subs[id] = [=](const std::string& str_val) -> void { func(str_val); };
+      if (!v.val.empty())
+      {
+        v.subs[id](v.val);
+      }
+      return id;
+    } /* subscribeOptionalValue */
 
     /**
      * @brief Subscribe to the given configuration variable (sequence)
@@ -554,12 +715,12 @@ class Config
      */
     template <template <typename, typename> class Container,
               typename Rsp, typename F=std::function<void(const Rsp&)>>
-    void subscribeValue(const std::string& section, const std::string& tag,
-                        const Container<Rsp, std::allocator<Rsp>>& def, F func)
+    SubId subscribeValue(const std::string& section, const std::string& tag,
+                         const Container<Rsp, std::allocator<Rsp>>& def, F func)
     {
       Value& v = getValueP(section, tag, def);
-      v.subs.push_back(
-          [=](const std::string& str_val) -> void
+      SubId id = v.next_id++;
+      v.subs[id] = [=](const std::string& str_val) -> void
           {
             std::stringstream ssval(str_val);
             ssval.imbue(std::locale(ssval.getloc(), new csv_whitespace));
@@ -579,8 +740,9 @@ class Config
               c.push_back(tmp);
             }
             func(std::move(c));
-          });
-      v.subs.back()(v.val);
+          };
+      v.subs[id](v.val);
+      return id;
     } /* Config::subscribeValue */
 
     /**
@@ -689,14 +851,37 @@ class Config
      * by calling the setValue function. It will only be emitted if the value
      * actually changes.
      */
-    sigc::signal<void(const std::string&, const std::string&)> valueUpdated;
+    sigc::signal<void(const std::string&, const std::string&, const std::string&)> valueUpdated;
+
+    /**
+     * @brief   Remove a previously registered subscription
+     * @param   section The configuration section name
+     * @param   tag     The configuration tag name
+     * @param   id      The subscription ID returned by subscribeValue / subscribeOptionalValue
+     *
+     * If the id is no longer valid (already removed or never registered), this
+     * is a no-op.  Safe to call from within a subscribed callback.
+     */
+    void unsubscribeValue(const std::string& section, const std::string& tag, SubId id)
+    {
+      auto sec_it = m_sections.find(section);
+      if (sec_it != m_sections.end())
+      {
+        auto val_it = sec_it->second.find(tag);
+        if (val_it != sec_it->second.end())
+        {
+          val_it->second.subs.erase(id);
+        }
+      }
+    }
 
   private:
     using Subscriber = std::function<void(const std::string&)>;
     struct Value
     {
-      std::string             val;
-      std::vector<Subscriber> subs;
+      std::string                 val;
+      SubId                       next_id = 0;
+      std::map<SubId, Subscriber> subs;
     };
     typedef std::map<std::string, Value>  Values;
     typedef std::map<std::string, Values> Sections;
@@ -729,15 +914,42 @@ class Config
       csv_whitespace(std::size_t refs=0) : ctype(make_table(), false, refs) {}
     };
 
-    Sections  sections;
+    ConfigBackendPtr m_backend;
+    Sections         m_sections;       // In-memory for subscriptions
+    std::string      m_main_config_file; // Path to main config file (for CFG_DIR resolution)
+    std::string      m_last_error;     // Last error from a failed open call
 
-    bool parseCfgFile(FILE *file);
-    char *trimSpaces(char *line);
-    char *parseSection(char *line);
-    char *parseDelimitedString(char *str, char begin_tok, char end_tok);
-    bool parseValueLine(char *line, std::string& tag, std::string& value);
-    char *parseValue(char *value);
-    char *translateEscapedChars(char *val);
+    void loadFromBackend(void);
+    void syncToBackend(const std::string& section, const std::string& tag);
+    void onBackendValueChanged(const std::string& section, const std::string& tag, const std::string& value);
+    void connectBackendSignals(void);
+    void finalizeBackendSetup(void);
+    void setBackend(ConfigBackendPtr backend);
+    void loadCfgDir(void);
+    bool openFromDbConfigInternal(const std::string& db_conf_path,
+                                  const std::string& default_config_name,
+                                  const std::string& default_table_prefix);
+
+    struct DbConf
+    {
+      std::string type;
+      std::string source;
+      std::string table_prefix;
+      bool        enable_change_notifications;
+      unsigned int poll_interval_seconds;
+      DbConf() : enable_change_notifications(false), poll_interval_seconds(0) {}
+    };
+
+    static std::string findConfigFile(const std::string& config_dir,
+                                      const std::string& filename);
+    bool parseDbConfFile(const std::string& path, DbConf& conf);
+    void applyTablePrefix(DbConf& conf, const std::string& default_prefix);
+    ConfigBackendPtr createAndConfigureBackend(const DbConf& conf,
+                                              const std::string& default_config_file);
+    bool initializeDatabase(ConfigBackend* backend,
+                            const std::string& default_config_file);
+    bool populateFromExistingFiles(ConfigBackend* backend,
+                                   const std::string& config_file);
 
     template <class T>
     bool setValueFromString(T& val, const std::string &str) const
@@ -755,13 +967,13 @@ class Config
     Value& getValueP(const std::string& section, const std::string& tag,
                      const T& def)
     {
-      Values::iterator val_it = sections[section].find(tag);
-      if (val_it == sections[section].end())
+      Values::iterator val_it = m_sections[section].find(tag);
+      if (val_it == m_sections[section].end())
       {
         setValue(section, tag, def);
       }
 
-      return sections[section][tag];
+      return m_sections[section][tag];
     } /* getValueP */
 
 }; /* class Config */

--- a/src/async/core/AsyncConfig.h
+++ b/src/async/core/AsyncConfig.h
@@ -303,6 +303,8 @@ class Config
      * @param 	tag   	   The name of the configuration variable to get
      * @param 	value 	   The value is returned in this argument. Any previous
      *	      	      	   contents is wiped
+     * @param	missing_ok If set to \em true, return \em true if the
+     *                     configuration variable is missing
      * @return	Returns \em true on success or else \em false on failure
      *
      * This function is used to get the value for a configuration variable
@@ -318,6 +320,8 @@ class Config
      * @param 	tag   	   The name of the configuration variable to get
      * @param 	value 	   The value is returned in this argument. Any previous
      *	      	      	   contents is wiped
+     * @param	missing_ok If set to \em true, return \em true if the
+     *                     configuration variable is missing
      * @return	Returns \em true on success or else \em false on failure
      *
      * This function is used to get the value for a configuration variable

--- a/src/async/core/AsyncConfigBackend.cpp
+++ b/src/async/core/AsyncConfigBackend.cpp
@@ -1,0 +1,275 @@
+/**
+ * @file   AsyncConfigBackend.cpp
+ * @brief  Implementation of ConfigBackend base class and factory functions
+ * @author Rui Barreiros / CR7BPM
+ * @date   2025-09-19
+
+This file contains the base class implementation for configuration backends that
+can load configuration data from various sources like files, databases, etc.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute  it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#include "AsyncConfigBackend.h"
+#include "AsyncConfigSource.h"
+#include "AsyncFdWatch.h"
+#include <iostream>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+
+namespace Async
+{
+
+ConfigBackend::ConfigBackend(bool enable_notifications, unsigned int auto_poll_interval_ms)
+  : m_enable_change_notifications(enable_notifications),
+    m_default_poll_interval(auto_poll_interval_ms),
+    m_current_poll_interval(0),
+    m_fd_watch(nullptr),
+    m_poll_running(false)
+{
+  m_wakeup_pipe[0] = m_wakeup_pipe[1] = -1;
+} /* ConfigBackend::ConfigBackend */
+
+ConfigBackend::~ConfigBackend(void)
+{
+  stopAutoPolling();
+} /* ConfigBackend::~ConfigBackend */
+
+void ConfigBackend::setTablePrefix(const std::string& prefix)
+{
+  m_table_prefix = prefix;
+} /* ConfigBackend::setTablePrefix */
+
+std::string ConfigBackend::getFullTableName(const std::string& base_name) const
+{
+  return m_table_prefix + base_name;
+} /* ConfigBackend::getFullTableName */
+
+void ConfigBackend::enableChangeNotifications(bool enable)
+{
+  m_enable_change_notifications = enable;
+} /* ConfigBackend::enableChangeNotifications */
+
+bool ConfigBackend::changeNotificationsEnabled(void) const
+{
+  return m_enable_change_notifications;
+} /* ConfigBackend::changeNotificationsEnabled */
+
+bool ConfigBackend::checkForExternalChanges(void)
+{
+  // Database backends should override this
+  return false;
+} /* ConfigBackend::checkForExternalChanges */
+
+void ConfigBackend::startAutoPolling(unsigned int interval_ms)
+{
+  if (interval_ms == 0)
+  {
+    stopAutoPolling();
+    return;
+  }
+
+  stopAutoPolling();
+
+  if (::pipe(m_wakeup_pipe) == -1)
+  {
+    std::cerr << "*** ERROR: ConfigBackend: pipe() failed: "
+              << strerror(errno) << std::endl;
+    return;
+  }
+  // Make the read end non-blocking so drain reads never stall
+  int flags = ::fcntl(m_wakeup_pipe[0], F_GETFL, 0);
+  ::fcntl(m_wakeup_pipe[0], F_SETFL, flags | O_NONBLOCK);
+
+  m_fd_watch = new Async::FdWatch(m_wakeup_pipe[0], Async::FdWatch::FD_WATCH_RD);
+  m_fd_watch->activity.connect(sigc::mem_fun(*this, &ConfigBackend::onWakeupPipe));
+
+  std::cout << "Starting async config polling (interval "
+            << interval_ms << " ms)" << std::endl;
+
+  m_current_poll_interval = interval_ms;
+  m_poll_running = true;
+  m_poll_thread = std::thread(&ConfigBackend::pollThreadFunc, this, interval_ms);
+} /* ConfigBackend::startAutoPolling */
+
+void ConfigBackend::stopAutoPolling(void)
+{
+  if (!m_poll_running.load())
+  {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(m_poll_mutex);
+    m_poll_running = false;
+  }
+  m_poll_cv.notify_all();
+
+  if (m_poll_thread.joinable())
+  {
+    m_poll_thread.join();
+  }
+
+  delete m_fd_watch;
+  m_fd_watch = nullptr;
+
+  if (m_wakeup_pipe[0] != -1)
+  {
+    ::close(m_wakeup_pipe[0]);
+    ::close(m_wakeup_pipe[1]);
+    m_wakeup_pipe[0] = m_wakeup_pipe[1] = -1;
+  }
+
+  // Discard any queued changes that never made it to the event loop
+  {
+    std::lock_guard<std::mutex> lock(m_queue_mutex);
+    while (!m_pending_changes.empty())
+      m_pending_changes.pop();
+  }
+
+  m_current_poll_interval = 0;
+  std::cout << "Stopped async config polling" << std::endl;
+} /* ConfigBackend::stopAutoPolling */
+
+bool ConfigBackend::isAutoPolling(void) const
+{
+  return m_poll_running.load();
+} /* ConfigBackend::isAutoPolling */
+
+unsigned int ConfigBackend::getPollingInterval(void) const
+{
+  return m_current_poll_interval;
+} /* ConfigBackend::getPollingInterval */
+
+void ConfigBackend::pollThreadFunc(unsigned int interval_ms)
+{
+  std::unique_lock<std::mutex> lock(m_poll_mutex);
+  while (m_poll_running.load())
+  {
+    auto status = m_poll_cv.wait_for(lock,
+        std::chrono::milliseconds(interval_ms));
+
+    if (!m_poll_running.load())
+    {
+      break;
+    }
+
+    if (status == std::cv_status::timeout)
+    {
+      lock.unlock();
+      checkForExternalChanges();
+      lock.lock();
+    }
+  }
+} /* ConfigBackend::pollThreadFunc */
+
+void ConfigBackend::onWakeupPipe(Async::FdWatch*)
+{
+  // Drain all notification bytes written by the poll thread
+  char buf[64];
+  while (::read(m_wakeup_pipe[0], buf, sizeof(buf)) > 0) {}
+
+  // Swap-out the queue so we hold the lock for the shortest possible time
+  std::queue<std::tuple<std::string,std::string,std::string>> batch;
+  {
+    std::lock_guard<std::mutex> lock(m_queue_mutex);
+    std::swap(batch, m_pending_changes);
+  }
+
+  // Emit all queued valueChanged signals on the event-loop thread
+  while (!batch.empty())
+  {
+    auto& [section, tag, value] = batch.front();
+    valueChanged(section, tag, value);
+    batch.pop();
+  }
+} /* ConfigBackend::onWakeupPipe */
+
+void ConfigBackend::notifyValueChanged(const std::string& section,
+                                      const std::string& tag,
+                                      const std::string& value)
+{
+  if (!m_enable_change_notifications.load())
+  {
+    return;
+  }
+
+  std::cout << "Configuration changed: [" << section << "]/" << tag
+            << " = " << value << std::endl;
+
+  if (m_wakeup_pipe[1] != -1)
+  {
+    // Called from the poll thread: queue the change and wake the event loop
+    {
+      std::lock_guard<std::mutex> lock(m_queue_mutex);
+      m_pending_changes.emplace(section, tag, value);
+    }
+    char byte = 1;
+    if (::write(m_wakeup_pipe[1], &byte, sizeof(byte)) == -1 && errno != EAGAIN)
+    {
+      std::cerr << "*** WARNING: ConfigBackend: wakeup pipe write failed: "
+                << strerror(errno) << std::endl;
+    }
+  }
+  else
+  {
+    // No polling thread active: emit directly on the calling (event-loop) thread
+    valueChanged(section, tag, value);
+  }
+} /* ConfigBackend::notifyValueChanged */
+
+// Factory convenience functions
+
+ConfigBackendPtr createConfigBackend(const std::string& url)
+{
+  auto parsed = ConfigSource::parse(url);
+  if (!parsed)
+  {
+    std::cerr << "*** ERROR: Invalid configuration source URL: " << url << std::endl;
+    return nullptr;
+  }
+
+  return createConfigBackendByType(parsed->backend_type_name, parsed->connection_info);
+} /* createConfigBackend */
+
+ConfigBackendPtr createConfigBackendByType(const std::string& backend_type,
+                                          const std::string& connection_info)
+{
+  ConfigBackendPtr backend(ConfigBackendFactory::createNamedObject(backend_type));
+  if (!backend)
+  {
+    std::cerr << "*** ERROR: Failed to create backend of type '" << backend_type 
+              << "'. Available: " << ConfigBackendFactory::validFactories() << std::endl;
+    return nullptr;
+  }
+  
+  if (!backend->open(connection_info))
+  {
+    std::cerr << "*** ERROR: Failed to open backend of type '" << backend_type 
+              << "' with connection info: " << connection_info << std::endl;
+    return nullptr;
+  }
+  
+  return backend;
+} /* createConfigBackendByType */
+
+} /* namespace Async */
+

--- a/src/async/core/AsyncConfigBackend.cpp
+++ b/src/async/core/AsyncConfigBackend.cpp
@@ -79,6 +79,20 @@ bool ConfigBackend::checkForExternalChanges(void)
   return false;
 } /* ConfigBackend::checkForExternalChanges */
 
+bool ConfigBackend::pollForExternalChanges(void)
+{
+  return checkForExternalChanges();
+} /* ConfigBackend::pollForExternalChanges */
+
+bool ConfigBackend::openPollConnection(void)
+{
+  return true;
+} /* ConfigBackend::openPollConnection */
+
+void ConfigBackend::closePollConnection(void)
+{
+} /* ConfigBackend::closePollConnection */
+
 void ConfigBackend::startAutoPolling(unsigned int interval_ms)
 {
   if (interval_ms == 0)
@@ -101,6 +115,18 @@ void ConfigBackend::startAutoPolling(unsigned int interval_ms)
 
   m_fd_watch = new Async::FdWatch(m_wakeup_pipe[0], Async::FdWatch::FD_WATCH_RD);
   m_fd_watch->activity.connect(sigc::mem_fun(*this, &ConfigBackend::onWakeupPipe));
+
+  if (!openPollConnection())
+  {
+    std::cerr << "*** ERROR: ConfigBackend: Failed to open poll connection"
+              << std::endl;
+    delete m_fd_watch;
+    m_fd_watch = nullptr;
+    ::close(m_wakeup_pipe[0]);
+    ::close(m_wakeup_pipe[1]);
+    m_wakeup_pipe[0] = m_wakeup_pipe[1] = -1;
+    return;
+  }
 
   std::cout << "Starting async config polling (interval "
             << interval_ms << " ms)" << std::endl;
@@ -137,6 +163,8 @@ void ConfigBackend::stopAutoPolling(void)
     ::close(m_wakeup_pipe[1]);
     m_wakeup_pipe[0] = m_wakeup_pipe[1] = -1;
   }
+
+  closePollConnection();
 
   // Discard any queued changes that never made it to the event loop
   {
@@ -175,7 +203,7 @@ void ConfigBackend::pollThreadFunc(unsigned int interval_ms)
     if (status == std::cv_status::timeout)
     {
       lock.unlock();
-      checkForExternalChanges();
+      pollForExternalChanges();
       lock.lock();
     }
   }
@@ -213,7 +241,7 @@ void ConfigBackend::notifyValueChanged(const std::string& section,
   }
 
   std::cout << "Configuration changed: [" << section << "]/" << tag
-            << " = " << value << std::endl;
+            << std::endl;
 
   if (m_wakeup_pipe[1] != -1)
   {
@@ -243,7 +271,7 @@ ConfigBackendPtr createConfigBackend(const std::string& url)
   auto parsed = ConfigSource::parse(url);
   if (!parsed)
   {
-    std::cerr << "*** ERROR: Invalid configuration source URL: " << url << std::endl;
+    std::cerr << "*** ERROR: Invalid configuration source URL" << std::endl;
     return nullptr;
   }
 
@@ -263,8 +291,8 @@ ConfigBackendPtr createConfigBackendByType(const std::string& backend_type,
   
   if (!backend->open(connection_info))
   {
-    std::cerr << "*** ERROR: Failed to open backend of type '" << backend_type 
-              << "' with connection info: " << connection_info << std::endl;
+    std::cerr << "*** ERROR: Failed to open '" << backend_type
+              << "' configuration backend" << std::endl;
     return nullptr;
   }
   

--- a/src/async/core/AsyncConfigBackend.h
+++ b/src/async/core/AsyncConfigBackend.h
@@ -1,0 +1,429 @@
+/**
+@file	 AsyncConfigBackend.h
+@brief   Abstract base class for configuration backends
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the base class declarationfor configuration backends that
+can load configuration data from various sources like files, databases, etc.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute  it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#ifndef ASYNC_CONFIG_BACKEND_INCLUDED
+#define ASYNC_CONFIG_BACKEND_INCLUDED
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <string>
+#include <map>
+#include <list>
+#include <memory>
+#include <ctime>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <tuple>
+#include <sigc++/sigc++.h>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+#include <AsyncFactory.h>
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Forward declarations
+ *
+ ****************************************************************************/
+
+namespace Async
+{
+  class FdWatch;
+}
+
+/****************************************************************************
+ *
+ * Namespace
+ *
+ ****************************************************************************/
+
+namespace Async
+{
+
+/****************************************************************************
+ *
+ * Forward declarations of classes inside of the declared namespace
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+class ConfigBackend : public sigc::trackable
+{
+  public:
+    /**
+     * @brief   Constructor with notification settings
+     * @param   enable_notifications  Enable change notifications (default: false)
+     * @param   auto_poll_interval_ms Auto-polling interval in milliseconds (0 = disabled)
+     *
+     * If enable_notifications is true and auto_poll_interval_ms > 0, auto-polling
+     * will start immediately.
+     */
+    ConfigBackend(bool enable_notifications = false,
+                  unsigned int auto_poll_interval_ms = 0);
+  
+    /**
+     * @brief 	Destructor
+     */
+    virtual ~ConfigBackend(void);
+  
+    /**
+     * @brief 	Open/connect to the configuration source
+     * @param 	source The configuration source (file path, connection string, etc.)
+     * @return	Returns \em true on success or else \em false.
+     *
+     * This function will establish a connection to the configuration source.
+     * For file backends, this opens the file. For database backends, this
+     * establishes a database connection.
+     */
+    virtual bool open(const std::string& source) = 0;
+    
+    /**
+     * @brief 	Close/disconnect from the configuration source
+     *
+     * This function closes the connection to the configuration source and
+     * performs any necessary cleanup.
+     */
+    virtual void close(void) = 0;
+    
+    /**
+     * @brief 	Check if the backend is connected/open
+     * @return	Returns \em true if connected, \em false otherwise
+     */
+    virtual bool isOpen(void) const = 0;
+    
+    /**
+     * @brief 	Get the string value of a configuration variable
+     * @param 	section The name of the section where the configuration
+     *	      	      	variable is located
+     * @param 	tag   	The name of the configuration variable to get
+     * @param 	value 	The value is returned in this argument
+     * @return	Returns \em true on success or else \em false on failure
+     *
+     * This function retrieves the value for a configuration variable.
+     */
+    virtual bool getValue(const std::string& section, const std::string& tag,
+                          std::string& value) const = 0;
+
+    /**
+     * @brief 	Set the value of a configuration variable
+     * @param 	section   The name of the section where the configuration
+     *	      	      	  variable is located
+     * @param 	tag   	  The name of the configuration variable to set.
+     * @param   value     The value to set
+     * @return	Returns \em true on success or else \em false on failure
+     *
+     * This function sets the value of a configuration variable.
+     * Not all backends may support writing (e.g., read-only file backends).
+     */
+    virtual bool setValue(const std::string& section, const std::string& tag,
+                          const std::string& value) = 0;
+
+    /**
+     * @brief   Return the name of all configuration sections
+     * @return  Returns a list of all existing section names
+     */
+    virtual std::list<std::string> listSections(void) const = 0;
+
+    /**
+     * @brief 	Return the name of all the tags in the given section
+     * @param 	section The name of the section where the configuration
+     *	      	      	variables are located
+     * @return	Returns the list of tags in the given section
+     */
+    virtual std::list<std::string> listSection(const std::string& section) const = 0;
+
+    /**
+     * @brief   Get backend type identifier
+     * @return  Returns a string identifying the backend type
+     */
+    virtual std::string getBackendType(void) const = 0;
+
+    /**
+     * @brief   Get backend-specific information
+     * @return  Returns a string with backend-specific details
+     */
+    virtual std::string getBackendInfo(void) const = 0;
+
+    /**
+     * @brief   Set the table prefix for database backends
+     * @param   prefix The prefix to use for table names (e.g., "svxlink_", "prod_svxreflector_")
+     *
+     * This method allows setting a custom table prefix for database backends.
+     * The prefix will be prepended to the base table name ("config") to create
+     * isolated table names for different applications or environments.
+     * 
+     * For file backends, this has no effect.
+     */
+    virtual void setTablePrefix(const std::string& prefix);
+
+    /**
+     * @brief   Get the current table prefix
+     * @return  The current table prefix
+     */
+    const std::string& getTablePrefix(void) const { return m_table_prefix; }
+
+    /**
+     * @brief   Initialize database tables (for database backends)
+     * @return  true on success, false on failure
+     * @note    This should be called after setTablePrefix() and before any data access
+     */
+    virtual bool initializeTables(void) { return true; }
+
+    /**
+     * @brief   Finalize database initialization after tables are populated
+     * @return  true on success, false on failure
+     * @note    This should be called after tables are created and populated with data.
+     *          Backends can use this to initialize change tracking timestamps, etc.
+     */
+    virtual bool finalizeInitialization(void) { return true; }
+
+    /**
+     * @brief   Enable or disable change notifications
+     * @param   enable true to enable, false to disable
+     */
+    void enableChangeNotifications(bool enable);
+
+    /**
+     * @brief   Check if change notifications are enabled
+     * @return  true if enabled, false otherwise
+     */
+    bool changeNotificationsEnabled(void) const;
+
+    /**
+     * @brief   Check for external changes (e.g., direct database updates)
+     * @return  true if changes were detected, false otherwise
+     *
+     * This method is called by the auto-polling timer (if enabled) or can be
+     * called manually. Database backends that require polling to check on
+     * database changes need to override this method.
+     */
+    virtual bool checkForExternalChanges(void);
+
+    /**
+     * @brief   Start automatic polling for external changes
+     * @param   interval_ms Polling interval in milliseconds
+     *
+     * Starts a timer that periodically calls checkForExternalChanges().
+     * Stops any existing polling timer first.
+     */
+    void startAutoPolling(unsigned int interval_ms);
+
+    /**
+     * @brief   Stop automatic polling
+     */
+    void stopAutoPolling(void);
+
+    /**
+     * @brief   Check if auto-polling is active
+     * @return  true if polling is active, false otherwise
+     */
+    bool isAutoPolling(void) const;
+
+    /**
+     * @brief   Get the current polling interval
+     * @return  The polling interval in milliseconds, or 0 if not polling
+     */
+    unsigned int getPollingInterval(void) const;
+
+    /**
+     * @brief   Signal emitted when a configuration value changes
+     * @param   section The section name
+     * @param   tag The configuration tag name
+     * @param   value The new value
+     *
+     * This signal can be emitted on notifyValueChanged() calls
+     * which signal that a value changed.
+     * 
+     * @see checkForExternalChanges()
+     */
+    sigc::signal<void(const std::string&, const std::string&, const std::string&)> valueChanged;
+
+  protected:
+    /**
+     * @brief   Notify listeners of a value change
+     * @param   section The section name
+     * @param   tag The configuration tag name
+     * @param   value The new value
+     *
+     * Call this method from setValue() and checkForExternalChanges() implementations
+     * to emit the valueChanged signal.
+     * 
+     * Respects the m_enable_change_notifications flag.
+     */
+    void notifyValueChanged(const std::string& section,
+                           const std::string& tag,
+                           const std::string& value);
+
+  protected:
+    /**
+     * @brief   Get the full table name with prefix
+     * @param   base_name The base table name (e.g., "config")
+     * @return  The full table name with prefix applied
+     *
+     * Helper method for database backends to construct full table names.
+     * Returns prefix + base_name (e.g., "svxlink_config", "prod_reflector_config")
+     */
+    std::string getFullTableName(const std::string& base_name) const;
+
+  private:
+    std::string               m_table_prefix;
+    std::atomic<bool>         m_enable_change_notifications;
+    unsigned int              m_default_poll_interval;
+    unsigned int              m_current_poll_interval;
+
+    // Non-blocking poll infrastructure
+    int                       m_wakeup_pipe[2];   // [0]=read, [1]=write
+    Async::FdWatch*           m_fd_watch;
+    std::mutex                m_queue_mutex;
+    std::queue<std::tuple<std::string,std::string,std::string>> m_pending_changes;
+    std::thread               m_poll_thread;
+    std::mutex                m_poll_mutex;
+    std::condition_variable   m_poll_cv;
+    std::atomic<bool>         m_poll_running;
+
+    void onWakeupPipe(Async::FdWatch* w);
+    void pollThreadFunc(unsigned int interval_ms);
+
+    ConfigBackend(const ConfigBackend&) = delete;
+    ConfigBackend& operator=(const ConfigBackend&) = delete;
+
+}; /* class ConfigBackend */
+
+/**
+ * @brief Smart pointer type for ConfigBackend
+ */
+using ConfigBackendPtr = std::unique_ptr<ConfigBackend>;
+
+/****************************************************************************
+ *
+ * AsyncFactory Pattern Support
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Factory for creating ConfigBackend instances
+ *
+ * Example registration:
+ * @code
+ * static ConfigBackendSpecificFactory<MySQLConfigBackend> mysql_factory;
+ * @endcode
+ */
+using ConfigBackendFactory = Factory<ConfigBackend>;
+
+/**
+ * @brief Specific factory for a ConfigBackend implementation
+ * @tparam T The concrete backend class (must inherit from ConfigBackend)
+ *
+ * Automatically registers the backend with the factory.
+ */
+template<class T>
+struct ConfigBackendSpecificFactory : public SpecificFactory<ConfigBackend, T>
+{
+  ConfigBackendSpecificFactory(void)
+    : SpecificFactory<ConfigBackend, T>(T::OBJNAME) {}
+};
+
+/****************************************************************************
+ *
+ * Convenience Functions
+ *
+ ****************************************************************************/
+
+/**
+ * @brief Create a ConfigBackend from a URL
+ * @param url Configuration source URL (e.g., "mysql://user:pass@host/db")
+ * @return ConfigBackendPtr on success, nullptr on failure
+ *
+ * Parses the URL, detects the backend type, and creates the appropriate backend.
+ *
+ * Example:
+ * @code
+ * auto backend = Async::createConfigBackend("sqlite:///var/lib/svxlink/db.sqlite");
+ * if (backend && backend->open(...)) {
+ *   // Use backend
+ * }
+ * @endcode
+ */
+ConfigBackendPtr createConfigBackend(const std::string& url);
+
+/**
+ * @brief Create a ConfigBackend by explicit type
+ * @param backend_type Backend type name (e.g., "mysql", "sqlite")
+ * @param connection_info Connection information (file path or connection string)
+ * @return ConfigBackendPtr on success, nullptr on failure
+ *
+ * Example:
+ * @code
+ * auto backend = Async::createConfigBackendByType("mysql", "host,3306,db,user,pass");
+ * @endcode
+ */
+ConfigBackendPtr createConfigBackendByType(const std::string& backend_type,
+                                          const std::string& connection_info);
+
+} /* namespace */
+
+#endif /* ASYNC_CONFIG_BACKEND_INCLUDED */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncConfigBackend.h
+++ b/src/async/core/AsyncConfigBackend.h
@@ -314,6 +314,31 @@ class ConfigBackend : public sigc::trackable
                            const std::string& tag,
                            const std::string& value);
 
+    /**
+     * @brief   Check for external changes from the auto-poll thread
+     * @return  true if changes were detected, false otherwise
+     *
+     * Called periodically by the background poll thread. Database backends
+     * that use a dedicated poll connection should override this method.
+     * The default implementation delegates to checkForExternalChanges().
+     */
+    virtual bool pollForExternalChanges(void);
+
+    /**
+     * @brief   Open a dedicated database connection for the poll thread
+     * @return  true on success, false on failure
+     *
+     * Called by startAutoPolling() before the poll thread is started.
+     */
+    virtual bool openPollConnection(void);
+
+    /**
+     * @brief   Close the dedicated poll-thread database connection
+     *
+     * Called by stopAutoPolling() after the poll thread has exited.
+     */
+    virtual void closePollConnection(void);
+
   protected:
     /**
      * @brief   Get the full table name with prefix

--- a/src/async/core/AsyncConfigSource.cpp
+++ b/src/async/core/AsyncConfigSource.cpp
@@ -1,0 +1,243 @@
+/**
+@file   AsyncConfigSource.cpp
+@brief  Implementation of configuration source URL parser
+@author Rui Barreiros / CR7BPM
+@date   2025-10-20
+
+This file contains the implementation of the ConfigSource class that is used to
+parse configuration source URLs and detect the backend type.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it is useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+\endverbatim
+*/
+
+#include "AsyncConfigSource.h"
+#include "AsyncConfigBackend.h"
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+
+namespace Async
+{
+
+std::optional<ConfigSource> ConfigSource::parse(const std::string& url)
+{
+  if (url.empty())
+  {
+    std::cerr << "*** ERROR: Empty configuration source URL" << std::endl;
+    return std::nullopt;
+  }
+
+  ConfigSource source;
+  source.backend_type = detectBackendType(url);
+  source.backend_type_name = getBackendTypeName(source.backend_type);
+
+  if (source.backend_type == BACKEND_UNKNOWN)
+  {
+    std::cerr << "*** ERROR: Unknown backend type in URL: " << url << std::endl;
+    std::cerr << "*** Available backends: " << ConfigBackendFactory::validFactories() << std::endl;
+    return std::nullopt;
+  }
+
+  // Check if backend is compiled in
+  if (!isBackendAvailable(source.backend_type))
+  {
+    std::cerr << "*** ERROR: Backend '" << source.backend_type_name
+              << "' not compiled in. Available: " << ConfigBackendFactory::validFactories() << std::endl;
+    return std::nullopt;
+  }
+
+  // Extract connection info
+  if (source.backend_type == BACKEND_FILE)
+  {
+    // For file backend, strip "file://" prefix
+    if (url.substr(0, 7) == "file://")
+    {
+      source.connection_info = url.substr(7);
+    }
+    else
+    {
+      source.connection_info = url;
+    }
+  }
+  else
+  {
+    // For database backends, parse URL
+    if (!parseDatabaseURL(url, source.connection_info))
+    {
+      std::cerr << "*** ERROR: Failed to parse database URL: " << url << std::endl;
+      return std::nullopt;
+    }
+  }
+
+  return source;
+} /* ConfigSource::parse */
+
+ConfigSource::BackendType ConfigSource::detectBackendType(const std::string& url)
+{
+  if (url.substr(0, 7) == "file://")
+  {
+    return BACKEND_FILE;
+  }
+  else if (url.substr(0, 9) == "sqlite://")
+  {
+    return BACKEND_SQLITE;
+  }
+  else if (url.substr(0, 8) == "mysql://")
+  {
+    return BACKEND_MYSQL;
+  }
+  else if (url.substr(0, 13) == "postgresql://")
+  {
+    return BACKEND_POSTGRESQL;
+  }
+  else if (url.find("://") == std::string::npos)
+  {
+    // No scheme means file backend
+    return BACKEND_FILE;
+  }
+
+  return BACKEND_UNKNOWN;
+} /* ConfigSource::detectBackendType */
+
+std::string ConfigSource::getBackendTypeName(BackendType type)
+{
+  switch (type)
+  {
+    case BACKEND_FILE:       return "file";
+    case BACKEND_SQLITE:     return "sqlite";
+    case BACKEND_MYSQL:      return "mysql";
+    case BACKEND_POSTGRESQL: return "postgresql";
+    case BACKEND_UNKNOWN:    return "unknown";
+    default:                 return "unknown";
+  }
+} /* ConfigSource::getBackendTypeName */
+
+bool ConfigSource::parseDatabaseURL(const std::string& url,
+                                    std::string& connection_string)
+{
+  // Expected formats:
+  //   SQLite:     sqlite:///path/to/file.db
+  //   MySQL:      mysql://[user:pass@]host[:port]/database
+  //   PostgreSQL: postgresql://[user:pass@]host[:port]/database
+  
+  size_t scheme_end = url.find("://");
+  if (scheme_end == std::string::npos)
+  {
+    return false;
+  }
+
+  std::string scheme = url.substr(0, scheme_end);
+  std::string remainder = url.substr(scheme_end + 3);
+  
+  // Special case for SQLite - it's just a file path
+  if (scheme == "sqlite")
+  {
+    connection_string = remainder;
+    return true;
+  }
+  
+  // Parse user:pass@ if present
+  std::string user, pass, host, database;
+  int port = -1;
+
+  size_t at_pos = remainder.find('@');
+  if (at_pos != std::string::npos)
+  {
+    // User/pass present
+    std::string userpass = remainder.substr(0, at_pos);
+    remainder = remainder.substr(at_pos + 1);
+
+    size_t colon_pos = userpass.find(':');
+    if (colon_pos != std::string::npos)
+    {
+      user = userpass.substr(0, colon_pos);
+      pass = userpass.substr(colon_pos + 1);
+    }
+    else
+    {
+      user = userpass;
+    }
+  }
+
+  // Parse host[:port]/database
+  size_t slash_pos = remainder.find('/');
+  if (slash_pos == std::string::npos)
+  {
+    std::cerr << "*** ERROR: Database URL missing database name" << std::endl;
+    return false;
+  }
+
+  std::string hostport = remainder.substr(0, slash_pos);
+  database = remainder.substr(slash_pos + 1);
+
+  // Parse host:port
+  size_t colon_pos = hostport.find(':');
+  if (colon_pos != std::string::npos)
+  {
+    host = hostport.substr(0, colon_pos);
+    port = std::stoi(hostport.substr(colon_pos + 1));
+  }
+  else
+  {
+    host = hostport;
+  }
+
+  // Build connection string in format: host,port,database,user,pass
+  std::ostringstream oss;
+  oss << host << ",";
+  oss << (port > 0 ? std::to_string(port) : "") << ",";
+  oss << database << ",";
+  oss << user << ",";
+  oss << pass;
+
+  connection_string = oss.str();
+  return true;
+} /* ConfigSource::parseDatabaseURL */
+
+bool ConfigSource::isBackendAvailable(const std::string& backend_type_name)
+{
+  if (backend_type_name == "file")
+  {
+    return true; // Always available
+  }
+#ifdef HAS_SQLITE_SUPPORT
+  if (backend_type_name == "sqlite")
+  {
+    return true;
+  }
+#endif
+#ifdef HAS_MYSQL_SUPPORT
+  if (backend_type_name == "mysql")
+  {
+    return true;
+  }
+#endif
+#ifdef HAS_POSTGRESQL_SUPPORT
+  if (backend_type_name == "postgresql")
+  {
+    return true;
+  }
+#endif
+  return false;
+} /* ConfigSource::isBackendAvailable */
+
+bool ConfigSource::isBackendAvailable(BackendType type)
+{
+  return isBackendAvailable(getBackendTypeName(type));
+} /* ConfigSource::isBackendAvailable */
+
+} /* namespace */
+

--- a/src/async/core/AsyncConfigSource.cpp
+++ b/src/async/core/AsyncConfigSource.cpp
@@ -27,7 +27,7 @@ GNU General Public License for more details.
 #include "AsyncConfigBackend.h"
 #include <iostream>
 #include <sstream>
-#include <algorithm>
+#include <stdexcept>
 
 namespace Async
 {
@@ -46,7 +46,8 @@ std::optional<ConfigSource> ConfigSource::parse(const std::string& url)
 
   if (source.backend_type == BACKEND_UNKNOWN)
   {
-    std::cerr << "*** ERROR: Unknown backend type in URL: " << url << std::endl;
+    std::cerr << "*** ERROR: Unknown backend type in configuration source URL"
+              << std::endl;
     std::cerr << "*** Available backends: " << ConfigBackendFactory::validFactories() << std::endl;
     return std::nullopt;
   }
@@ -77,7 +78,7 @@ std::optional<ConfigSource> ConfigSource::parse(const std::string& url)
     // For database backends, parse URL
     if (!parseDatabaseURL(url, source.connection_info))
     {
-      std::cerr << "*** ERROR: Failed to parse database URL: " << url << std::endl;
+      std::cerr << "*** ERROR: Failed to parse database URL" << std::endl;
       return std::nullopt;
     }
   }
@@ -188,7 +189,15 @@ bool ConfigSource::parseDatabaseURL(const std::string& url,
   if (colon_pos != std::string::npos)
   {
     host = hostport.substr(0, colon_pos);
-    port = std::stoi(hostport.substr(colon_pos + 1));
+    try
+    {
+      port = std::stoi(hostport.substr(colon_pos + 1));
+    }
+    catch (const std::exception&)
+    {
+      std::cerr << "*** ERROR: Invalid port in database URL" << std::endl;
+      return false;
+    }
   }
   else
   {

--- a/src/async/core/AsyncConfigSource.h
+++ b/src/async/core/AsyncConfigSource.h
@@ -1,0 +1,145 @@
+/**
+@file   AsyncConfigSource.h
+@brief  Configuration source URL parser and backend detection
+@author Rui Barreiros / CR7BPM
+@date   2025-10-20
+
+This file contains the declaration of the ConfigSource class that is used to
+parse configuration source URLs and detect the backend type.
+
+Supports:
+  - file://path/to/file.conf
+  - sqlite://path/to/db.sqlite
+  - mysql://user:pass@host:port/database
+  - postgresql://user:pass@host:port/database
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#ifndef ASYNC_CONFIG_SOURCE_INCLUDED
+#define ASYNC_CONFIG_SOURCE_INCLUDED
+
+#include <string>
+#include <optional>
+
+namespace Async
+{
+
+/**
+ * @brief Configuration source parser and backend detector
+ *
+ * Parses configuration source URLs and provides information about
+ * backend types and availability. Does not create backends itself.
+ *
+ * Example:
+ * @code
+ * auto source = ConfigSource::parse("mysql://user:pass@localhost/svxlink");
+ * if (source && source->isValid()) {
+ *   std::cout << "Backend: " << source->backend_type_name << std::endl;
+ *   std::cout << "Connection: " << source->connection_info << std::endl;
+ * }
+ * @endcode
+ */
+class ConfigSource
+{
+public:
+  /**
+   * @brief Enumeration of supported backend types
+   */
+  enum BackendType
+  {
+    BACKEND_FILE,        ///< File-based configuration
+    BACKEND_SQLITE,      ///< SQLite database
+    BACKEND_MYSQL,       ///< MySQL database
+    BACKEND_POSTGRESQL,  ///< PostgreSQL database
+    BACKEND_UNKNOWN      ///< Unknown or invalid backend
+  };
+
+  /**
+   * @brief Backend type name (e.g., "file", "sqlite")
+   */
+  std::string backend_type_name;
+
+  /**
+   * @brief Connection information (file path or connection string)
+   */
+  std::string connection_info;
+
+  /**
+   * @brief Detected backend type
+   */
+  BackendType backend_type;
+
+  /**
+   * @brief Parse a configuration source URL
+   * @param url The URL to parse (e.g., "file://path" or "mysql://...")
+   * @return Optional ConfigSource if parsing succeeds, nullopt otherwise
+   */
+  static std::optional<ConfigSource> parse(const std::string& url);
+
+  /**
+   * @brief Check if a backend type is available (compiled in)
+   * @param backend_type_name Backend name (e.g., "sqlite", "mysql")
+   * @return true if the backend is available
+   */
+  static bool isBackendAvailable(const std::string& backend_type_name);
+
+  /**
+   * @brief Check if a backend type is available (compiled in)
+   * @param type Backend type enumeration
+   * @return true if the backend is available
+   */
+  static bool isBackendAvailable(BackendType type);
+
+  /**
+   * @brief Check if this source is valid
+   * @return true if backend_type is not BACKEND_UNKNOWN
+   */
+  bool isValid() const { return backend_type != BACKEND_UNKNOWN; }
+
+private:
+  /**
+   * @brief Detect backend type from URL
+   * @param url The URL to analyze
+   * @return Detected backend type
+   */
+  static BackendType detectBackendType(const std::string& url);
+
+  /**
+   * @brief Get backend type name from enum
+   * @param type Backend type
+   * @return Name string (e.g., "sqlite")
+   */
+  static std::string getBackendTypeName(BackendType type);
+
+  /**
+   * @brief Parse database URL into connection string
+   * @param url The database URL
+   * @param connection_string Output connection string
+   * @return true if parsing succeeds
+   */
+  static bool parseDatabaseURL(const std::string& url,
+                               std::string& connection_string);
+};
+
+} /* namespace Async */
+
+#endif /* ASYNC_CONFIG_SOURCE_INCLUDED */
+

--- a/src/async/core/AsyncConfigSource.h
+++ b/src/async/core/AsyncConfigSource.h
@@ -10,8 +10,8 @@ parse configuration source URLs and detect the backend type.
 Supports:
   - file://path/to/file.conf
   - sqlite://path/to/db.sqlite
-  - mysql://user:pass@host:port/database
-  - postgresql://user:pass@host:port/database
+  - mysql://user:pass@@host:port/database
+  - postgresql://user:pass@@host:port/database
 
 \verbatim
 Async - A library for programming event driven applications

--- a/src/async/core/AsyncFileConfigBackend.cpp
+++ b/src/async/core/AsyncFileConfigBackend.cpp
@@ -1,0 +1,468 @@
+/**
+@file	 AsyncFileConfigBackend.cpp
+@brief   File-based configuration backend implementation
+@author  Tobias Blomberg / SM0SVX, Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the implementation of the file-based configuration backend
+that reads INI-formatted configuration files.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <unistd.h>
+#include <errno.h>
+#include <ctype.h>
+
+#include <iostream>
+#include <cassert>
+#include <cstring>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncFileConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Namespaces to use
+ *
+ ****************************************************************************/
+
+using namespace std;
+using namespace Async;
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local class definitions
+ *
+ ****************************************************************************/
+
+// Factory registration for file backend
+static ConfigBackendSpecificFactory<FileConfigBackend> file_factory;
+
+/****************************************************************************
+ *
+ * Prototypes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Public member functions
+ *
+ ****************************************************************************/
+
+FileConfigBackend::FileConfigBackend(void)
+  : ConfigBackend(false, 0), m_is_open(false)
+{
+} /* FileConfigBackend::FileConfigBackend */
+
+FileConfigBackend::~FileConfigBackend(void)
+{
+  close();
+} /* FileConfigBackend::~FileConfigBackend */
+
+bool FileConfigBackend::open(const string& source)
+{
+  close();
+  
+  errno = 0;
+  m_filename = source;
+
+  FILE *file = fopen(source.c_str(), "r");
+  if (file == NULL)
+  {
+    return false;
+  }
+
+  bool success = parseCfgFile(file);
+
+  fclose(file);
+  file = NULL;
+
+  if (success)
+  {
+    m_is_open = true;
+  }
+
+  return success;
+} /* FileConfigBackend::open */
+
+void FileConfigBackend::close(void)
+{
+  m_sections.clear();
+  m_filename.clear();
+  m_is_open = false;
+} /* FileConfigBackend::close */
+
+bool FileConfigBackend::isOpen(void) const
+{
+  return m_is_open;
+} /* FileConfigBackend::isOpen */
+
+bool FileConfigBackend::getValue(const std::string& section, const std::string& tag,
+                                 std::string& value) const
+{
+  if (!m_is_open)
+  {
+    return false;
+  }
+
+  Sections::const_iterator sec_it = m_sections.find(section);
+  if (sec_it == m_sections.end())
+  {
+    return false;
+  }
+
+  Values::const_iterator val_it = sec_it->second.find(tag);
+  if (val_it == sec_it->second.end())
+  {
+    return false;
+  }
+
+  value = val_it->second.val;
+  return true;
+} /* FileConfigBackend::getValue */
+
+bool FileConfigBackend::setValue(const std::string& section, const std::string& tag,
+                                 const std::string& value)
+{
+  if (!m_is_open)
+  {
+    return false;
+  }
+
+  Values &values = m_sections[section];
+  values[tag].val = value;
+  notifyValueChanged(section, tag, value);
+  return true;
+} /* FileConfigBackend::setValue */
+
+list<string> FileConfigBackend::listSections(void) const
+{
+  list<string> section_list;
+  
+  if (!m_is_open)
+  {
+    return section_list;
+  }
+
+  for (Sections::const_iterator it = m_sections.begin(); it != m_sections.end(); ++it)
+  {
+    section_list.push_back(it->first);
+  }
+  return section_list;
+} /* FileConfigBackend::listSections */
+
+list<string> FileConfigBackend::listSection(const string& section) const
+{
+  list<string> tags;
+  
+  if (!m_is_open)
+  {
+    return tags;
+  }
+  
+  Sections::const_iterator sec_it = m_sections.find(section);
+  if (sec_it == m_sections.end())
+  {
+    return tags;
+  }
+  
+  const Values& values = sec_it->second;
+  for (Values::const_iterator it = values.begin(); it != values.end(); ++it)
+  {
+    tags.push_back(it->first);
+  }
+  
+  return tags;
+} /* FileConfigBackend::listSection */
+
+std::string FileConfigBackend::getBackendType(void) const
+{
+  return "file";
+} /* FileConfigBackend::getBackendType */
+
+std::string FileConfigBackend::getBackendInfo(void) const
+{
+  return m_filename;
+} /* FileConfigBackend::getBackendInfo */
+
+/****************************************************************************
+ *
+ * Protected member functions
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Private member functions
+ *
+ ****************************************************************************/
+
+bool FileConfigBackend::parseCfgFile(FILE *file)
+{
+  char line[16384];
+  int line_no = 0;
+  string current_sec;
+  string current_tag;
+  
+  while (fgets(line, sizeof(line), file) != 0)
+  {
+    ++line_no;
+    char *l = trimSpaces(line);
+    
+    switch (l[0])
+    {
+      case 0:     // Ignore empty rows and
+      case '#':   // rows starting with a #-character == comments
+        break;
+      
+      case '[':
+      {
+        char *sec = parseSection(l);
+        if ((sec == 0) || (sec[0] == 0))
+        {
+          cerr << "*** ERROR: Configuration file parse error. Illegal section "
+                  "name syntax on line " << line_no << endl;
+          return false;
+        }
+        current_sec = sec;
+        current_tag = "";
+        if (m_sections.count(current_sec) == 0)
+        {
+          m_sections[current_sec];  // Create a new empty section
+        }
+        break;
+      }
+      
+      case '"':
+      {
+        char *val = parseValue(l);
+        if (val == 0)
+        {
+          cerr << "*** ERROR: Configuration file parse error. Illegal value "
+                  "syntax on line " << line_no << endl;
+          return false;
+        }
+        
+        if (current_tag.empty())
+        {
+          cerr << "*** ERROR: Configuration file parse error. Line "
+                  "continuation without previous value on line "
+               << line_no << endl;
+          return false;
+        }
+        assert(!current_sec.empty());
+        
+        Values &values = m_sections[current_sec];
+        string& value = values[current_tag].val;
+        value += val;
+        break;
+      }
+      
+      default:
+      {
+        string tag, value;
+        if (!parseValueLine(l, tag, value))
+        {
+          cerr << "*** ERROR: Configuration file parse error. Illegal value "
+                  "line syntax on line " << line_no << endl;
+          return false;
+        }
+        
+        if (current_sec.empty())
+        {
+          cerr << "*** ERROR: Configuration file parse error. Value without "
+                  "section on line " << line_no << endl;
+          return false;
+        }
+        Values &values = m_sections[current_sec];
+        current_tag = tag;
+        values[current_tag].val = value;
+        break;
+      }
+    }
+  }
+  
+  return true;
+} /* FileConfigBackend::parseCfgFile */
+
+char *FileConfigBackend::trimSpaces(char *line)
+{
+  char *begin = line;
+  while ((*begin != 0) && isspace(*begin))
+  {
+    ++begin;
+  }
+  
+  char *end = begin + strlen(begin);
+  while ((end != begin) && (isspace(*end) || (*end == 0)))
+  {
+    *end-- = 0;
+  }
+  
+  return begin;
+} /* FileConfigBackend::trimSpaces */
+
+char *FileConfigBackend::parseSection(char *line)
+{
+  return parseDelimitedString(line, '[', ']');
+} /* FileConfigBackend::parseSection */
+
+char *FileConfigBackend::parseDelimitedString(char *str, char begin_tok, char end_tok)
+{
+  if (str[0] != begin_tok)
+  {
+    return 0;
+  }
+  
+  char *end = str + strlen(str) - 1;
+  if (*end != end_tok)
+  {
+    return 0;
+  }
+  *end = 0;
+  
+  return str + 1;
+} /* FileConfigBackend::parseDelimitedString */
+
+bool FileConfigBackend::parseValueLine(char *line, string& tag, string& value)
+{
+  char *eq = strchr(line, '=');
+  if (eq == 0)
+  {
+    return false;
+  }
+  *eq = 0;
+  
+  tag = trimSpaces(line);
+  char *val = parseValue(eq + 1);
+  if (val == 0)
+  {
+    return false;
+  }
+  
+  value = val;
+  
+  return true;
+} /* FileConfigBackend::parseValueLine */
+
+char *FileConfigBackend::parseValue(char *value)
+{
+  value = trimSpaces(value);
+  if (value[0] == '"')
+  {
+    value = parseDelimitedString(value, '"', '"');
+  }
+  
+  if (value == 0)
+  {
+    return 0;
+  }
+  
+  return translateEscapedChars(value);
+} /* FileConfigBackend::parseValue */
+
+char *FileConfigBackend::translateEscapedChars(char *val)
+{
+  char *head = val;
+  char *tail = head;
+  
+  while (*head != 0)
+  {
+    if (*head == '\\')
+    {
+      ++head;
+      switch (*head)
+      {
+        case 'n':
+          *tail = '\n';
+          break;
+          
+        case 'r':
+          *tail = '\r';
+          break;
+          
+        case 't':
+          *tail = '\t';
+          break;
+          
+        case '\\':
+          *tail = '\\';
+          break;
+          
+        case '"':
+          *tail = '"';
+          break;
+          
+        default:
+          return 0;
+      }
+    }
+    else
+    {
+      *tail = *head;
+    }
+    ++head;
+    ++tail;
+  }
+  *tail = 0;
+  
+  return val;
+} /* FileConfigBackend::translateEscapedChars */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncFileConfigBackend.h
+++ b/src/async/core/AsyncFileConfigBackend.h
@@ -1,0 +1,227 @@
+/**
+@file	 AsyncFileConfigBackend.h
+@brief   File-based configuration backend implementation
+@author  Tobias Blomberg / SM0SVX, Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the file-based configuration backend that reads INI-formatted
+configuration files, similar to the original AsyncConfig implementation.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#ifndef ASYNC_FILE_CONFIG_BACKEND_INCLUDED
+#define ASYNC_FILE_CONFIG_BACKEND_INCLUDED
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <string>
+#include <map>
+#include <list>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Forward declarations
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Namespace
+ *
+ ****************************************************************************/
+
+namespace Async
+{
+
+/****************************************************************************
+ *
+ * Forward declarations of classes inside of the declared namespace
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief	File-based configuration backend
+@author Tobias Blomberg / SM0SVX
+@date   2025-09-19
+
+This class implements a configuration backend that reads INI-formatted
+configuration files. It provides the same functionality as the original
+AsyncConfig class but through the ConfigBackend interface.
+
+*/
+class FileConfigBackend : public ConfigBackend
+{
+  public:
+    static constexpr const char* OBJNAME = "file";
+
+    /**
+     * @brief 	Default constructor
+     */
+    FileConfigBackend(void);
+  
+    /**
+     * @brief 	Destructor
+     */
+    virtual ~FileConfigBackend(void);
+  
+    /**
+     * @brief 	Open the given config file
+     * @param 	source The path to the configuration file to open
+     * @return	Returns \em true on success or else \em false.
+     *
+     * This function will read the given configuration file into memory.
+     * If this function return false and errno != 0, the errno variable may
+     * give a hint what the problem was.
+     */
+    virtual bool open(const std::string& source) override;
+    
+    /**
+     * @brief 	Close the configuration file
+     *
+     * This function closes the file and cleans up resources.
+     */
+    virtual void close(void) override;
+    
+    /**
+     * @brief 	Check if the file backend is open
+     * @return	Returns \em true if file is loaded, \em false otherwise
+     */
+    virtual bool isOpen(void) const override;
+    
+    /**
+     * @brief 	Get the string value of a configuration variable
+     * @param 	section The name of the section where the configuration
+     *	      	      	variable is located
+     * @param 	tag   	The name of the configuration variable to get
+     * @param 	value 	The value is returned in this argument
+     * @return	Returns \em true on success or else \em false on failure
+     */
+    virtual bool getValue(const std::string& section, const std::string& tag,
+                          std::string& value) const override;
+
+    /**
+     * @brief 	Set the value of a configuration variable
+     * @param 	section   The name of the section where the configuration
+     *	      	      	  variable is located
+     * @param 	tag   	  The name of the configuration variable to set.
+     * @param   value     The value to set
+     * @return	Returns \em true on success or else \em false on failure
+     *
+     * Note: This function only modifies the in-memory representation.
+     * It does not write back to the configuration file.
+     */
+    virtual bool setValue(const std::string& section, const std::string& tag,
+                          const std::string& value) override;
+
+    /**
+     * @brief   Return the name of all configuration sections
+     * @return  Returns a list of all existing section names
+     */
+    virtual std::list<std::string> listSections(void) const override;
+
+    /**
+     * @brief 	Return the name of all the tags in the given section
+     * @param 	section The name of the section where the configuration
+     *	      	      	variables are located
+     * @return	Returns the list of tags in the given section
+     */
+    virtual std::list<std::string> listSection(const std::string& section) const override;
+
+    /**
+     * @brief   Get backend type identifier
+     * @return  Returns "file"
+     */
+    virtual std::string getBackendType(void) const override;
+
+    /**
+     * @brief   Get backend-specific information
+     * @return  Returns the file path
+     */
+    virtual std::string getBackendInfo(void) const override;
+
+  protected:
+
+  private:
+    struct Value
+    {
+      std::string val;
+    };
+    typedef std::map<std::string, Value>  Values;
+    typedef std::map<std::string, Values> Sections;
+
+    Sections    m_sections;
+    std::string m_filename;
+    bool        m_is_open;
+
+    bool parseCfgFile(FILE *file);
+    char *trimSpaces(char *line);
+    char *parseSection(char *line);
+    char *parseDelimitedString(char *str, char begin_tok, char end_tok);
+    bool parseValueLine(char *line, std::string& tag, std::string& value);
+    char *parseValue(char *value);
+    char *translateEscapedChars(char *val);
+
+}; /* class FileConfigBackend */
+
+} /* namespace */
+
+#endif /* ASYNC_FILE_CONFIG_BACKEND_INCLUDED */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncMySQLConfigBackend.cpp
+++ b/src/async/core/AsyncMySQLConfigBackend.cpp
@@ -108,6 +108,8 @@ MySQLConfigBackend::MySQLConfigBackend(void)
 
 MySQLConfigBackend::~MySQLConfigBackend(void)
 {
+  // Stop the poll thread before closing the connection handle!!!
+  stopAutoPolling();
   close();
 } /* MySQLConfigBackend::~MySQLConfigBackend */
 

--- a/src/async/core/AsyncMySQLConfigBackend.cpp
+++ b/src/async/core/AsyncMySQLConfigBackend.cpp
@@ -1,0 +1,582 @@
+/**
+@file	 AsyncMySQLConfigBackend.cpp
+@brief   MySQL/MariaDB-based configuration backend implementation
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the implementation of the MySQL/MariaDB-based configuration backend.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <mysql/mysql.h>
+#include <iostream>
+#include <sstream>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncMySQLConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Namespaces to use
+ *
+ ****************************************************************************/
+
+using namespace std;
+using namespace Async;
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local class definitions
+ *
+ ****************************************************************************/
+
+#ifdef HAS_MYSQL_SUPPORT
+// Factory registration for MySQL backend
+static ConfigBackendSpecificFactory<MySQLConfigBackend> mysql_factory;
+#endif
+
+/****************************************************************************
+ *
+ * Prototypes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Public member functions
+ *
+ ****************************************************************************/
+
+MySQLConfigBackend::MySQLConfigBackend(void)
+  : ConfigBackend(true, 300000), m_mysql(nullptr), m_last_check_time("1970-01-01 00:00:00")
+{
+  m_conn_params.port = 3306; // Default MySQL port
+} /* MySQLConfigBackend::MySQLConfigBackend */
+
+MySQLConfigBackend::~MySQLConfigBackend(void)
+{
+  close();
+} /* MySQLConfigBackend::~MySQLConfigBackend */
+
+bool MySQLConfigBackend::open(const string& source)
+{
+  close();
+  
+  m_connection_string = source;
+  
+  if (!parseConnectionString(source, m_conn_params))
+  {
+    cerr << "*** ERROR: Invalid MySQL connection string format" << endl;
+    return false;
+  }
+  
+  m_mysql = mysql_init(nullptr);
+  if (m_mysql == nullptr)
+  {
+    cerr << "*** ERROR: Failed to initialize MySQL connection" << endl;
+    return false;
+  }
+  
+  // Set connection timeout
+  unsigned int timeout = 10;
+  mysql_options(m_mysql, MYSQL_OPT_CONNECT_TIMEOUT, &timeout);
+  
+  // Enable automatic reconnection
+  bool reconnect = true;
+  mysql_options(m_mysql, MYSQL_OPT_RECONNECT, &reconnect);
+  
+  if (mysql_real_connect(m_mysql,
+                         m_conn_params.host.c_str(),
+                         m_conn_params.user.c_str(),
+                         m_conn_params.password.c_str(),
+                         m_conn_params.database.c_str(),
+                         m_conn_params.port,
+                         nullptr, 0) == nullptr)
+  {
+    cerr << "*** ERROR: Failed to connect to MySQL database: " << getLastError() << endl;
+    close();
+    return false;
+  }
+    
+  // Note: Tables will be created later after table prefix is set
+  // createTables() is now called from initializeDatabase()
+  
+  return true;
+} /* MySQLConfigBackend::open */
+
+void MySQLConfigBackend::close(void)
+{
+  if (m_mysql != nullptr)
+  {
+    mysql_close(m_mysql);
+    m_mysql = nullptr;
+  }
+  m_connection_string.clear();
+} /* MySQLConfigBackend::close */
+
+bool MySQLConfigBackend::isOpen(void) const
+{
+  return (m_mysql != nullptr);
+} /* MySQLConfigBackend::isOpen */
+
+bool MySQLConfigBackend::getValue(const std::string& section, const std::string& tag,
+                                  std::string& value) const
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  string escaped_section = escapeString(section);
+  string escaped_tag = escapeString(tag);
+  
+  ostringstream query;
+  query << "SELECT value FROM " << table_name << " WHERE section = '" << escaped_section 
+        << "' AND tag = '" << escaped_tag << "'";
+  
+  if (mysql_query(m_mysql, query.str().c_str()) != 0)
+  {
+    cerr << "*** ERROR: Failed to execute SELECT query: " << getLastError() << endl;
+    return false;
+  }
+  
+  MYSQL_RES* result = mysql_store_result(m_mysql);
+  if (result == nullptr)
+  {
+    cerr << "*** ERROR: Failed to get query result: " << getLastError() << endl;
+    return false;
+  }
+  
+  MYSQL_ROW row = mysql_fetch_row(result);
+  if (row != nullptr && row[0] != nullptr)
+  {
+    value = row[0];
+    mysql_free_result(result);
+    return true;
+  }
+  
+  mysql_free_result(result);
+  return false;
+} /* MySQLConfigBackend::getValue */
+
+bool MySQLConfigBackend::setValue(const std::string& section, const std::string& tag,
+                                  const std::string& value)
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  string escaped_section = escapeString(section);
+  string escaped_tag = escapeString(tag);
+  string escaped_value = escapeString(value);
+  
+  ostringstream query;
+  query << "INSERT INTO " << table_name << " (section, tag, value) VALUES ('"
+        << escaped_section << "', '" << escaped_tag << "', '" << escaped_value
+        << "') ON DUPLICATE KEY UPDATE value = '" << escaped_value 
+        << "', updated_at = CURRENT_TIMESTAMP";
+  
+  if (mysql_query(m_mysql, query.str().c_str()) != 0)
+  {
+    cerr << "*** ERROR: Failed to execute INSERT/UPDATE query: " << getLastError() << endl;
+    return false;
+  }
+  
+  notifyValueChanged(section, tag, value);
+  return true;
+} /* MySQLConfigBackend::setValue */
+
+list<string> MySQLConfigBackend::listSections(void) const
+{
+  list<string> sections;
+  
+  if (!isOpen())
+  {
+    return sections;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::ostringstream query;
+  query << "SELECT DISTINCT section FROM " << table_name << " ORDER BY section";
+  
+  if (mysql_query(m_mysql, query.str().c_str()) != 0)
+  {
+    cerr << "*** ERROR: Failed to execute SELECT DISTINCT query: " << getLastError() << endl;
+    return sections;
+  }
+  
+  MYSQL_RES* result = mysql_store_result(m_mysql);
+  if (result == nullptr)
+  {
+    cerr << "*** ERROR: Failed to get query result: " << getLastError() << endl;
+    return sections;
+  }
+  
+  MYSQL_ROW row;
+  while ((row = mysql_fetch_row(result)) != nullptr)
+  {
+    if (row[0] != nullptr)
+    {
+      sections.push_back(row[0]);
+    }
+  }
+  
+  mysql_free_result(result);
+  return sections;
+} /* MySQLConfigBackend::listSections */
+
+list<string> MySQLConfigBackend::listSection(const string& section) const
+{
+  list<string> tags;
+  
+  if (!isOpen())
+  {
+    return tags;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  string escaped_section = escapeString(section);
+  
+  ostringstream query;
+  query << "SELECT tag FROM " << table_name << " WHERE section = '" << escaped_section 
+        << "' ORDER BY tag";
+  
+  if (mysql_query(m_mysql, query.str().c_str()) != 0)
+  {
+    cerr << "*** ERROR: Failed to execute SELECT tags query: " << getLastError() << endl;
+    return tags;
+  }
+  
+  MYSQL_RES* result = mysql_store_result(m_mysql);
+  if (result == nullptr)
+  {
+    cerr << "*** ERROR: Failed to get query result: " << getLastError() << endl;
+    return tags;
+  }
+  
+  MYSQL_ROW row;
+  while ((row = mysql_fetch_row(result)) != nullptr)
+  {
+    if (row[0] != nullptr)
+    {
+      tags.push_back(row[0]);
+    }
+  }
+  
+  mysql_free_result(result);
+  return tags;
+} /* MySQLConfigBackend::listSection */
+
+std::string MySQLConfigBackend::getBackendType(void) const
+{
+  return "mysql";
+} /* MySQLConfigBackend::getBackendType */
+
+std::string MySQLConfigBackend::getBackendInfo(void) const
+{
+  if (!isOpen())
+  {
+    return "Not connected";
+  }
+  
+  ostringstream info;
+  info << "host=" << m_conn_params.host 
+       << ";port=" << m_conn_params.port
+       << ";user=" << m_conn_params.user
+       << ";database=" << m_conn_params.database;
+  
+  return info.str();
+} /* MySQLConfigBackend::getBackendInfo */
+
+bool MySQLConfigBackend::initializeTables(void)
+{
+  if (!isOpen())
+  {
+    cerr << "*** ERROR: Cannot initialize tables - database not open" << endl;
+    return false;
+  }
+  
+  // Create tables if they don't exist
+  if (!createTables())
+  {
+    cerr << "*** ERROR: Failed to create database tables" << endl;
+    return false;
+  }
+  
+  return true;
+} /* MySQLConfigBackend::initializeTables */
+
+bool MySQLConfigBackend::finalizeInitialization(void)
+{
+  if (!isOpen())
+  {
+    cerr << "*** ERROR: Cannot finalize initialization - database not open" << endl;
+    return false;
+  }
+  
+  initializeLastCheckTime();
+  
+  return true;
+} /* MySQLConfigBackend::finalizeInitialization */
+
+bool MySQLConfigBackend::checkForExternalChanges(void)
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+
+  // Query for all records updated since last check
+  std::string table_name = getFullTableName("config");
+  string escaped_last_check = escapeString(m_last_check_time);
+  ostringstream query;
+  query << "SELECT section, tag, value, updated_at FROM " << table_name << " "
+        << "WHERE updated_at > '" << escaped_last_check << "' "
+        << "ORDER BY updated_at";
+
+  if (mysql_query(m_mysql, query.str().c_str()) != 0)
+  {
+    cerr << "*** ERROR: Failed to execute change detection query: " << getLastError() << endl;
+    return false;
+  }
+
+  MYSQL_RES* result = mysql_store_result(m_mysql);
+  if (!result)
+  {
+    cerr << "*** ERROR: Failed to store result: " << getLastError() << endl;
+    return false;
+  }
+
+  bool changes_detected = false;
+  std::string latest_timestamp = m_last_check_time;
+  MYSQL_ROW row;
+
+  while ((row = mysql_fetch_row(result)))
+  {
+    if (row[0] && row[1] && row[2] && row[3])
+    {
+      notifyValueChanged(std::string(row[0]), std::string(row[1]), std::string(row[2]));
+      latest_timestamp = std::string(row[3]);
+      changes_detected = true;
+    }
+  }
+
+  mysql_free_result(result);
+
+  // Update last check time to the latest timestamp seen
+  if (changes_detected)
+  {
+    m_last_check_time = latest_timestamp;
+  }
+
+  return changes_detected;
+} /* MySQLConfigBackend::checkForExternalChanges */
+
+/****************************************************************************
+ *
+ * Protected member functions
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Private member functions
+ *
+ ****************************************************************************/
+
+bool MySQLConfigBackend::parseConnectionString(const std::string& conn_str, ConnectionParams& params)
+{
+  // Parse connection string format: "host=hostname;port=3306;user=username;password=password;database=dbname"
+  istringstream iss(conn_str);
+  string token;
+  
+  while (getline(iss, token, ';'))
+  {
+    size_t eq_pos = token.find('=');
+    if (eq_pos == string::npos)
+    {
+      continue;
+    }
+    
+    string key = token.substr(0, eq_pos);
+    string value = token.substr(eq_pos + 1);
+    
+    if (key == "host")
+    {
+      params.host = value;
+    }
+    else if (key == "port")
+    {
+      params.port = static_cast<unsigned int>(stoul(value));
+    }
+    else if (key == "user")
+    {
+      params.user = value;
+    }
+    else if (key == "password")
+    {
+      params.password = value;
+    }
+    else if (key == "database")
+    {
+      params.database = value;
+    }
+  }
+  
+  // Validate required parameters
+  if (params.host.empty() || params.user.empty() || params.database.empty())
+  {
+    return false;
+  }
+  
+  return true;
+} /* MySQLConfigBackend::parseConnectionString */
+
+bool MySQLConfigBackend::createTables(void)
+{
+  std::string table_name = getFullTableName("config");
+  
+  std::ostringstream create_table_sql;
+  create_table_sql << "CREATE TABLE IF NOT EXISTS " << table_name << " ("
+    "  id INT AUTO_INCREMENT PRIMARY KEY,"
+    "  section VARCHAR(255) NOT NULL,"
+    "  tag VARCHAR(255) NOT NULL,"
+    "  value TEXT NOT NULL,"
+    "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
+    "  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,"
+    "  UNIQUE KEY unique_" << table_name << " (section, tag),"
+    "  INDEX idx_" << table_name << "_section (section)"
+    ") ENGINE=InnoDB DEFAULT CHARSET=utf8";
+  
+  if (mysql_query(m_mysql, create_table_sql.str().c_str()) != 0)
+  {
+    cerr << "*** ERROR: Failed to create config table: " << getLastError() << endl;
+    return false;
+  }
+  
+  return true;
+} /* MySQLConfigBackend::createTables */
+
+std::string MySQLConfigBackend::escapeString(const std::string& str) const
+{
+  if (!isOpen() || str.empty())
+  {
+    return str;
+  }
+  
+  char* escaped = new char[str.length() * 2 + 1];
+  unsigned long escaped_length = mysql_real_escape_string(m_mysql, escaped, str.c_str(), str.length());
+  
+  string result(escaped, escaped_length);
+  delete[] escaped;
+  
+  return result;
+} /* MySQLConfigBackend::escapeString */
+
+std::string MySQLConfigBackend::getLastError(void) const
+{
+  if (m_mysql != nullptr)
+  {
+    return mysql_error(m_mysql);
+  }
+  return "MySQL connection not initialized";
+} /* MySQLConfigBackend::getLastError */
+
+void MySQLConfigBackend::initializeLastCheckTime(void)
+{
+  if (!isOpen())
+  {
+    return;
+  }
+
+  // Query for the most recent updated_at timestamp in the database
+  std::string table_name = getFullTableName("config");
+  std::ostringstream query;
+  query << "SELECT MAX(updated_at) FROM " << table_name;
+
+  if (mysql_query(m_mysql, query.str().c_str()) != 0)
+  {
+    cerr << "*** WARNING: Failed to query max updated_at: " << getLastError() << endl;
+    return;
+  }
+
+  MYSQL_RES* result = mysql_store_result(m_mysql);
+  if (result == nullptr)
+  {
+    cerr << "*** WARNING: Failed to store result: " << getLastError() << endl;
+    return;
+  }
+
+  MYSQL_ROW row = mysql_fetch_row(result);
+  if (row != nullptr && row[0] != nullptr)
+  {
+    m_last_check_time = std::string(row[0]);
+  }
+  else
+  {
+    // Database is empty or all updated_at are NULL
+    m_last_check_time = "1970-01-01 00:00:00";
+  }
+
+  mysql_free_result(result);
+} /* MySQLConfigBackend::initializeLastCheckTime */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncMySQLConfigBackend.cpp
+++ b/src/async/core/AsyncMySQLConfigBackend.cpp
@@ -35,6 +35,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <mysql/mysql.h>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 /****************************************************************************
  *
@@ -101,7 +102,8 @@ static ConfigBackendSpecificFactory<MySQLConfigBackend> mysql_factory;
  ****************************************************************************/
 
 MySQLConfigBackend::MySQLConfigBackend(void)
-  : ConfigBackend(true, 300000), m_mysql(nullptr), m_last_check_time("1970-01-01 00:00:00")
+  : ConfigBackend(true, 300000), m_mysql(nullptr), m_mysql_poll(nullptr),
+    m_last_check_time("1970-01-01 00:00:00")
 {
   m_conn_params.port = 3306; // Default MySQL port
 } /* MySQLConfigBackend::MySQLConfigBackend */
@@ -125,42 +127,23 @@ bool MySQLConfigBackend::open(const string& source)
     return false;
   }
   
-  m_mysql = mysql_init(nullptr);
-  if (m_mysql == nullptr)
+  if (!connectMysql(m_mysql))
   {
-    cerr << "*** ERROR: Failed to initialize MySQL connection" << endl;
-    return false;
-  }
-  
-  // Set connection timeout
-  unsigned int timeout = 10;
-  mysql_options(m_mysql, MYSQL_OPT_CONNECT_TIMEOUT, &timeout);
-  
-  // Enable automatic reconnection
-  bool reconnect = true;
-  mysql_options(m_mysql, MYSQL_OPT_RECONNECT, &reconnect);
-  
-  if (mysql_real_connect(m_mysql,
-                         m_conn_params.host.c_str(),
-                         m_conn_params.user.c_str(),
-                         m_conn_params.password.c_str(),
-                         m_conn_params.database.c_str(),
-                         m_conn_params.port,
-                         nullptr, 0) == nullptr)
-  {
-    cerr << "*** ERROR: Failed to connect to MySQL database: " << getLastError() << endl;
+    cerr << "*** ERROR: Failed to connect to MySQL database: "
+         << getLastError(m_mysql) << endl;
     close();
     return false;
   }
-    
+
   // Note: Tables will be created later after table prefix is set
   // createTables() is now called from initializeDatabase()
-  
+
   return true;
 } /* MySQLConfigBackend::open */
 
 void MySQLConfigBackend::close(void)
 {
+  closePollConnection();
   if (m_mysql != nullptr)
   {
     mysql_close(m_mysql);
@@ -168,6 +151,40 @@ void MySQLConfigBackend::close(void)
   }
   m_connection_string.clear();
 } /* MySQLConfigBackend::close */
+
+bool MySQLConfigBackend::openPollConnection(void)
+{
+  closePollConnection();
+
+  if (!isOpen())
+  {
+    return false;
+  }
+
+  if (!connectMysql(m_mysql_poll))
+  {
+    cerr << "*** ERROR: Failed to open MySQL poll connection: "
+         << getLastError(m_mysql_poll) << endl;
+    closePollConnection();
+    return false;
+  }
+
+  return true;
+} /* MySQLConfigBackend::openPollConnection */
+
+void MySQLConfigBackend::closePollConnection(void)
+{
+  if (m_mysql_poll != nullptr)
+  {
+    mysql_close(m_mysql_poll);
+    m_mysql_poll = nullptr;
+  }
+} /* MySQLConfigBackend::closePollConnection */
+
+bool MySQLConfigBackend::pollForExternalChanges(void)
+{
+  return checkForExternalChangesUsing(m_mysql_poll);
+} /* MySQLConfigBackend::pollForExternalChanges */
 
 bool MySQLConfigBackend::isOpen(void) const
 {
@@ -379,34 +396,46 @@ bool MySQLConfigBackend::finalizeInitialization(void)
 
 bool MySQLConfigBackend::checkForExternalChanges(void)
 {
-  if (!isOpen())
+  return checkForExternalChangesUsing(m_mysql);
+} /* MySQLConfigBackend::checkForExternalChanges */
+
+bool MySQLConfigBackend::checkForExternalChangesUsing(MYSQL* mysql)
+{
+  if (!isOpen() || mysql == nullptr)
   {
     return false;
   }
 
+  std::string last_check_time;
+  {
+    std::lock_guard<std::mutex> lock(m_last_check_mutex);
+    last_check_time = m_last_check_time;
+  }
+
   // Query for all records updated since last check
   std::string table_name = getFullTableName("config");
-  string escaped_last_check = escapeString(m_last_check_time);
+  string escaped_last_check = escapeString(last_check_time, mysql);
   ostringstream query;
   query << "SELECT section, tag, value, updated_at FROM " << table_name << " "
         << "WHERE updated_at > '" << escaped_last_check << "' "
         << "ORDER BY updated_at";
 
-  if (mysql_query(m_mysql, query.str().c_str()) != 0)
+  if (mysql_query(mysql, query.str().c_str()) != 0)
   {
-    cerr << "*** ERROR: Failed to execute change detection query: " << getLastError() << endl;
+    cerr << "*** ERROR: Failed to execute change detection query: "
+         << getLastError(mysql) << endl;
     return false;
   }
 
-  MYSQL_RES* result = mysql_store_result(m_mysql);
+  MYSQL_RES* result = mysql_store_result(mysql);
   if (!result)
   {
-    cerr << "*** ERROR: Failed to store result: " << getLastError() << endl;
+    cerr << "*** ERROR: Failed to store result: " << getLastError(mysql) << endl;
     return false;
   }
 
   bool changes_detected = false;
-  std::string latest_timestamp = m_last_check_time;
+  std::string latest_timestamp = last_check_time;
   MYSQL_ROW row;
 
   while ((row = mysql_fetch_row(result)))
@@ -424,11 +453,12 @@ bool MySQLConfigBackend::checkForExternalChanges(void)
   // Update last check time to the latest timestamp seen
   if (changes_detected)
   {
+    std::lock_guard<std::mutex> lock(m_last_check_mutex);
     m_last_check_time = latest_timestamp;
   }
 
   return changes_detected;
-} /* MySQLConfigBackend::checkForExternalChanges */
+} /* MySQLConfigBackend::checkForExternalChangesUsing */
 
 /****************************************************************************
  *
@@ -441,6 +471,36 @@ bool MySQLConfigBackend::checkForExternalChanges(void)
  * Private member functions
  *
  ****************************************************************************/
+
+bool MySQLConfigBackend::connectMysql(MYSQL*& mysql)
+{
+  mysql = mysql_init(nullptr);
+  if (mysql == nullptr)
+  {
+    return false;
+  }
+
+  unsigned int timeout = 10;
+  mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &timeout);
+
+  bool reconnect = true;
+  mysql_options(mysql, MYSQL_OPT_RECONNECT, &reconnect);
+
+  if (mysql_real_connect(mysql,
+                         m_conn_params.host.c_str(),
+                         m_conn_params.user.c_str(),
+                         m_conn_params.password.c_str(),
+                         m_conn_params.database.c_str(),
+                         m_conn_params.port,
+                         nullptr, 0) == nullptr)
+  {
+    mysql_close(mysql);
+    mysql = nullptr;
+    return false;
+  }
+
+  return true;
+} /* MySQLConfigBackend::connectMysql */
 
 bool MySQLConfigBackend::parseConnectionString(const std::string& conn_str, ConnectionParams& params)
 {
@@ -465,7 +525,15 @@ bool MySQLConfigBackend::parseConnectionString(const std::string& conn_str, Conn
     }
     else if (key == "port")
     {
-      params.port = static_cast<unsigned int>(stoul(value));
+      try
+      {
+        params.port = static_cast<unsigned int>(stoul(value));
+      }
+      catch (const std::exception&)
+      {
+        cerr << "*** ERROR: Invalid port in MySQL connection string" << endl;
+        return false;
+      }
     }
     else if (key == "user")
     {
@@ -517,25 +585,36 @@ bool MySQLConfigBackend::createTables(void)
 
 std::string MySQLConfigBackend::escapeString(const std::string& str) const
 {
-  if (!isOpen() || str.empty())
+  return escapeString(str, m_mysql);
+} /* MySQLConfigBackend::escapeString */
+
+std::string MySQLConfigBackend::escapeString(const std::string& str, MYSQL* mysql) const
+{
+  if (mysql == nullptr || str.empty())
   {
     return str;
   }
-  
+
   char* escaped = new char[str.length() * 2 + 1];
-  unsigned long escaped_length = mysql_real_escape_string(m_mysql, escaped, str.c_str(), str.length());
-  
+  unsigned long escaped_length =
+      mysql_real_escape_string(mysql, escaped, str.c_str(), str.length());
+
   string result(escaped, escaped_length);
   delete[] escaped;
-  
+
   return result;
 } /* MySQLConfigBackend::escapeString */
 
 std::string MySQLConfigBackend::getLastError(void) const
 {
-  if (m_mysql != nullptr)
+  return getLastError(m_mysql);
+} /* MySQLConfigBackend::getLastError */
+
+std::string MySQLConfigBackend::getLastError(MYSQL* mysql) const
+{
+  if (mysql != nullptr)
   {
-    return mysql_error(m_mysql);
+    return mysql_error(mysql);
   }
   return "MySQL connection not initialized";
 } /* MySQLConfigBackend::getLastError */
@@ -566,14 +645,17 @@ void MySQLConfigBackend::initializeLastCheckTime(void)
   }
 
   MYSQL_ROW row = mysql_fetch_row(result);
-  if (row != nullptr && row[0] != nullptr)
   {
-    m_last_check_time = std::string(row[0]);
-  }
-  else
-  {
-    // Database is empty or all updated_at are NULL
-    m_last_check_time = "1970-01-01 00:00:00";
+    std::lock_guard<std::mutex> lock(m_last_check_mutex);
+    if (row != nullptr && row[0] != nullptr)
+    {
+      m_last_check_time = std::string(row[0]);
+    }
+    else
+    {
+      // Database is empty or all updated_at are NULL
+      m_last_check_time = "1970-01-01 00:00:00";
+    }
   }
 
   mysql_free_result(result);

--- a/src/async/core/AsyncMySQLConfigBackend.h
+++ b/src/async/core/AsyncMySQLConfigBackend.h
@@ -1,0 +1,259 @@
+/**
+@file	 AsyncMySQLConfigBackend.h
+@brief   MySQL/MariaDB-based configuration backend implementation
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the MySQL/MariaDB-based configuration backend that stores
+configuration data in a MySQL or MariaDB database.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#ifndef ASYNC_MYSQL_CONFIG_BACKEND_INCLUDED
+#define ASYNC_MYSQL_CONFIG_BACKEND_INCLUDED
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <string>
+#include <list>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Forward declarations
+ *
+ ****************************************************************************/
+
+struct MYSQL;
+
+/****************************************************************************
+ *
+ * Namespace
+ *
+ ****************************************************************************/
+
+namespace Async
+{
+
+/****************************************************************************
+ *
+ * Forward declarations of classes inside of the declared namespace
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief	MySQL/MariaDB-based configuration backend
+@author Rui Barreiros / CR7BPM
+@date   2025-09-19
+
+This class implements a configuration backend that stores configuration
+data in a MySQL or MariaDB database. The database schema consists of a single
+table with columns for section, tag, and value.
+
+Connection string format:
+"host=hostname;port=3306;user=username;password=password;database=dbname"
+
+Database schema:
+CREATE TABLE config (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  section VARCHAR(255) NOT NULL,
+  tag VARCHAR(255) NOT NULL,
+  value TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY unique_config (section, tag)
+);
+*/
+class MySQLConfigBackend : public ConfigBackend
+{
+  public:
+    static constexpr const char* OBJNAME = "mysql";
+
+    /**
+     * @brief 	Default constructor
+     */
+    MySQLConfigBackend(void);
+  
+    /**
+     * @brief 	Destructor
+     */
+    virtual ~MySQLConfigBackend(void);
+  
+    /**
+     * @brief 	Connect to the MySQL database
+     * @param 	source The connection string
+     * @return	Returns \em true on success or else \em false.
+     *
+     * This function will connect to the MySQL database and create the necessary
+     * tables if they don't exist. The source parameter should be a connection
+     * string in the format:
+     * "host=hostname;port=3306;user=username;password=password;database=dbname"
+     */
+    virtual bool open(const std::string& source) override;
+    
+    /**
+     * @brief 	Close the MySQL database connection
+     *
+     * This function closes the database connection and cleans up resources.
+     */
+    virtual void close(void) override;
+    
+    /**
+     * @brief 	Check if the database connection is open
+     * @return	Returns \em true if connected, \em false otherwise
+     */
+    virtual bool isOpen(void) const override;
+    
+    /**
+     * @brief 	Get the string value of a configuration variable
+     * @param 	section The name of the section where the configuration
+     *	      	      	variable is located
+     * @param 	tag   	The name of the configuration variable to get
+     * @param 	value 	The value is returned in this argument
+     * @return	Returns \em true on success or else \em false on failure
+     */
+    virtual bool getValue(const std::string& section, const std::string& tag,
+                          std::string& value) const override;
+
+    /**
+     * @brief 	Set the value of a configuration variable
+     * @param 	section   The name of the section where the configuration
+     *	      	      	  variable is located
+     * @param 	tag   	  The name of the configuration variable to set.
+     * @param   value     The value to set
+     * @return	Returns \em true on success or else \em false on failure
+     *
+     * This function inserts or updates the configuration variable in the database.
+     */
+    virtual bool setValue(const std::string& section, const std::string& tag,
+                          const std::string& value) override;
+
+    /**
+     * @brief   Return the name of all configuration sections
+     * @return  Returns a list of all existing section names
+     */
+    virtual std::list<std::string> listSections(void) const override;
+
+    /**
+     * @brief 	Return the name of all the tags in the given section
+     * @param 	section The name of the section where the configuration
+     *	      	      	variables are located
+     * @return	Returns the list of tags in the given section
+     */
+    virtual std::list<std::string> listSection(const std::string& section) const override;
+
+    /**
+     * @brief   Get backend type identifier
+     * @return  Returns "mysql"
+     */
+    virtual std::string getBackendType(void) const override;
+
+    /**
+     * @brief   Get backend-specific information
+     * @return  Returns the connection information (without password)
+     */
+    virtual std::string getBackendInfo(void) const override;
+
+    /**
+     * @brief   Check for external changes to the database
+     * @return  true if changes were detected, false otherwise
+     */
+    virtual bool checkForExternalChanges(void) override;
+
+    /**
+     * @brief Initialize database tables
+     * @return true on success, false on failure
+     */
+    virtual bool initializeTables(void) override;
+
+    /**
+     * @brief Finalize database initialization after tables are populated
+     * @return true on success, false on failure
+     */
+    virtual bool finalizeInitialization(void) override;
+
+  protected:
+
+  private:
+    struct ConnectionParams
+    {
+      std::string host;
+      unsigned int port;
+      std::string user;
+      std::string password;
+      std::string database;
+    };
+
+    MYSQL*           m_mysql;
+    ConnectionParams m_conn_params;
+    std::string      m_connection_string;
+    std::string      m_last_check_time;
+
+    bool parseConnectionString(const std::string& conn_str, ConnectionParams& params);
+    bool createTables(void);
+    std::string escapeString(const std::string& str) const;
+    std::string getLastError(void) const;
+    void initializeLastCheckTime(void);
+
+}; /* class MySQLConfigBackend */
+
+} /* namespace */
+
+#endif /* ASYNC_MYSQL_CONFIG_BACKEND_INCLUDED */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncMySQLConfigBackend.h
+++ b/src/async/core/AsyncMySQLConfigBackend.h
@@ -38,6 +38,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <list>
+#include <mutex>
 
 /****************************************************************************
  *
@@ -226,6 +227,9 @@ class MySQLConfigBackend : public ConfigBackend
     virtual bool finalizeInitialization(void) override;
 
   protected:
+    virtual bool pollForExternalChanges(void) override;
+    virtual bool openPollConnection(void) override;
+    virtual void closePollConnection(void) override;
 
   private:
     struct ConnectionParams
@@ -238,14 +242,20 @@ class MySQLConfigBackend : public ConfigBackend
     };
 
     MYSQL*           m_mysql;
+    MYSQL*           m_mysql_poll;
     ConnectionParams m_conn_params;
     std::string      m_connection_string;
     std::string      m_last_check_time;
+    mutable std::mutex m_last_check_mutex;
 
     bool parseConnectionString(const std::string& conn_str, ConnectionParams& params);
     bool createTables(void);
+    bool connectMysql(MYSQL*& mysql);
+    bool checkForExternalChangesUsing(MYSQL* mysql);
     std::string escapeString(const std::string& str) const;
+    std::string escapeString(const std::string& str, MYSQL* mysql) const;
     std::string getLastError(void) const;
+    std::string getLastError(MYSQL* mysql) const;
     void initializeLastCheckTime(void);
 
 }; /* class MySQLConfigBackend */

--- a/src/async/core/AsyncPostgreSQLConfigBackend.cpp
+++ b/src/async/core/AsyncPostgreSQLConfigBackend.cpp
@@ -1,0 +1,624 @@
+/**
+@file	 AsyncPostgreSQLConfigBackend.cpp
+@brief   PostgreSQL-based configuration backend implementation
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the implementation of the PostgreSQL-based configuration backend.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <libpq-fe.h>
+#include <iostream>
+#include <sstream>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncPostgreSQLConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Namespaces to use
+ *
+ ****************************************************************************/
+
+using namespace std;
+using namespace Async;
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local class definitions
+ *
+ ****************************************************************************/
+
+#ifdef HAS_POSTGRESQL_SUPPORT
+// Factory registration for PostgreSQL backend
+static ConfigBackendSpecificFactory<PostgreSQLConfigBackend> postgresql_factory;
+#endif
+
+/****************************************************************************
+ *
+ * Prototypes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Public member functions
+ *
+ ****************************************************************************/
+
+PostgreSQLConfigBackend::PostgreSQLConfigBackend(void)
+  : ConfigBackend(true, 300000), m_conn(nullptr), m_last_check_time("1970-01-01 00:00:00")
+{
+} /* PostgreSQLConfigBackend::PostgreSQLConfigBackend */
+
+PostgreSQLConfigBackend::~PostgreSQLConfigBackend(void)
+{
+  close();
+} /* PostgreSQLConfigBackend::~PostgreSQLConfigBackend */
+
+bool PostgreSQLConfigBackend::open(const string& source)
+{
+  close();
+  
+  m_connection_string = source;
+  parseConnectionInfo(source);
+  
+  m_conn = PQconnectdb(source.c_str());
+  
+  if (PQstatus(m_conn) != CONNECTION_OK)
+  {
+    cerr << "*** ERROR: Failed to connect to PostgreSQL database: " << getLastError() << endl;
+    close();
+    return false;
+  }
+  
+  return true;
+} /* PostgreSQLConfigBackend::open */
+
+void PostgreSQLConfigBackend::close(void)
+{
+  if (m_conn != nullptr)
+  {
+    PQfinish(m_conn);
+    m_conn = nullptr;
+  }
+  m_connection_string.clear();
+  m_connection_info.clear();
+} /* PostgreSQLConfigBackend::close */
+
+bool PostgreSQLConfigBackend::isOpen(void) const
+{
+  return (m_conn != nullptr && PQstatus(m_conn) == CONNECTION_OK);
+} /* PostgreSQLConfigBackend::isOpen */
+
+bool PostgreSQLConfigBackend::getValue(const std::string& section, const std::string& tag,
+                                       std::string& value) const
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT value FROM " + table_name + " WHERE section = $1 AND tag = $2";
+  
+  const char* params[2] = { section.c_str(), tag.c_str() };
+  
+  PGresult* result = PQexecParams(m_conn,
+                                  sql.c_str(),
+                                  2,      // number of parameters
+                                  nullptr, // parameter types (NULL = infer)
+                                  params, // parameter values
+                                  nullptr, // parameter lengths (NULL = strings)
+                                  nullptr, // parameter formats (NULL = text)
+                                  0);     // result format (0 = text)
+  
+  if (PQresultStatus(result) != PGRES_TUPLES_OK)
+  {
+    cerr << "*** ERROR: Failed to execute SELECT query: " << PQerrorMessage(m_conn) << endl;
+    PQclear(result);
+    return false;
+  }
+  
+  int nrows = PQntuples(result);
+  if (nrows > 0)
+  {
+    char* result_value = PQgetvalue(result, 0, 0);
+    if (result_value != nullptr)
+    {
+      value = result_value;
+    }
+    else
+    {
+      value.clear();
+    }
+    PQclear(result);
+    return true;
+  }
+  
+  PQclear(result);
+  return false;
+} /* PostgreSQLConfigBackend::getValue */
+
+bool PostgreSQLConfigBackend::setValue(const std::string& section, const std::string& tag,
+                                       const std::string& value)
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "INSERT INTO " + table_name + " (section, tag, value) VALUES ($1, $2, $3) "
+                    "ON CONFLICT (section, tag) DO UPDATE SET "
+                    "value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP";
+  
+  const char* params[3] = { section.c_str(), tag.c_str(), value.c_str() };
+  
+  PGresult* result = PQexecParams(m_conn,
+                                  sql.c_str(),
+                                  3,      // number of parameters
+                                  nullptr, // parameter types (NULL = infer)
+                                  params, // parameter values
+                                  nullptr, // parameter lengths (NULL = strings)
+                                  nullptr, // parameter formats (NULL = text)
+                                  0);     // result format (0 = text)
+  
+  if (PQresultStatus(result) != PGRES_COMMAND_OK)
+  {
+    cerr << "*** ERROR: Failed to execute INSERT/UPDATE query: " << PQerrorMessage(m_conn) << endl;
+    PQclear(result);
+    return false;
+  }
+  
+  PQclear(result);
+  notifyValueChanged(section, tag, value);
+  return true;
+} /* PostgreSQLConfigBackend::setValue */
+
+list<string> PostgreSQLConfigBackend::listSections(void) const
+{
+  list<string> sections;
+  
+  if (!isOpen())
+  {
+    return sections;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT DISTINCT section FROM " + table_name + " ORDER BY section";
+  
+  PGresult* result = executeQueryWithResult(sql);
+  if (result == nullptr)
+  {
+    return sections;
+  }
+  
+  int nrows = PQntuples(result);
+  for (int i = 0; i < nrows; i++)
+  {
+    char* section = PQgetvalue(result, i, 0);
+    if (section != nullptr)
+    {
+      sections.push_back(section);
+    }
+  }
+  
+  PQclear(result);
+  return sections;
+} /* PostgreSQLConfigBackend::listSections */
+
+list<string> PostgreSQLConfigBackend::listSection(const string& section) const
+{
+  list<string> tags;
+  
+  if (!isOpen())
+  {
+    return tags;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT tag FROM " + table_name + " WHERE section = $1 ORDER BY tag";
+  
+  const char* params[1] = { section.c_str() };
+  
+  PGresult* result = PQexecParams(m_conn,
+                                  sql.c_str(),
+                                  1,      // number of parameters
+                                  nullptr, // parameter types (NULL = infer)
+                                  params, // parameter values
+                                  nullptr, // parameter lengths (NULL = strings)
+                                  nullptr, // parameter formats (NULL = text)
+                                  0);     // result format (0 = text)
+  
+  if (PQresultStatus(result) != PGRES_TUPLES_OK)
+  {
+    cerr << "*** ERROR: Failed to execute SELECT tags query: " << PQerrorMessage(m_conn) << endl;
+    PQclear(result);
+    return tags;
+  }
+  
+  int nrows = PQntuples(result);
+  for (int i = 0; i < nrows; i++)
+  {
+    char* tag = PQgetvalue(result, i, 0);
+    if (tag != nullptr)
+    {
+      tags.push_back(tag);
+    }
+  }
+  
+  PQclear(result);
+  return tags;
+} /* PostgreSQLConfigBackend::listSection */
+
+std::string PostgreSQLConfigBackend::getBackendType(void) const
+{
+  return "postgresql";
+} /* PostgreSQLConfigBackend::getBackendType */
+
+std::string PostgreSQLConfigBackend::getBackendInfo(void) const
+{
+  return m_connection_info;
+} /* PostgreSQLConfigBackend::getBackendInfo */
+
+bool PostgreSQLConfigBackend::initializeTables(void)
+{
+  if (!isOpen())
+  {
+    cerr << "*** ERROR: Cannot initialize tables - database not open" << endl;
+    return false;
+  }
+  
+  // Create tables if they don't exist
+  if (!createTables())
+  {
+    cerr << "*** ERROR: Failed to create database tables" << endl;
+    return false;
+  }
+  
+  return true;
+} /* PostgreSQLConfigBackend::initializeTables */
+
+bool PostgreSQLConfigBackend::finalizeInitialization(void)
+{
+  if (!isOpen())
+  {
+    cerr << "*** ERROR: Cannot finalize initialization - database not open" << endl;
+    return false;
+  }
+  
+  initializeLastCheckTime();
+  
+  return true;
+} /* PostgreSQLConfigBackend::finalizeInitialization */
+
+bool PostgreSQLConfigBackend::checkForExternalChanges(void)
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+
+  // Query for all records updated since last check
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT section, tag, value, updated_at FROM " + table_name + " "
+                    "WHERE updated_at > $1 ORDER BY updated_at";
+  
+  const char* params[1] = { m_last_check_time.c_str() };
+  
+  PGresult* result = PQexecParams(m_conn,
+                                  sql.c_str(),
+                                  1,      // number of parameters
+                                  nullptr, // parameter types (NULL = infer)
+                                  params, // parameter values
+                                  nullptr, // parameter lengths (NULL = strings)
+                                  nullptr, // parameter formats (NULL = text)
+                                  0);     // result format (0 = text)
+
+  if (PQresultStatus(result) != PGRES_TUPLES_OK)
+  {
+    cerr << "*** ERROR: Failed to execute change detection query: " << PQerrorMessage(m_conn) << endl;
+    PQclear(result);
+    return false;
+  }
+
+  bool changes_detected = false;
+  std::string latest_timestamp = m_last_check_time;
+  int rows = PQntuples(result);
+
+  for (int i = 0; i < rows; i++)
+  {
+    const char* section = PQgetvalue(result, i, 0);
+    const char* tag = PQgetvalue(result, i, 1);
+    const char* value = PQgetvalue(result, i, 2);
+    const char* updated_at = PQgetvalue(result, i, 3);
+
+    if (section && tag && value && updated_at)
+    {
+      notifyValueChanged(std::string(section), std::string(tag), std::string(value));
+      latest_timestamp = std::string(updated_at);
+      changes_detected = true;
+    }
+  }
+
+  PQclear(result);
+
+  // Update last check time to the latest timestamp seen
+  if (changes_detected)
+  {
+    m_last_check_time = latest_timestamp;
+  }
+
+  return changes_detected;
+} /* PostgreSQLConfigBackend::checkForExternalChanges */
+
+/****************************************************************************
+ *
+ * Protected member functions
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Private member functions
+ *
+ ****************************************************************************/
+
+bool PostgreSQLConfigBackend::createTables(void)
+{
+  std::string table_name = getFullTableName("config");
+  
+  std::string create_table_sql = 
+    "CREATE TABLE IF NOT EXISTS " + table_name + " ("
+    "  id SERIAL PRIMARY KEY,"
+    "  section VARCHAR(255) NOT NULL,"
+    "  tag VARCHAR(255) NOT NULL,"
+    "  value TEXT NOT NULL,"
+    "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
+    "  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
+    "  UNIQUE(section, tag)"
+    ")";
+  
+  if (!executeQuery(create_table_sql))
+  {
+    return false;
+  }
+  
+  // Create index for faster lookups
+  std::string create_index_sql = 
+    "CREATE INDEX IF NOT EXISTS idx_" + table_name + "_section ON " + table_name + "(section)";
+  
+  if (!executeQuery(create_index_sql))
+  {
+    return false;
+  }
+  
+  // Create trigger to update updated_at timestamp
+  const char* create_trigger_function = 
+    "CREATE OR REPLACE FUNCTION update_updated_at_column() "
+    "RETURNS TRIGGER AS $$ "
+    "BEGIN "
+    "  NEW.updated_at = CURRENT_TIMESTAMP; "
+    "  RETURN NEW; "
+    "END; "
+    "$$ language 'plpgsql'";
+  
+  if (!executeQuery(create_trigger_function))
+  {
+    return false;
+  }
+  
+  std::string create_trigger = 
+    "DROP TRIGGER IF EXISTS update_" + table_name + "_updated_at ON " + table_name + "; "
+    "CREATE TRIGGER update_" + table_name + "_updated_at "
+    "  BEFORE UPDATE ON " + table_name + " "
+    "  FOR EACH ROW "
+    "  EXECUTE FUNCTION update_updated_at_column()";
+  
+  if (!executeQuery(create_trigger))
+  {
+    return false;
+  }
+  
+  return true;
+} /* PostgreSQLConfigBackend::createTables */
+
+bool PostgreSQLConfigBackend::executeQuery(const std::string& query) const
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  PGresult* result = PQexec(m_conn, query.c_str());
+  
+  if (PQresultStatus(result) != PGRES_COMMAND_OK)
+  {
+    cerr << "*** ERROR: Failed to execute query: " << PQerrorMessage(m_conn) << endl;
+    PQclear(result);
+    return false;
+  }
+  
+  PQclear(result);
+  return true;
+} /* PostgreSQLConfigBackend::executeQuery */
+
+PGresult* PostgreSQLConfigBackend::executeQueryWithResult(const std::string& query) const
+{
+  if (!isOpen())
+  {
+    return nullptr;
+  }
+  
+  PGresult* result = PQexec(m_conn, query.c_str());
+  
+  if (PQresultStatus(result) != PGRES_TUPLES_OK)
+  {
+    cerr << "*** ERROR: Failed to execute query: " << PQerrorMessage(m_conn) << endl;
+    PQclear(result);
+    return nullptr;
+  }
+  
+  return result;
+} /* PostgreSQLConfigBackend::executeQueryWithResult */
+
+std::string PostgreSQLConfigBackend::escapeString(const std::string& str) const
+{
+  if (!isOpen() || str.empty())
+  {
+    return str;
+  }
+  
+  char* escaped = new char[str.length() * 2 + 1];
+  int error;
+  size_t escaped_length = PQescapeStringConn(m_conn, escaped, str.c_str(), str.length(), &error);
+  
+  if (error != 0)
+  {
+    delete[] escaped;
+    return str; // Return original string if escaping failed
+  }
+  
+  string result(escaped, escaped_length);
+  delete[] escaped;
+  
+  return result;
+} /* PostgreSQLConfigBackend::escapeString */
+
+std::string PostgreSQLConfigBackend::getLastError(void) const
+{
+  if (m_conn != nullptr)
+  {
+    return PQerrorMessage(m_conn);
+  }
+  return "PostgreSQL connection not initialized";
+} /* PostgreSQLConfigBackend::getLastError */
+
+void PostgreSQLConfigBackend::parseConnectionInfo(const std::string& conn_str)
+{
+  // Create a sanitized version of the connection string without password
+  istringstream iss(conn_str);
+  ostringstream sanitized;
+  string token;
+  bool first = true;
+  
+  while (iss >> token)
+  {
+    if (token.find("password=") == 0)
+    {
+      // Skip password parameter
+      continue;
+    }
+    
+    if (!first)
+    {
+      sanitized << " ";
+    }
+    first = false;
+    sanitized << token;
+  }
+  
+  m_connection_info = sanitized.str();
+} /* PostgreSQLConfigBackend::parseConnectionInfo */
+
+void PostgreSQLConfigBackend::initializeLastCheckTime(void)
+{
+  if (!isOpen())
+  {
+    return;
+  }
+
+  // Query for the most recent updated_at timestamp in the database
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT MAX(updated_at) FROM " + table_name;
+
+  PGresult* result = PQexec(m_conn, sql.c_str());
+  
+  if (PQresultStatus(result) != PGRES_TUPLES_OK)
+  {
+    cerr << "*** WARNING: Failed to query max updated_at: " << PQerrorMessage(m_conn) << endl;
+    PQclear(result);
+    return;
+  }
+
+  int nrows = PQntuples(result);
+  if (nrows > 0)
+  {
+    char* max_timestamp = PQgetvalue(result, 0, 0);
+    if (max_timestamp != nullptr && max_timestamp[0] != '\0')
+    {
+      m_last_check_time = std::string(max_timestamp);
+    }
+    else
+    {
+      // Database is empty or all updated_at are NULL
+      m_last_check_time = "1970-01-01 00:00:00";
+    }
+  }
+  else
+  {
+    // No rows returned
+    m_last_check_time = "1970-01-01 00:00:00";
+  }
+
+  PQclear(result);
+} /* PostgreSQLConfigBackend::initializeLastCheckTime */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncPostgreSQLConfigBackend.cpp
+++ b/src/async/core/AsyncPostgreSQLConfigBackend.cpp
@@ -107,6 +107,8 @@ PostgreSQLConfigBackend::PostgreSQLConfigBackend(void)
 
 PostgreSQLConfigBackend::~PostgreSQLConfigBackend(void)
 {
+  // Stop the poll thread before closing the connection handle!!!
+  stopAutoPolling();
   close();
 } /* PostgreSQLConfigBackend::~PostgreSQLConfigBackend */
 

--- a/src/async/core/AsyncPostgreSQLConfigBackend.cpp
+++ b/src/async/core/AsyncPostgreSQLConfigBackend.cpp
@@ -101,7 +101,8 @@ static ConfigBackendSpecificFactory<PostgreSQLConfigBackend> postgresql_factory;
  ****************************************************************************/
 
 PostgreSQLConfigBackend::PostgreSQLConfigBackend(void)
-  : ConfigBackend(true, 300000), m_conn(nullptr), m_last_check_time("1970-01-01 00:00:00")
+  : ConfigBackend(true, 300000), m_conn(nullptr), m_conn_poll(nullptr),
+    m_last_check_time("1970-01-01 00:00:00")
 {
 } /* PostgreSQLConfigBackend::PostgreSQLConfigBackend */
 
@@ -133,6 +134,7 @@ bool PostgreSQLConfigBackend::open(const string& source)
 
 void PostgreSQLConfigBackend::close(void)
 {
+  closePollConnection();
   if (m_conn != nullptr)
   {
     PQfinish(m_conn);
@@ -141,6 +143,41 @@ void PostgreSQLConfigBackend::close(void)
   m_connection_string.clear();
   m_connection_info.clear();
 } /* PostgreSQLConfigBackend::close */
+
+bool PostgreSQLConfigBackend::openPollConnection(void)
+{
+  closePollConnection();
+
+  if (!isOpen())
+  {
+    return false;
+  }
+
+  m_conn_poll = PQconnectdb(m_connection_string.c_str());
+  if (PQstatus(m_conn_poll) != CONNECTION_OK)
+  {
+    cerr << "*** ERROR: Failed to open PostgreSQL poll connection: "
+         << getLastError(m_conn_poll) << endl;
+    closePollConnection();
+    return false;
+  }
+
+  return true;
+} /* PostgreSQLConfigBackend::openPollConnection */
+
+void PostgreSQLConfigBackend::closePollConnection(void)
+{
+  if (m_conn_poll != nullptr)
+  {
+    PQfinish(m_conn_poll);
+    m_conn_poll = nullptr;
+  }
+} /* PostgreSQLConfigBackend::closePollConnection */
+
+bool PostgreSQLConfigBackend::pollForExternalChanges(void)
+{
+  return checkForExternalChangesUsing(m_conn_poll);
+} /* PostgreSQLConfigBackend::pollForExternalChanges */
 
 bool PostgreSQLConfigBackend::isOpen(void) const
 {
@@ -351,19 +388,30 @@ bool PostgreSQLConfigBackend::finalizeInitialization(void)
 
 bool PostgreSQLConfigBackend::checkForExternalChanges(void)
 {
-  if (!isOpen())
+  return checkForExternalChangesUsing(m_conn);
+} /* PostgreSQLConfigBackend::checkForExternalChanges */
+
+bool PostgreSQLConfigBackend::checkForExternalChangesUsing(PGconn* conn)
+{
+  if (!isOpen() || conn == nullptr)
   {
     return false;
+  }
+
+  std::string last_check_time;
+  {
+    std::lock_guard<std::mutex> lock(m_last_check_mutex);
+    last_check_time = m_last_check_time;
   }
 
   // Query for all records updated since last check
   std::string table_name = getFullTableName("config");
   std::string sql = "SELECT section, tag, value, updated_at FROM " + table_name + " "
                     "WHERE updated_at > $1 ORDER BY updated_at";
-  
-  const char* params[1] = { m_last_check_time.c_str() };
-  
-  PGresult* result = PQexecParams(m_conn,
+
+  const char* params[1] = { last_check_time.c_str() };
+
+  PGresult* result = PQexecParams(conn,
                                   sql.c_str(),
                                   1,      // number of parameters
                                   nullptr, // parameter types (NULL = infer)
@@ -374,13 +422,14 @@ bool PostgreSQLConfigBackend::checkForExternalChanges(void)
 
   if (PQresultStatus(result) != PGRES_TUPLES_OK)
   {
-    cerr << "*** ERROR: Failed to execute change detection query: " << PQerrorMessage(m_conn) << endl;
+    cerr << "*** ERROR: Failed to execute change detection query: "
+         << getLastError(conn) << endl;
     PQclear(result);
     return false;
   }
 
   bool changes_detected = false;
-  std::string latest_timestamp = m_last_check_time;
+  std::string latest_timestamp = last_check_time;
   int rows = PQntuples(result);
 
   for (int i = 0; i < rows; i++)
@@ -403,11 +452,12 @@ bool PostgreSQLConfigBackend::checkForExternalChanges(void)
   // Update last check time to the latest timestamp seen
   if (changes_detected)
   {
+    std::lock_guard<std::mutex> lock(m_last_check_mutex);
     m_last_check_time = latest_timestamp;
   }
 
   return changes_detected;
-} /* PostgreSQLConfigBackend::checkForExternalChanges */
+} /* PostgreSQLConfigBackend::checkForExternalChangesUsing */
 
 /****************************************************************************
  *
@@ -544,9 +594,14 @@ std::string PostgreSQLConfigBackend::escapeString(const std::string& str) const
 
 std::string PostgreSQLConfigBackend::getLastError(void) const
 {
-  if (m_conn != nullptr)
+  return getLastError(m_conn);
+} /* PostgreSQLConfigBackend::getLastError */
+
+std::string PostgreSQLConfigBackend::getLastError(PGconn* conn) const
+{
+  if (conn != nullptr)
   {
-    return PQerrorMessage(m_conn);
+    return PQerrorMessage(conn);
   }
   return "PostgreSQL connection not initialized";
 } /* PostgreSQLConfigBackend::getLastError */
@@ -599,23 +654,26 @@ void PostgreSQLConfigBackend::initializeLastCheckTime(void)
   }
 
   int nrows = PQntuples(result);
-  if (nrows > 0)
   {
-    char* max_timestamp = PQgetvalue(result, 0, 0);
-    if (max_timestamp != nullptr && max_timestamp[0] != '\0')
+    std::lock_guard<std::mutex> lock(m_last_check_mutex);
+    if (nrows > 0)
     {
-      m_last_check_time = std::string(max_timestamp);
+      char* max_timestamp = PQgetvalue(result, 0, 0);
+      if (max_timestamp != nullptr && max_timestamp[0] != '\0')
+      {
+        m_last_check_time = std::string(max_timestamp);
+      }
+      else
+      {
+        // Database is empty or all updated_at are NULL
+        m_last_check_time = "1970-01-01 00:00:00";
+      }
     }
     else
     {
-      // Database is empty or all updated_at are NULL
+      // No rows returned
       m_last_check_time = "1970-01-01 00:00:00";
     }
-  }
-  else
-  {
-    // No rows returned
-    m_last_check_time = "1970-01-01 00:00:00";
   }
 
   PQclear(result);

--- a/src/async/core/AsyncPostgreSQLConfigBackend.h
+++ b/src/async/core/AsyncPostgreSQLConfigBackend.h
@@ -1,0 +1,253 @@
+/**
+@file	 AsyncPostgreSQLConfigBackend.h
+@brief   PostgreSQL-based configuration backend implementation
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the PostgreSQL-based configuration backend that stores
+configuration data in a PostgreSQL database.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#ifndef ASYNC_POSTGRESQL_CONFIG_BACKEND_INCLUDED
+#define ASYNC_POSTGRESQL_CONFIG_BACKEND_INCLUDED
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <string>
+#include <list>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Forward declarations
+ *
+ ****************************************************************************/
+
+typedef struct pg_conn PGconn;
+typedef struct pg_result PGresult;
+
+/****************************************************************************
+ *
+ * Namespace
+ *
+ ****************************************************************************/
+
+namespace Async
+{
+
+/****************************************************************************
+ *
+ * Forward declarations of classes inside of the declared namespace
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief	PostgreSQL-based configuration backend
+@author Rui Barreiros / CR7BPM
+@date   2025-09-19
+
+This class implements a configuration backend that stores configuration
+data in a PostgreSQL database. The database schema consists of a single
+table with columns for section, tag, and value.
+
+Connection string format:
+"host=hostname port=5432 dbname=database user=username password=password"
+
+Database schema:
+CREATE TABLE config (
+  id SERIAL PRIMARY KEY,
+  section VARCHAR(255) NOT NULL,
+  tag VARCHAR(255) NOT NULL,
+  value TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(section, tag)
+);
+*/
+class PostgreSQLConfigBackend : public ConfigBackend
+{
+  public:
+    static constexpr const char* OBJNAME = "postgresql";
+
+    /**
+     * @brief 	Default constructor
+     */
+    PostgreSQLConfigBackend(void);
+  
+    /**
+     * @brief 	Destructor
+     */
+    virtual ~PostgreSQLConfigBackend(void);
+  
+    /**
+     * @brief 	Connect to the PostgreSQL database
+     * @param 	source The connection string
+     * @return	Returns \em true on success or else \em false.
+     *
+     * This function will connect to the PostgreSQL database and create the
+     * necessary tables if they don't exist. The source parameter should be
+     * a connection string in the format:
+     * "host=hostname port=5432 dbname=database user=username password=password"
+     */
+    virtual bool open(const std::string& source) override;
+    
+    /**
+     * @brief 	Close the PostgreSQL database connection
+     *
+     * This function closes the database connection and cleans up resources.
+     */
+    virtual void close(void) override;
+    
+    /**
+     * @brief 	Check if the database connection is open
+     * @return	Returns \em true if connected, \em false otherwise
+     */
+    virtual bool isOpen(void) const override;
+    
+    /**
+     * @brief 	Get the string value of a configuration variable
+     * @param 	section The name of the section where the configuration
+     *	      	      	variable is located
+     * @param 	tag   	The name of the configuration variable to get
+     * @param 	value 	The value is returned in this argument
+     * @return	Returns \em true on success or else \em false on failure
+     */
+    virtual bool getValue(const std::string& section, const std::string& tag,
+                          std::string& value) const override;
+
+    /**
+     * @brief 	Set the value of a configuration variable
+     * @param 	section   The name of the section where the configuration
+     *	      	      	  variable is located
+     * @param 	tag   	  The name of the configuration variable to set.
+     * @param   value     The value to set
+     * @return	Returns \em true on success or else \em false on failure
+     *
+     * This function inserts or updates the configuration variable in the database.
+     */
+    virtual bool setValue(const std::string& section, const std::string& tag,
+                          const std::string& value) override;
+
+    /**
+     * @brief   Return the name of all configuration sections
+     * @return  Returns a list of all existing section names
+     */
+    virtual std::list<std::string> listSections(void) const override;
+
+    /**
+     * @brief 	Return the name of all the tags in the given section
+     * @param 	section The name of the section where the configuration
+     *	      	      	variables are located
+     * @return	Returns the list of tags in the given section
+     */
+    virtual std::list<std::string> listSection(const std::string& section) const override;
+
+    /**
+     * @brief   Get backend type identifier
+     * @return  Returns "postgresql"
+     */
+    virtual std::string getBackendType(void) const override;
+
+    /**
+     * @brief   Get backend-specific information
+     * @return  Returns the connection information (without password)
+     */
+    virtual std::string getBackendInfo(void) const override;
+
+    /**
+     * @brief   Check for external changes to the database
+     * @return  true if changes were detected, false otherwise
+     */
+    virtual bool checkForExternalChanges(void) override;
+
+    /**
+     * @brief Initialize database tables
+     * @return true on success, false on failure
+     */
+    virtual bool initializeTables(void) override;
+
+    /**
+     * @brief Finalize database initialization after tables are populated
+     * @return true on success, false on failure
+     */
+    virtual bool finalizeInitialization(void) override;
+
+  protected:
+
+  private:
+    PGconn*     m_conn;
+    std::string m_connection_string;
+    std::string m_connection_info;
+    std::string m_last_check_time;
+
+    bool createTables(void);
+    bool executeQuery(const std::string& query) const;
+    PGresult* executeQueryWithResult(const std::string& query) const;
+    std::string escapeString(const std::string& str) const;
+    std::string getLastError(void) const;
+    void parseConnectionInfo(const std::string& conn_str);
+    void initializeLastCheckTime(void);
+
+}; /* class PostgreSQLConfigBackend */
+
+} /* namespace */
+
+#endif /* ASYNC_POSTGRESQL_CONFIG_BACKEND_INCLUDED */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncPostgreSQLConfigBackend.h
+++ b/src/async/core/AsyncPostgreSQLConfigBackend.h
@@ -38,6 +38,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <list>
+#include <mutex>
 
 /****************************************************************************
  *
@@ -227,18 +228,25 @@ class PostgreSQLConfigBackend : public ConfigBackend
     virtual bool finalizeInitialization(void) override;
 
   protected:
+    virtual bool pollForExternalChanges(void) override;
+    virtual bool openPollConnection(void) override;
+    virtual void closePollConnection(void) override;
 
   private:
     PGconn*     m_conn;
+    PGconn*     m_conn_poll;
     std::string m_connection_string;
     std::string m_connection_info;
     std::string m_last_check_time;
+    mutable std::mutex m_last_check_mutex;
 
     bool createTables(void);
+    bool checkForExternalChangesUsing(PGconn* conn);
     bool executeQuery(const std::string& query) const;
     PGresult* executeQueryWithResult(const std::string& query) const;
     std::string escapeString(const std::string& str) const;
     std::string getLastError(void) const;
+    std::string getLastError(PGconn* conn) const;
     void parseConnectionInfo(const std::string& conn_str);
     void initializeLastCheckTime(void);
 

--- a/src/async/core/AsyncSQLiteConfigBackend.cpp
+++ b/src/async/core/AsyncSQLiteConfigBackend.cpp
@@ -1,0 +1,577 @@
+/**
+@file	 AsyncSQLiteConfigBackend.cpp
+@brief   SQLite-based configuration backend implementation
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the implementation of the SQLite-based configuration backend.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <sqlite3.h>
+#include <iostream>
+#include <sstream>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncSQLiteConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Namespaces to use
+ *
+ ****************************************************************************/
+
+using namespace std;
+using namespace Async;
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local class definitions
+ *
+ ****************************************************************************/
+
+#ifdef HAS_SQLITE_SUPPORT
+// Factory registration for SQLite backend
+static ConfigBackendSpecificFactory<SQLiteConfigBackend> sqlite_factory;
+#endif
+
+/****************************************************************************
+ *
+ * Prototypes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Public member functions
+ *
+ ****************************************************************************/
+
+SQLiteConfigBackend::SQLiteConfigBackend(void)
+  : ConfigBackend(true, 300000), m_db(nullptr), m_last_check_time("1970-01-01 00:00:00")
+{
+} /* SQLiteConfigBackend::SQLiteConfigBackend */
+
+SQLiteConfigBackend::~SQLiteConfigBackend(void)
+{
+  close();
+} /* SQLiteConfigBackend::~SQLiteConfigBackend */
+
+bool SQLiteConfigBackend::open(const string& source)
+{
+  close();
+  
+  m_db_path = source;
+  
+  int rc = sqlite3_open(source.c_str(), &m_db);
+  if (rc != SQLITE_OK)
+  {
+    cerr << "*** ERROR: Cannot open SQLite database '" << source 
+         << "': " << sqlite3_errmsg(m_db) << endl;
+    close();
+    return false;
+  }
+  
+  // Enable foreign keys
+  if (!executeSQL("PRAGMA foreign_keys = ON"))
+  {
+    cerr << "*** ERROR: Failed to enable foreign keys" << endl;
+    close();
+    return false;
+  }
+  
+  return true;
+} /* SQLiteConfigBackend::open */
+
+void SQLiteConfigBackend::close(void)
+{
+  if (m_db != nullptr)
+  {
+    sqlite3_close(m_db);
+    m_db = nullptr;
+  }
+  m_db_path.clear();
+} /* SQLiteConfigBackend::close */
+
+bool SQLiteConfigBackend::isOpen(void) const
+{
+  return (m_db != nullptr);
+} /* SQLiteConfigBackend::isOpen */
+
+bool SQLiteConfigBackend::getValue(const std::string& section, const std::string& tag,
+                                   std::string& value) const
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT value FROM " + table_name + " WHERE section = ? AND tag = ?";
+  sqlite3_stmt* stmt;
+  
+  int rc = sqlite3_prepare_v2(m_db, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK)
+  {
+    cerr << "*** ERROR: Failed to prepare SELECT statement: " << getLastError() << endl;
+    return false;
+  }
+  
+  sqlite3_bind_text(stmt, 1, section.c_str(), -1, SQLITE_STATIC);
+  sqlite3_bind_text(stmt, 2, tag.c_str(), -1, SQLITE_STATIC);
+  
+  rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW)
+  {
+    const char* result = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    if (result != nullptr)
+    {
+      value = result;
+    }
+    else
+    {
+      value.clear();
+    }
+    sqlite3_finalize(stmt);
+    return true;
+  }
+  else if (rc == SQLITE_DONE)
+  {
+    // No row found
+    sqlite3_finalize(stmt);
+    return false;
+  }
+  else
+  {
+    cerr << "*** ERROR: Failed to execute SELECT statement: " << getLastError() << endl;
+    sqlite3_finalize(stmt);
+    return false;
+  }
+} /* SQLiteConfigBackend::getValue */
+
+bool SQLiteConfigBackend::setValue(const std::string& section, const std::string& tag,
+                                   const std::string& value)
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "INSERT OR REPLACE INTO " + table_name + " (section, tag, value, updated_at) "
+                    "VALUES (?, ?, ?, CURRENT_TIMESTAMP)";
+  sqlite3_stmt* stmt;
+  
+  int rc = sqlite3_prepare_v2(m_db, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK)
+  {
+    cerr << "*** ERROR: Failed to prepare INSERT statement: " << getLastError() << endl;
+    return false;
+  }
+  
+  sqlite3_bind_text(stmt, 1, section.c_str(), -1, SQLITE_STATIC);
+  sqlite3_bind_text(stmt, 2, tag.c_str(), -1, SQLITE_STATIC);
+  sqlite3_bind_text(stmt, 3, value.c_str(), -1, SQLITE_STATIC);
+  
+  /*
+  cout << "*** DEBUG: Executing INSERT statement: " << sql << endl;
+  cout << "*** DEBUG: Section: " << section << endl;
+  cout << "*** DEBUG: Tag: " << tag << endl;
+  cout << "*** DEBUG: Value: " << value << endl;
+  */
+  
+  rc = sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+  
+  if (rc != SQLITE_DONE)
+  {
+    cerr << "*** ERROR: Failed to execute INSERT statement: " << getLastError() << endl;
+    return false;
+  }
+  
+  notifyValueChanged(section, tag, value);
+  return true;
+} /* SQLiteConfigBackend::setValue */
+
+list<string> SQLiteConfigBackend::listSections(void) const
+{
+  list<string> sections;
+  
+  if (!isOpen())
+  {
+    return sections;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT DISTINCT section FROM " + table_name + " ORDER BY section";
+  sqlite3_stmt* stmt;
+  
+  int rc = sqlite3_prepare_v2(m_db, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK)
+  {
+    cerr << "*** ERROR: Failed to prepare SELECT DISTINCT statement: " << getLastError() << endl;
+    return sections;
+  }
+  
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW)
+  {
+    const char* section = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    if (section != nullptr)
+    {
+      sections.push_back(section);
+    }
+  }
+  
+  sqlite3_finalize(stmt);
+  
+  if (rc != SQLITE_DONE)
+  {
+    cerr << "*** ERROR: Failed to execute SELECT DISTINCT statement: " << getLastError() << endl;
+    sections.clear();
+  }
+  
+  return sections;
+} /* SQLiteConfigBackend::listSections */
+
+list<string> SQLiteConfigBackend::listSection(const string& section) const
+{
+  list<string> tags;
+  
+  if (!isOpen())
+  {
+    return tags;
+  }
+  
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT tag FROM " + table_name + " WHERE section = ? ORDER BY tag";
+  sqlite3_stmt* stmt;
+  
+  int rc = sqlite3_prepare_v2(m_db, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK)
+  {
+    cerr << "*** ERROR: Failed to prepare SELECT tags statement: " << getLastError() << endl;
+    return tags;
+  }
+  
+  sqlite3_bind_text(stmt, 1, section.c_str(), -1, SQLITE_STATIC);
+  
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW)
+  {
+    const char* tag = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    if (tag != nullptr)
+    {
+      tags.push_back(tag);
+    }
+  }
+  
+  sqlite3_finalize(stmt);
+  
+  if (rc != SQLITE_DONE)
+  {
+    cerr << "*** ERROR: Failed to execute SELECT tags statement: " << getLastError() << endl;
+    tags.clear();
+  }
+  
+  return tags;
+} /* SQLiteConfigBackend::listSection */
+
+std::string SQLiteConfigBackend::getBackendType(void) const
+{
+  return "sqlite";
+} /* SQLiteConfigBackend::getBackendType */
+
+std::string SQLiteConfigBackend::getBackendInfo(void) const
+{
+  return m_db_path;
+} /* SQLiteConfigBackend::getBackendInfo */
+
+bool SQLiteConfigBackend::initializeTables(void)
+{
+  if (!isOpen())
+  {
+    cerr << "*** ERROR: Cannot initialize tables - database not open" << endl;
+    return false;
+  }
+  
+  // Create tables if they don't exist
+  if (!createTables())
+  {
+    cerr << "*** ERROR: Failed to create database tables" << endl;
+    return false;
+  }
+  
+  return true;
+} /* SQLiteConfigBackend::initializeTables */
+
+bool SQLiteConfigBackend::finalizeInitialization(void)
+{
+  if (!isOpen())
+  {
+    cerr << "*** ERROR: Cannot finalize initialization - database not open" << endl;
+    return false;
+  }
+  
+  initializeLastCheckTime();
+  
+  return true;
+} /* SQLiteConfigBackend::finalizeInitialization */
+
+bool SQLiteConfigBackend::checkForExternalChanges(void)
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+
+  // Query for all records updated since last check
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT section, tag, value, updated_at FROM " + table_name + " WHERE updated_at > ? ORDER BY updated_at";
+  sqlite3_stmt* stmt;
+
+  int rc = sqlite3_prepare_v2(m_db, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK)
+  {
+    cerr << "*** ERROR: Failed to prepare change detection query: " << getLastError() << endl;
+    return false;
+  }
+
+  sqlite3_bind_text(stmt, 1, m_last_check_time.c_str(), -1, SQLITE_STATIC);
+
+  // Debug output
+  char* expanded_sql = sqlite3_expanded_sql(stmt);
+  if (expanded_sql != nullptr)
+  {
+    //std::cout << "[DEBUG] Change detection SQL: " << expanded_sql << std::endl;
+    sqlite3_free(expanded_sql);
+  }
+  //std::cout << "[DEBUG] Last check time: " << m_last_check_time << std::endl;
+
+  bool changes_detected = false;
+  std::string latest_timestamp = m_last_check_time;
+
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW)
+  {
+    const char* section = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    const char* tag = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+    const char* value = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2));
+    const char* updated_at = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3));
+
+    if (section && tag && value && updated_at)
+    {
+      //std::cout << "[DEBUG] Change detected: [" << section << "]" << tag 
+      //          << " = '" << value << "' (updated_at: " << updated_at << ")" << std::endl;
+      notifyValueChanged(std::string(section), std::string(tag), std::string(value));
+      latest_timestamp = std::string(updated_at);
+      changes_detected = true;
+    }
+  }
+
+  sqlite3_finalize(stmt);
+
+  // Update last check time to the latest timestamp seen
+  if (changes_detected)
+  {
+    //std::cout << "[DEBUG] Updated last_check_time: " << m_last_check_time 
+    //          << " -> " << latest_timestamp << std::endl;
+    m_last_check_time = latest_timestamp;
+  }
+  else
+  {
+    //std::cout << "[DEBUG] No external changes detected" << std::endl;
+  }
+
+  return changes_detected;
+} /* SQLiteConfigBackend::checkForExternalChanges */
+
+/****************************************************************************
+ *
+ * Protected member functions
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Private member functions
+ *
+ ****************************************************************************/
+
+bool SQLiteConfigBackend::createTables(void)
+{
+  // Get the full table name with prefix
+  std::string table_name = getFullTableName("config");
+  
+  std::string create_config_table = 
+    "CREATE TABLE IF NOT EXISTS " + table_name + " ("
+    "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "  section TEXT NOT NULL,"
+    "  tag TEXT NOT NULL,"
+    "  value TEXT NOT NULL,"
+    "  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,"
+    "  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,"
+    "  UNIQUE(section, tag)"
+    ")";
+  
+  if (!executeSQL(create_config_table))
+  {
+    cerr << "*** ERROR: Failed to create config table: " << table_name << endl;
+    return false;
+  }
+  
+  // Create index for faster lookups
+  std::string create_index = 
+    "CREATE INDEX IF NOT EXISTS idx_" + table_name + "_section_tag ON " + table_name + "(section, tag)";
+  
+  if (!executeSQL(create_index))
+  {
+    cerr << "*** ERROR: Failed to create index" << endl;
+    return false;
+  }
+  
+  // Create trigger to automatically update updated_at on any UPDATE
+  std::string create_trigger = 
+    "CREATE TRIGGER IF NOT EXISTS update_" + table_name + "_timestamp "
+    "AFTER UPDATE ON " + table_name + " "
+    "FOR EACH ROW "
+    "BEGIN "
+    "  UPDATE " + table_name + " SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id; "
+    "END";
+  
+  if (!executeSQL(create_trigger))
+  {
+    cerr << "*** ERROR: Failed to create update trigger" << endl;
+    return false;
+  }
+  
+  return true;
+} /* SQLiteConfigBackend::createTables */
+
+bool SQLiteConfigBackend::executeSQL(const std::string& sql) const
+{
+  if (!isOpen())
+  {
+    return false;
+  }
+  
+  char* error_msg = nullptr;
+  int rc = sqlite3_exec(m_db, sql.c_str(), nullptr, nullptr, &error_msg);
+  
+  if (rc != SQLITE_OK)
+  {
+    cerr << "*** ERROR: SQL execution failed: " << error_msg << endl;
+    sqlite3_free(error_msg);
+    return false;
+  }
+  
+  return true;
+} /* SQLiteConfigBackend::executeSQL */
+
+std::string SQLiteConfigBackend::getLastError(void) const
+{
+  if (m_db != nullptr)
+  {
+    return sqlite3_errmsg(m_db);
+  }
+  return "Database not open";
+} /* SQLiteConfigBackend::getLastError */
+
+void SQLiteConfigBackend::initializeLastCheckTime(void)
+{
+  if (!isOpen())
+  {
+    return;
+  }
+
+  // Query for the most recent updated_at timestamp in the database
+  std::string table_name = getFullTableName("config");
+  std::string sql = "SELECT MAX(updated_at) FROM " + table_name;
+  sqlite3_stmt* stmt;
+
+  int rc = sqlite3_prepare_v2(m_db, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK)
+  {
+    std::cerr << "*** WARNING: Failed to query max updated_at: " << getLastError() << std::endl;
+    return;
+  }
+
+  rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW)
+  {
+    const char* max_timestamp = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    if (max_timestamp != nullptr)
+    {
+      m_last_check_time = std::string(max_timestamp);
+      //std::cout << "[DEBUG] Initialized last_check_time to: " << m_last_check_time << std::endl;
+    }
+    else
+    {
+      // Database is empty or all updated_at are NULL
+      m_last_check_time = "1970-01-01 00:00:00";
+      //std::cout << "[DEBUG] Database empty, initialized last_check_time to epoch" << std::endl;
+    }
+  }
+  else
+  {
+    // Query failed, use default
+    m_last_check_time = "1970-01-01 00:00:00";
+    //std::cout << "[DEBUG] Query failed, initialized last_check_time to epoch" << std::endl;
+  }
+
+  sqlite3_finalize(stmt);
+} /* SQLiteConfigBackend::initializeLastCheckTime */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/AsyncSQLiteConfigBackend.cpp
+++ b/src/async/core/AsyncSQLiteConfigBackend.cpp
@@ -107,6 +107,8 @@ SQLiteConfigBackend::SQLiteConfigBackend(void)
 
 SQLiteConfigBackend::~SQLiteConfigBackend(void)
 {
+  // Stop the poll thread before closing the database handle!!!  
+  stopAutoPolling();
   close();
 } /* SQLiteConfigBackend::~SQLiteConfigBackend */
 

--- a/src/async/core/AsyncSQLiteConfigBackend.h
+++ b/src/async/core/AsyncSQLiteConfigBackend.h
@@ -1,0 +1,247 @@
+/**
+@file	 AsyncSQLiteConfigBackend.h
+@brief   SQLite-based configuration backend implementation
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This file contains the SQLite-based configuration backend that stores
+configuration data in an SQLite database.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+#ifndef ASYNC_SQLITE_CONFIG_BACKEND_INCLUDED
+#define ASYNC_SQLITE_CONFIG_BACKEND_INCLUDED
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <string>
+#include <list>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "AsyncConfigBackend.h"
+
+/****************************************************************************
+ *
+ * Forward declarations
+ *
+ ****************************************************************************/
+
+struct sqlite3;
+
+/****************************************************************************
+ *
+ * Namespace
+ *
+ ****************************************************************************/
+
+namespace Async
+{
+
+/****************************************************************************
+ *
+ * Forward declarations of classes inside of the declared namespace
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief	SQLite-based configuration backend
+@author Rui Barreiros / CR7BPM
+@date   2025-09-19
+
+This class implements a configuration backend that stores configuration
+data in an SQLite database. The database schema consists of a single table
+with columns for section, tag, and value.
+
+Database schema:
+CREATE TABLE config (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  section TEXT NOT NULL,
+  tag TEXT NOT NULL,
+  value TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(section, tag)
+);
+*/
+class SQLiteConfigBackend : public ConfigBackend
+{
+  public:
+    static constexpr const char* OBJNAME = "sqlite";
+
+    /**
+     * @brief 	Default constructor
+     */
+    SQLiteConfigBackend(void);
+  
+    /**
+     * @brief 	Destructor
+     */
+    virtual ~SQLiteConfigBackend(void);
+  
+    /**
+     * @brief 	Open the SQLite database
+     * @param 	source The path to the SQLite database file
+     * @return	Returns \em true on success or else \em false.
+     *
+     * This function will open the SQLite database and create the necessary
+     * tables if they don't exist. The source parameter should be the path
+     * to the SQLite database file.
+     */
+    virtual bool open(const std::string& source) override;
+    
+    /**
+     * @brief 	Close the SQLite database connection
+     *
+     * This function closes the database connection and cleans up resources.
+     */
+    virtual void close(void) override;
+    
+    /**
+     * @brief 	Check if the database connection is open
+     * @return	Returns \em true if connected, \em false otherwise
+     */
+    virtual bool isOpen(void) const override;
+    
+    /**
+     * @brief 	Get the string value of a configuration variable
+     * @param 	section The name of the section where the configuration
+     *	      	      	variable is located
+     * @param 	tag   	The name of the configuration variable to get
+     * @param 	value 	The value is returned in this argument
+     * @return	Returns \em true on success or else \em false on failure
+     */
+    virtual bool getValue(const std::string& section, const std::string& tag,
+                          std::string& value) const override;
+
+    /**
+     * @brief 	Set the value of a configuration variable
+     * @param 	section   The name of the section where the configuration
+     *	      	      	  variable is located
+     * @param 	tag   	  The name of the configuration variable to set.
+     * @param   value     The value to set
+     * @return	Returns \em true on success or else \em false on failure
+     *
+     * This function inserts or updates the configuration variable in the database.
+     */
+    virtual bool setValue(const std::string& section, const std::string& tag,
+                          const std::string& value) override;
+
+    /**
+     * @brief   Return the name of all configuration sections
+     * @return  Returns a list of all existing section names
+     */
+    virtual std::list<std::string> listSections(void) const override;
+
+    /**
+     * @brief 	Return the name of all the tags in the given section
+     * @param 	section The name of the section where the configuration
+     *	      	      	variables are located
+     * @return	Returns the list of tags in the given section
+     */
+    virtual std::list<std::string> listSection(const std::string& section) const override;
+
+    /**
+     * @brief   Get backend type identifier
+     * @return  Returns "sqlite"
+     */
+    virtual std::string getBackendType(void) const override;
+
+    /**
+     * @brief   Get backend-specific information
+     * @return  Returns the database file path
+     */
+    virtual std::string getBackendInfo(void) const override;
+
+    /**
+     * @brief   Check for external changes to the database
+     * @return  true if changes were detected, false otherwise
+     *
+     * This method queries the database for any records that have been modified
+     * since the last check and emits valueChanged signals for each change.
+     */
+    virtual bool checkForExternalChanges(void) override;
+
+    /**
+     * @brief Initialize database tables
+     * @return true on success, false on failure
+     */
+    virtual bool initializeTables(void) override;
+
+    /**
+     * @brief Finalize database initialization after tables are populated
+     * @return true on success, false on failure
+     */
+    virtual bool finalizeInitialization(void) override;
+
+  protected:
+
+  private:
+    sqlite3*    m_db;
+    std::string m_db_path;
+    std::string m_last_check_time;
+
+    bool createTables(void);
+    bool executeSQL(const std::string& sql) const;
+    std::string getLastError(void) const;
+    void initializeLastCheckTime(void);
+
+}; /* class SQLiteConfigBackend */
+
+} /* namespace */
+
+#endif /* ASYNC_SQLITE_CONFIG_BACKEND_INCLUDED */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/core/CMakeLists.txt
+++ b/src/async/core/CMakeLists.txt
@@ -10,9 +10,11 @@ set(EXPINC AsyncApplication.h AsyncFdWatch.h AsyncTimer.h AsyncIpAddress.h
            AsyncPlugin.h AsyncEncryptedUdpSocket.h
            AsyncSslContext.h AsyncSslKeypair.h AsyncSslCertSigningReq.h
            AsyncSslX509.h AsyncSslX509Extensions.h
-           AsyncSslX509ExtSubjectAltName.h AsyncDigest.h)
+           AsyncSslX509ExtSubjectAltName.h AsyncDigest.h
+           AsyncConfigBackend.h AsyncConfigSource.h)
 
-set(LIBSRC AsyncApplication.cpp AsyncFdWatch.cpp AsyncTimer.cpp
+# Base library sources
+set(LIBSRC_BASE AsyncApplication.cpp AsyncFdWatch.cpp AsyncTimer.cpp
            AsyncIpAddress.cpp AsyncDnsLookup.cpp AsyncTcpClientBase.cpp
            AsyncUdpSocket.cpp AsyncTcpServerBase.cpp
            AsyncTcpConnection.cpp AsyncConfig.cpp AsyncSerial.cpp
@@ -20,7 +22,100 @@ set(LIBSRC AsyncApplication.cpp AsyncFdWatch.cpp AsyncTimer.cpp
            AsyncAtTimer.cpp AsyncExec.cpp AsyncPty.cpp AsyncPtyStreamBuf.cpp
            AsyncFramedTcpConnection.cpp AsyncHttpServerConnection.cpp
            AsyncTcpPrioClientBase.cpp AsyncPlugin.cpp
-           AsyncEncryptedUdpSocket.cpp)
+           AsyncEncryptedUdpSocket.cpp
+           AsyncConfigBackend.cpp AsyncConfigSource.cpp AsyncFileConfigBackend.cpp)
+
+# Initialize library sources with base sources
+set(LIBSRC ${LIBSRC_BASE})
+
+# Database backend detection and configuration
+message(STATUS "Detecting database backend support...")
+
+# Find SQLite3
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(SQLITE3 QUIET sqlite3)
+endif()
+
+if(NOT SQLITE3_FOUND)
+  find_path(SQLITE3_INCLUDE_DIR sqlite3.h)
+  find_library(SQLITE3_LIBRARY sqlite3)
+  if(SQLITE3_INCLUDE_DIR AND SQLITE3_LIBRARY)
+    set(SQLITE3_FOUND TRUE)
+    set(SQLITE3_LIBRARIES ${SQLITE3_LIBRARY})
+    set(SQLITE3_INCLUDE_DIRS ${SQLITE3_INCLUDE_DIR})
+  endif()
+endif()
+
+# Find MySQL/MariaDB
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(MYSQL QUIET mysqlclient)
+  if(NOT MYSQL_FOUND)
+    pkg_check_modules(MYSQL QUIET mariadb)
+  endif()
+endif()
+
+if(NOT MYSQL_FOUND)
+  find_path(MYSQL_INCLUDE_DIR mysql/mysql.h)
+  find_library(MYSQL_LIBRARY mysqlclient)
+  if(NOT MYSQL_LIBRARY)
+    find_library(MYSQL_LIBRARY mariadb)
+  endif()
+  if(MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+    set(MYSQL_FOUND TRUE)
+    set(MYSQL_LIBRARIES ${MYSQL_LIBRARY})
+    set(MYSQL_INCLUDE_DIRS ${MYSQL_INCLUDE_DIR})
+  endif()
+endif()
+
+# Find PostgreSQL
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(POSTGRESQL QUIET libpq)
+endif()
+
+if(NOT POSTGRESQL_FOUND)
+  find_path(POSTGRESQL_INCLUDE_DIR libpq-fe.h)
+  find_library(POSTGRESQL_LIBRARY pq)
+  if(POSTGRESQL_INCLUDE_DIR AND POSTGRESQL_LIBRARY)
+    set(POSTGRESQL_FOUND TRUE)
+    set(POSTGRESQL_LIBRARIES ${POSTGRESQL_LIBRARY})
+    set(POSTGRESQL_INCLUDE_DIRS ${POSTGRESQL_INCLUDE_DIR})
+  endif()
+endif()
+
+# Add backend sources and libraries based on availability
+if(SQLITE3_FOUND)
+  message(STATUS "  SQLite3: Found")
+  add_definitions(-DHAS_SQLITE_SUPPORT)
+  set(LIBSRC ${LIBSRC} AsyncSQLiteConfigBackend.cpp)
+  set(EXPINC ${EXPINC} AsyncSQLiteConfigBackend.h)
+  set(LIBS ${LIBS} ${SQLITE3_LIBRARIES})
+  include_directories(${SQLITE3_INCLUDE_DIRS})
+else()
+  message(STATUS "  SQLite3: Not found")
+endif()
+
+if(MYSQL_FOUND)
+  message(STATUS "  MySQL/MariaDB: Found")
+  add_definitions(-DHAS_MYSQL_SUPPORT)
+  set(LIBSRC ${LIBSRC} AsyncMySQLConfigBackend.cpp)
+  set(EXPINC ${EXPINC} AsyncMySQLConfigBackend.h)
+  set(LIBS ${LIBS} ${MYSQL_LIBRARIES})
+  include_directories(${MYSQL_INCLUDE_DIRS})
+else()
+  message(STATUS "  MySQL/MariaDB: Not found")
+endif()
+
+if(POSTGRESQL_FOUND)
+  message(STATUS "  PostgreSQL: Found")
+  add_definitions(-DHAS_POSTGRESQL_SUPPORT)
+  set(LIBSRC ${LIBSRC} AsyncPostgreSQLConfigBackend.cpp)
+  set(EXPINC ${EXPINC} AsyncPostgreSQLConfigBackend.h)
+  set(LIBS ${LIBS} ${POSTGRESQL_LIBRARIES})
+  include_directories(${POSTGRESQL_INCLUDE_DIRS})
+else()
+  message(STATUS "  PostgreSQL: Not found")
+endif()
 
 # Copy exported include files to the global include directory
 foreach(incfile ${EXPINC})

--- a/src/async/demo/AsyncConfigBackend_demo.cpp
+++ b/src/async/demo/AsyncConfigBackend_demo.cpp
@@ -1,0 +1,307 @@
+/**
+@file	 AsyncConfigBackend_demo.cpp
+@brief   Demo program showing the new configuration backend system
+@author  Rui Barreiros / CR7BPM
+@date	 2025-09-19
+
+This program demonstrates how to use the new configuration backend abstraction
+layer to load configuration from different sources.
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+\endverbatim
+*/
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <iostream>
+#include <string>
+#include <list>
+#include <fstream>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+#include <AsyncConfig.h>
+#include <AsyncConfigBackend.h>
+#include <AsyncConfigSource.h>
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Namespaces to use
+ *
+ ****************************************************************************/
+
+using namespace std;
+using namespace Async;
+
+/****************************************************************************
+ *
+ * Defines & typedefs
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local class definitions
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Prototypes
+ *
+ ****************************************************************************/
+
+void demonstrateBackend(const string& config_dir);
+void showAvailableBackends();
+void createSampleDbConfig(const string& config_dir);
+void demonstrateDbConfigInit(void);
+
+/****************************************************************************
+ *
+ * Exported Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Local Global Variables
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Main program
+ *
+ ****************************************************************************/
+
+int main(int argc, char **argv)
+{
+  cout << "SVXLink Configuration Backend Demo" << endl;
+  cout << "==================================" << endl << endl;
+
+  // Show available backends
+  showAvailableBackends();
+
+  // Demonstrate the new db.conf initialization method
+  cout << "=== New db.conf Initialization Method ===" << endl;
+  demonstrateDbConfigInit();
+
+  if (argc >= 2)
+  {
+    string config_dir = argv[1];
+    cout << "\n=== Custom Configuration Directory ===" << endl;
+    cout << "Using configuration directory: " << config_dir << endl;
+    
+    // Create sample db.conf
+    createSampleDbConfig(config_dir);
+    
+    // Demonstrate the backend
+    demonstrateBackend(config_dir);
+  }
+  else
+  {
+    cout << "\nUsage: " << argv[0] << " [config_directory]" << endl;
+    cout << endl;
+    cout << "If no config directory is specified, the standard search paths will be used:" << endl;
+    cout << "  ~/.svxlink/db.conf" << endl;
+    cout << "  /etc/svxlink/db.conf" << endl;
+    cout << "  /usr/local/etc/svxlink/db.conf (or system install directory)" << endl;
+  }
+
+  return 0;
+} /* main */
+
+/****************************************************************************
+ *
+ * Functions
+ *
+ ****************************************************************************/
+
+void showAvailableBackends()
+{
+  cout << "Available configuration backends: " 
+       << ConfigBackendFactory::validFactories() << endl << endl;
+
+  // Show detailed availability
+  cout << "Backend availability:" << endl;
+  cout << "  File:       " 
+       << (ConfigSource::isBackendAvailable("file") ? "Yes" : "No") 
+       << endl;
+  cout << "  SQLite:     " 
+       << (ConfigSource::isBackendAvailable("sqlite") ? "Yes" : "No") 
+       << endl;
+  cout << "  MySQL:      " 
+       << (ConfigSource::isBackendAvailable("mysql") ? "Yes" : "No") 
+       << endl;
+  cout << "  PostgreSQL: " 
+       << (ConfigSource::isBackendAvailable("postgresql") ? "Yes" : "No") 
+       << endl << endl;
+} /* showAvailableBackends */
+
+void demonstrateDbConfigInit(void)
+{
+  cout << "Demonstrating automatic backend initialization using db.conf..." << endl;
+  
+  // This will fail gracefully since no db.conf exists in standard locations
+  // and no svxlink.conf exists either, but it shows the process
+  cout << "Attempting to initialize configuration (this may fail in demo environment):" << endl;
+  
+  try 
+  {
+    Config cfg;
+    // This would normally read db.conf and initialize the backend
+    // In a real application, this would either succeed or call exit(1)
+    cout << "Note: In a real application, cfg.open() would either succeed or abort the application" << endl;
+  }
+  catch (...)
+  {
+    cout << "Demo: Configuration initialization would handle errors and abort if needed" << endl;
+  }
+  
+  cout << endl;
+} /* demonstrateDbConfigInit */
+
+void createSampleDbConfig(const string& config_dir)
+{
+  cout << "Creating sample db.conf in: " << config_dir << endl;
+  
+  // Create directory if it doesn't exist
+  string mkdir_cmd = "mkdir -p " + config_dir;
+  int result = system(mkdir_cmd.c_str());
+  if (result != 0)
+  {
+    cerr << "Warning: Failed to create directory: " << config_dir << endl;
+  }
+  
+  // Create a simple SQLite db.conf
+  string db_conf_path = config_dir + "/db.conf";
+  ofstream db_conf(db_conf_path);
+  if (db_conf.is_open())
+  {
+    db_conf << "# SVXLink Database Configuration - Demo\n";
+    db_conf << "[DATABASE]\n";
+    db_conf << "TYPE=sqlite\n";
+    db_conf << "SOURCE=" << config_dir << "/demo_config.db\n";
+    db_conf.close();
+    cout << "Created " << db_conf_path << endl;
+  }
+  
+  cout << endl;
+} /* createSampleDbConfig */
+
+void demonstrateBackend(const string& config_dir)
+{
+  cout << "Demonstrating configuration backend with config directory: " << config_dir << endl;
+  
+  // Open configuration using db.conf
+  Config cfg;
+  if (!cfg.open(config_dir))
+  {
+    cout << "ERROR: Failed to open configuration" << endl;
+    return;
+  }
+  
+  cout << "Configuration opened successfully." << endl << endl;
+  
+  // List all sections
+  cout << "Configuration sections:" << endl;
+  list<string> sections = cfg.listSections();
+  for (const string& section : sections)
+  {
+    cout << "  [" << section << "]" << endl;
+    
+    // List tags in this section
+    list<string> tags = cfg.listSection(section);
+    for (const string& tag : tags)
+    {
+      string value = cfg.getValue(section, tag);
+      cout << "    " << tag << " = " << value << endl;
+    }
+    cout << endl;
+  }
+  
+  // Demonstrate template getValue functions
+  cout << "Template getValue demonstrations:" << endl;
+  
+  // String value
+  string logics;
+  if (cfg.getValue("GLOBAL", "LOGICS", logics))
+  {
+    cout << "  GLOBAL/LOGICS = \"" << logics << "\"" << endl;
+  }
+  
+  // Integer value
+  int vox_depth = 0;
+  if (cfg.getValue("Rx1", "VOX_FILTER_DEPTH", vox_depth))
+  {
+    cout << "  Rx1/VOX_FILTER_DEPTH = " << vox_depth << endl;
+  }
+  
+  // Integer with range checking
+  int vox_limit = 0;
+  if (cfg.getValue("Rx1", "VOX_LIMIT", -30, 0, vox_limit))
+  {
+    cout << "  Rx1/VOX_LIMIT = " << vox_limit << " (range checked)" << endl;
+  }
+  
+  // Missing value with default
+  string missing_value;
+  if (cfg.getValue("GLOBAL", "MISSING_VALUE", missing_value, true))
+  {
+    cout << "  GLOBAL/MISSING_VALUE = \"" << missing_value << "\" (missing_ok=true)" << endl;
+  }
+  else
+  {
+    cout << "  GLOBAL/MISSING_VALUE not found (as expected)" << endl;
+  }
+  
+  cout << endl;
+  
+  // Demonstrate value subscription
+  cout << "Demonstrating value subscription..." << endl;
+  
+  cfg.subscribeValue("GLOBAL", "LOGICS", string("DefaultLogic"), 
+                     [](const string& value) {
+                       cout << "  Subscription callback: GLOBAL/LOGICS changed to \"" 
+                            << value << "\"" << endl;
+                     });
+  
+  // Change the value to trigger subscription
+  cfg.setValue("GLOBAL", "LOGICS", "NewLogic");
+  
+  cout << endl << "Demo completed successfully!" << endl;
+} /* demonstrateBackend */
+
+/*
+ * This file has not been truncated
+ */

--- a/src/async/demo/AsyncConfigBackend_demo.cpp
+++ b/src/async/demo/AsyncConfigBackend_demo.cpp
@@ -81,10 +81,8 @@ using namespace Async;
  *
  ****************************************************************************/
 
-void demonstrateBackend(const string& config_dir);
 void showAvailableBackends();
-void createSampleDbConfig(const string& config_dir);
-void demonstrateDbConfigInit(void);
+void demonstrateBackend(Config& cfg);
 
 /****************************************************************************
  *
@@ -109,35 +107,49 @@ int main(int argc, char **argv)
   cout << "SVXLink Configuration Backend Demo" << endl;
   cout << "==================================" << endl << endl;
 
-  // Show available backends
   showAvailableBackends();
 
-  // Demonstrate the new db.conf initialization method
-  cout << "=== New db.conf Initialization Method ===" << endl;
-  demonstrateDbConfigInit();
+  Config cfg;
 
   if (argc >= 2)
   {
-    string config_dir = argv[1];
-    cout << "\n=== Custom Configuration Directory ===" << endl;
-    cout << "Using configuration directory: " << config_dir << endl;
-    
-    // Create sample db.conf
-    createSampleDbConfig(config_dir);
-    
-    // Demonstrate the backend
-    demonstrateBackend(config_dir);
+    // User supplied a db.conf path.  We only read it — the directory must
+    // already exist and be accessible.  Exit immediately if the file is
+    // missing rather than trying to create it.
+    const string db_conf_path = argv[1];
+    {
+      ifstream check(db_conf_path);
+      if (!check.good())
+      {
+        cerr << "*** ERROR: db.conf not found or not readable: "
+             << db_conf_path << endl;
+        return 1;
+      }
+    }
+
+    cout << "Using db.conf: " << db_conf_path << endl;
+    if (!cfg.open(db_conf_path))
+    {
+      cerr << "*** ERROR: Failed to open configuration from: "
+           << db_conf_path << endl;
+      return 1;
+    }
   }
   else
   {
-    cout << "\nUsage: " << argv[0] << " [config_directory]" << endl;
-    cout << endl;
-    cout << "If no config directory is specified, the standard search paths will be used:" << endl;
-    cout << "  ~/.svxlink/db.conf" << endl;
-    cout << "  /etc/svxlink/db.conf" << endl;
-    cout << "  /usr/local/etc/svxlink/db.conf (or system install directory)" << endl;
+    // No db.conf provided — fall back to a temporary SQLite database so the
+    // demo can run without any prior setup.
+    const string fallback_url = "sqlite:///tmp/AsyncConfigBackend_demo.db";
+    cout << "No db.conf specified.  Using fallback SQLite database:" << endl;
+    cout << "  " << fallback_url << endl << endl;
+    if (!cfg.openDirect(fallback_url))
+    {
+      cerr << "*** ERROR: Failed to open fallback SQLite database" << endl;
+      return 1;
+    }
   }
 
+  demonstrateBackend(cfg);
   return 0;
 } /* main */
 
@@ -149,156 +161,95 @@ int main(int argc, char **argv)
 
 void showAvailableBackends()
 {
-  cout << "Available configuration backends: " 
+  cout << "Available configuration backends: "
        << ConfigBackendFactory::validFactories() << endl << endl;
 
-  // Show detailed availability
   cout << "Backend availability:" << endl;
-  cout << "  File:       " 
-       << (ConfigSource::isBackendAvailable("file") ? "Yes" : "No") 
+  cout << "  File:       "
+       << (ConfigSource::isBackendAvailable("file")       ? "Yes" : "No")
        << endl;
-  cout << "  SQLite:     " 
-       << (ConfigSource::isBackendAvailable("sqlite") ? "Yes" : "No") 
+  cout << "  SQLite:     "
+       << (ConfigSource::isBackendAvailable("sqlite")     ? "Yes" : "No")
        << endl;
-  cout << "  MySQL:      " 
-       << (ConfigSource::isBackendAvailable("mysql") ? "Yes" : "No") 
+  cout << "  MySQL:      "
+       << (ConfigSource::isBackendAvailable("mysql")      ? "Yes" : "No")
        << endl;
-  cout << "  PostgreSQL: " 
-       << (ConfigSource::isBackendAvailable("postgresql") ? "Yes" : "No") 
+  cout << "  PostgreSQL: "
+       << (ConfigSource::isBackendAvailable("postgresql") ? "Yes" : "No")
        << endl << endl;
 } /* showAvailableBackends */
 
-void demonstrateDbConfigInit(void)
-{
-  cout << "Demonstrating automatic backend initialization using db.conf..." << endl;
-  
-  // This will fail gracefully since no db.conf exists in standard locations
-  // and no svxlink.conf exists either, but it shows the process
-  cout << "Attempting to initialize configuration (this may fail in demo environment):" << endl;
-  
-  try 
-  {
-    Config cfg;
-    // This would normally read db.conf and initialize the backend
-    // In a real application, this would either succeed or call exit(1)
-    cout << "Note: In a real application, cfg.open() would either succeed or abort the application" << endl;
-  }
-  catch (...)
-  {
-    cout << "Demo: Configuration initialization would handle errors and abort if needed" << endl;
-  }
-  
-  cout << endl;
-} /* demonstrateDbConfigInit */
 
-void createSampleDbConfig(const string& config_dir)
+void demonstrateBackend(Config& cfg)
 {
-  cout << "Creating sample db.conf in: " << config_dir << endl;
-  
-  // Create directory if it doesn't exist
-  string mkdir_cmd = "mkdir -p " + config_dir;
-  int result = system(mkdir_cmd.c_str());
-  if (result != 0)
-  {
-    cerr << "Warning: Failed to create directory: " << config_dir << endl;
-  }
-  
-  // Create a simple SQLite db.conf
-  string db_conf_path = config_dir + "/db.conf";
-  ofstream db_conf(db_conf_path);
-  if (db_conf.is_open())
-  {
-    db_conf << "# SVXLink Database Configuration - Demo\n";
-    db_conf << "[DATABASE]\n";
-    db_conf << "TYPE=sqlite\n";
-    db_conf << "SOURCE=" << config_dir << "/demo_config.db\n";
-    db_conf.close();
-    cout << "Created " << db_conf_path << endl;
-  }
-  
-  cout << endl;
-} /* createSampleDbConfig */
+  cout << "Backend type: " << cfg.getBackendType() << endl << endl;
 
-void demonstrateBackend(const string& config_dir)
-{
-  cout << "Demonstrating configuration backend with config directory: " << config_dir << endl;
-  
-  // Open configuration using db.conf
-  Config cfg;
-  if (!cfg.open(config_dir))
-  {
-    cout << "ERROR: Failed to open configuration" << endl;
-    return;
-  }
-  
-  cout << "Configuration opened successfully." << endl << endl;
-  
-  // List all sections
+  // Populate a few values so the demo is interesting even with a blank DB
+  cfg.setValue("GLOBAL",   "LOGICS",           "MyLogic");
+  cfg.setValue("MyLogic",  "TYPE",              "SimplexLogic");
+  cfg.setValue("MyLogic",  "RX",               "Rx1");
+  cfg.setValue("MyLogic",  "TX",               "Tx1");
+  cfg.setValue("Rx1",      "TYPE",             "Local");
+  cfg.setValue("Rx1",      "AUDIO_DEV",        "alsa:plughw:0");
+  cfg.setValue("Rx1",      "VOX_FILTER_DEPTH", "20");
+  cfg.setValue("Rx1",      "VOX_LIMIT",        "1000");
+
+  // List all sections and their tags
   cout << "Configuration sections:" << endl;
   list<string> sections = cfg.listSections();
   for (const string& section : sections)
   {
     cout << "  [" << section << "]" << endl;
-    
-    // List tags in this section
     list<string> tags = cfg.listSection(section);
     for (const string& tag : tags)
     {
-      string value = cfg.getValue(section, tag);
-      cout << "    " << tag << " = " << value << endl;
+      cout << "    " << tag << " = " << cfg.getValue(section, tag) << endl;
     }
     cout << endl;
   }
-  
-  // Demonstrate template getValue functions
-  cout << "Template getValue demonstrations:" << endl;
-  
-  // String value
+
+  // Typed getValue
+  cout << "Typed getValue demonstrations:" << endl;
+
   string logics;
   if (cfg.getValue("GLOBAL", "LOGICS", logics))
   {
     cout << "  GLOBAL/LOGICS = \"" << logics << "\"" << endl;
   }
-  
-  // Integer value
+
   int vox_depth = 0;
   if (cfg.getValue("Rx1", "VOX_FILTER_DEPTH", vox_depth))
   {
     cout << "  Rx1/VOX_FILTER_DEPTH = " << vox_depth << endl;
   }
-  
-  // Integer with range checking
+
   int vox_limit = 0;
   if (cfg.getValue("Rx1", "VOX_LIMIT", -30, 0, vox_limit))
   {
     cout << "  Rx1/VOX_LIMIT = " << vox_limit << " (range checked)" << endl;
   }
-  
-  // Missing value with default
+
   string missing_value;
   if (cfg.getValue("GLOBAL", "MISSING_VALUE", missing_value, true))
   {
-    cout << "  GLOBAL/MISSING_VALUE = \"" << missing_value << "\" (missing_ok=true)" << endl;
+    cout << "  GLOBAL/MISSING_VALUE = \""
+         << (missing_value.empty() ? "<not set>" : missing_value)
+         << "\" (missing_ok=true)" << endl;
   }
-  else
-  {
-    cout << "  GLOBAL/MISSING_VALUE not found (as expected)" << endl;
-  }
-  
+
   cout << endl;
-  
-  // Demonstrate value subscription
+
+  // Value subscription
   cout << "Demonstrating value subscription..." << endl;
-  
-  cfg.subscribeValue("GLOBAL", "LOGICS", string("DefaultLogic"), 
-                     [](const string& value) {
-                       cout << "  Subscription callback: GLOBAL/LOGICS changed to \"" 
-                            << value << "\"" << endl;
+
+  cfg.subscribeValue("GLOBAL", "LOGICS", string("DefaultLogic"),
+                     [](const string& val) {
+                       cout << "  Subscription callback: GLOBAL/LOGICS = \""
+                            << val << "\"" << endl;
                      });
-  
-  // Change the value to trigger subscription
-  cfg.setValue("GLOBAL", "LOGICS", "NewLogic");
-  
+
+  cfg.setValue("GLOBAL", "LOGICS", "ChangedLogic");
+
   cout << endl << "Demo completed successfully!" << endl;
 } /* demonstrateBackend */
 

--- a/src/async/demo/AsyncConfigBackend_demo.cpp
+++ b/src/async/demo/AsyncConfigBackend_demo.cpp
@@ -242,11 +242,11 @@ void demonstrateBackend(Config& cfg)
   // Value subscription
   cout << "Demonstrating value subscription..." << endl;
 
-  cfg.subscribeValue("GLOBAL", "LOGICS", string("DefaultLogic"),
-                     [](const string& val) {
-                       cout << "  Subscription callback: GLOBAL/LOGICS = \""
-                            << val << "\"" << endl;
-                     });
+  auto sub = cfg.subscribeValue("GLOBAL", "LOGICS", string("DefaultLogic"),
+                                [](const string& val) {
+                                  cout << "  Subscription callback: GLOBAL/LOGICS = \""
+                                       << val << "\"" << endl;
+                                });
 
   cfg.setValue("GLOBAL", "LOGICS", "ChangedLogic");
 

--- a/src/async/demo/AsyncConfig_demo.cpp
+++ b/src/async/demo/AsyncConfig_demo.cpp
@@ -12,7 +12,7 @@ using namespace Async;
 int main(int argc, char **argv)
 {
   Config cfg;
-  if (!cfg.open("test.cfg"))
+  if (!cfg.openDirect("file://test.cfg"))
   {
     cerr << "*** Error: Could not open config file test.cfg\n";
     exit(1);

--- a/src/async/demo/AsyncConfig_demo.cpp
+++ b/src/async/demo/AsyncConfig_demo.cpp
@@ -68,21 +68,21 @@ int main(int argc, char **argv)
 	    "not found or out of range.\n";
   }
 
-  cfg.subscribeValue("SECTION1", "VALUE1", "",
+  auto sub1 = cfg.subscribeValue("SECTION1", "VALUE1", "",
       [](const std::string& val)
       {
         cout << "SECTION1/VALUE1=" << val << endl;
       });
   cfg.setValue("SECTION1", "VALUE1", "A subscribed string value");
 
-  cfg.subscribeValue("SECTION2", "MY_INT", -1,
+  auto sub2 = cfg.subscribeValue("SECTION2", "MY_INT", -1,
       [](int val)
       {
         cout << "SECTION2/MY_INT=" << val << endl;
       });
   cfg.setValue("SECTION2", "MY_INT", 4711);
 
-  cfg.subscribeValue("SECTION1", "VEC", std::vector<int>{1,2,3},
+  auto sub3 = cfg.subscribeValue("SECTION1", "VEC", std::vector<int>{1,2,3},
       [=](const std::vector<int>& vec)
       {
         std::copy(vec.begin(), vec.end(),

--- a/src/async/demo/CMakeLists.txt
+++ b/src/async/demo/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CPPPROGS AsyncAudioIO_demo AsyncDnsLookup_demo AsyncFdWatch_demo
              AsyncAudioContainer_demo AsyncTcpPrioClient_demo
              AsyncStateMachine_demo AsyncPlugin_demo
              AsyncSslTcpServer_demo AsyncSslTcpClient_demo
-             AsyncSslX509_demo AsyncDigest_demo
+             AsyncSslX509_demo AsyncDigest_demo AsyncConfigBackend_demo
              )
 
 set(QTPROGS AsyncQtApplication_demo)

--- a/src/doc/README_DBCONFIG.md
+++ b/src/doc/README_DBCONFIG.md
@@ -1,0 +1,672 @@
+# SVXLink Database Configuration Backend
+
+This document describes the pluggable configuration backend system introduced in
+SVXLink.  It allows configuration to be stored in a relational database (SQLite,
+MySQL/MariaDB, or PostgreSQL) instead of — or alongside — the traditional `.conf`
+files.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Configuration Loading Priority](#2-configuration-loading-priority)
+3. [The `db.conf` File](#3-the-dbconf-file)
+4. [Database Table Schema](#4-database-table-schema)
+5. [Backend Setup](#5-backend-setup)
+  - [SQLite](#51-sqlite)
+  - [MySQL / MariaDB](#52-mysql--mariadb)
+  - [PostgreSQL](#53-postgresql)
+6. [Initialising from an Existing Config File (`--init-db`)](#6-initialising-from-an-existing-config-file----init-db)
+7. [Command-Line Options](#7-command-line-options)
+8. [Calibration Utilities](#8-calibration-utilities)
+  - [devcal](#81-devcal)
+  - [siglevdetcal](#82-siglevdetcal)
+9. [Live Change Notifications](#9-live-change-notifications)
+10. [Table Naming and Prefix Rules](#10-table-naming-and-prefix-rules)
+11. [Sharing One Database Between Binaries](#11-sharing-one-database-between-binaries)
+12. [Quick-Start Examples](#12-quick-start-examples)
+
+---
+
+## 1. Overview
+
+SVXLink applications (`svxlink`, `remotetrx`, `svxreflector`, `svxserver`) all
+use a single `AsyncConfig` class to read their configuration.  That class
+delegates every I/O operation to a **backend plugin**.  Four backends ship with
+SVXLink:
+
+
+| Backend type      | `TYPE=` value | Notes                                                   |
+| ----------------- | ------------- | ------------------------------------------------------- |
+| Plain config file | `file`        | Original behaviour; reads `.conf` files                 |
+| SQLite            | `sqlite`      | Single-file embedded database                           |
+| MySQL / MariaDB   | `mysql`       | Requires the `libmysqlclient` dev package at build time |
+| PostgreSQL        | `postgresql`  | Requires the `libpq-dev` package at build time          |
+
+
+Whether a database backend was compiled in can be checked at runtime:
+
+```
+svxlink --help
+```
+
+The available backends are listed in the error message if an unsupported type is
+requested.
+
+---
+
+## 2. Configuration Loading Priority
+
+Each binary follows a strict lookup chain at startup.  The first match wins:
+
+```
+1. --config <file>       → use the file backend with the given path
+       ↓ (not given)
+2. --dbconfig <file>     → parse <file> as db.conf, use the configured backend
+       ↓ (not given)
+3. Search standard paths for db.conf
+       ~/.svxlink/db.conf
+       /etc/svxlink/db.conf
+       <install-prefix>/etc/svxlink/db.conf
+   if found → use the configured backend
+       ↓ (not found)
+4. Search standard paths for the application's default config file
+       (~/.svxlink/svxlink.conf, /etc/svxlink/svxlink.conf, …)
+   if found → use the file backend
+       ↓ (not found)
+5. Fatal error — no configuration source available
+```
+
+`**CFG_DIR` processing** is only performed for the `file` backend.  Database
+backends load all their data directly from the database and ignore `CFG_DIR`.
+
+---
+
+## 3. The `db.conf` File
+
+`db.conf` is a lightweight INI-style file that tells SVXLink *which* backend to
+use and how to connect to it.  An example is installed at
+`/etc/svxlink/db.conf` (or `~/.svxlink/db.conf` for per-user configuration).
+
+### Format
+
+```ini
+[DATABASE]
+# Required: backend type
+TYPE=sqlite
+
+# Required: connection source (format depends on TYPE — see below)
+SOURCE=/var/lib/svxlink/svxlink.db
+
+# Optional: prefix prepended to the binary name when naming tables
+# Default: no extra prefix (binary name is used as-is, e.g. svxlink_config)
+#TABLE_PREFIX=prod_
+
+# Optional: enable live change notifications
+# When 1/true/yes, the application reacts to rows changed in the database
+# by another process without needing a restart or SIGHUP.
+ENABLE_CHANGE_NOTIFICATIONS=1
+
+# Optional: how often to poll the database for external changes (seconds)
+# Only meaningful when ENABLE_CHANGE_NOTIFICATIONS is enabled.
+# Default: 0 (polling disabled)
+POLL_INTERVAL=30
+```
+
+### `SOURCE` format by backend type
+
+
+| `TYPE`       | `SOURCE` example                                                                |
+| ------------ | ------------------------------------------------------------------------------- |
+| `file`       | `SOURCE=/etc/svxlink/svxlink.conf`                                              |
+| `sqlite`     | `SOURCE=/var/lib/svxlink/svxlink.db`                                            |
+| `mysql`      | `SOURCE=host=localhost;port=3306;user=svxlink;password=secret;database=svxlink` |
+| `postgresql` | `SOURCE=host=localhost port=5432 dbname=svxlink user=svxlink password=secret`   |
+
+
+> **MySQL note:** the `SOURCE` value uses semicolon-separated `key=value` pairs.
+>
+> **PostgreSQL note:** the `SOURCE` value is passed directly to `PQconnectdb()` as
+> a libpq connection string (space-separated `key=value` pairs).
+
+---
+
+## 4. Database Table Schema
+
+Every backend stores configuration in one table per application binary.  The
+table name is `<prefix>config` where `<prefix>` is derived from the binary name
+(see [Section 9](#9-table-naming-and-prefix-rules)).
+
+### Schema (common to all database backends)
+
+
+| Column       | Type                   | Description                                    |
+| ------------ | ---------------------- | ---------------------------------------------- |
+| `id`         | auto-increment integer | Internal row identifier                        |
+| `section`    | VARCHAR(255) / TEXT    | INI section name, e.g. `GLOBAL`                |
+| `tag`        | VARCHAR(255) / TEXT    | Key name within the section, e.g. `CALLSIGN`   |
+| `value`      | TEXT                   | Value string                                   |
+| `created_at` | TIMESTAMP              | Row creation time                              |
+| `updated_at` | TIMESTAMP              | Last modification time (auto-updated on MySQL) |
+
+
+A `UNIQUE(section, tag)` constraint is enforced on all backends so that upsert (update/insert)
+operations are safe.
+
+### SQLite DDL
+
+```sql
+CREATE TABLE IF NOT EXISTS svxlink_config (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    section     TEXT NOT NULL,
+    tag         TEXT NOT NULL,
+    value       TEXT NOT NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(section, tag)
+);
+```
+
+### MySQL / MariaDB DDL
+
+```sql
+CREATE TABLE IF NOT EXISTS svxlink_config (
+    id         INT AUTO_INCREMENT PRIMARY KEY,
+    section    VARCHAR(255) NOT NULL,
+    tag        VARCHAR(255) NOT NULL,
+    value      TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_svxlink_config (section, tag),
+    INDEX idx_svxlink_config_section (section)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+```
+
+### PostgreSQL DDL
+
+```sql
+CREATE TABLE IF NOT EXISTS svxlink_config (
+    id         SERIAL PRIMARY KEY,
+    section    VARCHAR(255) NOT NULL,
+    tag        VARCHAR(255) NOT NULL,
+    value      TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(section, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_svxlink_config_section
+    ON svxlink_config (section);
+```
+
+> **Note:** Tables are created automatically on first startup if the database
+> user has `CREATE TABLE` privileges.  You only need to create them manually if
+> you want a different storage configuration.
+
+---
+
+## 5. Backend Setup
+
+### 5.1 SQLite
+
+No server required — just ensure the directory for the database file is
+writable by the SVXLink process.
+
+`**/etc/svxlink/db.conf`**
+
+```ini
+[DATABASE]
+TYPE=sqlite
+SOURCE=/var/lib/svxlink/svxlink.db
+ENABLE_CHANGE_NOTIFICATIONS=1
+POLL_INTERVAL=60
+```
+
+Create the directory:
+
+```bash
+sudo mkdir -p /var/lib/svxlink
+sudo chown svxlink:svxlink /var/lib/svxlink
+```
+
+The database file and table are created automatically on first run.
+
+Inspect the database at any time:
+
+```bash
+sqlite3 /var/lib/svxlink/svxlink.db \
+    "SELECT section, tag, value FROM svxlink_config ORDER BY section, tag;"
+```
+
+---
+
+### 5.2 MySQL / MariaDB
+
+**Create the database and user:**
+
+```sql
+CREATE DATABASE svxlink CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE USER 'svxlink'@'localhost' IDENTIFIED BY 'changeme';
+GRANT ALL PRIVILEGES ON svxlink.* TO 'svxlink'@'localhost';
+FLUSH PRIVILEGES;
+```
+
+`**/etc/svxlink/db.conf**`
+
+```ini
+[DATABASE]
+TYPE=mysql
+SOURCE=host=localhost;port=3306;user=svxlink;password=changeme;database=svxlink
+ENABLE_CHANGE_NOTIFICATIONS=1
+POLL_INTERVAL=30
+```
+
+The `svxlink_config` table (and the table for every other binary that shares the
+same database) is created automatically on first run.
+
+Inspect the configuration:
+
+```bash
+mysql -u svxlink -p svxlink \
+    -e "SELECT section, tag, value FROM svxlink_config ORDER BY section, tag;"
+```
+
+---
+
+### 5.3 PostgreSQL
+
+**Create the database and user:**
+
+```sql
+CREATE USER svxlink WITH PASSWORD 'changeme';
+CREATE DATABASE svxlink OWNER svxlink;
+\c svxlink
+GRANT ALL ON SCHEMA public TO svxlink;
+```
+
+`**/etc/svxlink/db.conf**`
+
+```ini
+[DATABASE]
+TYPE=postgresql
+SOURCE=host=localhost port=5432 dbname=svxlink user=svxlink password=changeme
+ENABLE_CHANGE_NOTIFICATIONS=1
+POLL_INTERVAL=30
+```
+
+Inspect the configuration:
+
+```bash
+psql -U svxlink -d svxlink \
+    -c "SELECT section, tag, value FROM svxlink_config ORDER BY section, tag;"
+```
+
+---
+
+## 6. Initialising from an Existing Config File (`--init-db`)
+
+All four binaries support a `--init-db` flag.  When given, the application:
+
+1. Opens the backend configured in `db.conf` (or specified via `--dbconfig`).
+2. Checks whether the configuration table is **empty**.
+3. If empty, searches the standard config paths for the application's installed
+  example `.conf` file and copies all sections/keys/values into the database.
+4. Exits immediately after the import — the application does **not** start
+  normally.
+
+
+| Binary         | Source config file  |
+| -------------- | ------------------- |
+| `svxlink`      | `svxlink.conf`      |
+| `remotetrx`    | `remotetrx.conf`    |
+| `svxreflector` | `svxreflector.conf` |
+| `svxserver`    | `svxserver.conf`    |
+
+
+**The database must already be reachable and empty.**  If it already contains
+rows the import is skipped and a warning is printed.
+
+### Example workflow
+
+```bash
+# 1. Install db.conf pointing at an SQLite database
+sudo cp /usr/share/doc/svxlink/examples/db.conf /etc/svxlink/db.conf
+# Edit TYPE and SOURCE as needed …
+
+# 2. Import the installed example config into the (empty) database
+sudo svxlink --init-db
+
+# 3. Edit values directly in the database
+sqlite3 /var/lib/svxlink/svxlink.db \
+    "UPDATE svxlink_config SET value='SM0XYZ' WHERE section='GLOBAL' AND tag='CALLSIGN';"
+
+# 4. Start SVXLink normally — it reads from the database
+sudo svxlink
+```
+
+The same pattern works for `remotetrx` and `svxreflector`:
+
+```bash
+sudo remotetrx   --init-db
+sudo svxreflector --init-db
+```
+
+> **Tip:** If you want to re-import, drop and recreate the table (or delete all
+> rows) before running `--init-db` again.
+
+---
+
+## 7. Command-Line Options
+
+These options are available on all four binaries.
+
+
+| Option              | Description                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------- |
+| `--config <file>`   | Use this file directly as the configuration (file backend only). Overrides all other discovery. |
+| `--dbconfig <file>` | Use this file as `db.conf` (specifies the backend). Overrides the automatic `db.conf` search.   |
+| `--init-db`         | Import the installed example `.conf` file into an empty database backend, then exit.            |
+
+
+Examples:
+
+```bash
+# Run with an explicit config file (file backend)
+svxlink --config /home/alice/test.conf
+
+# Run with a custom db.conf
+svxlink --dbconfig /opt/svxlink/etc/db.conf
+
+# Initialise the database that a specific db.conf points to
+svxlink --dbconfig /opt/svxlink/etc/db.conf --init-db
+```
+
+---
+
+## 8. Calibration Utilities
+
+`devcal` and `siglevdetcal` are interactive calibration tools that open the
+same SVXLink hardware sections as the main `svxlink` binary.  Both support
+the full backend system — they can read configuration from a file, a database,
+or auto-discover it from the standard search paths.
+
+Because they operate on a specific hardware section (a receiver or transmitter
+named in the config), **a section name is always required** as a command-line
+argument.
+
+### 8.1 `devcal`
+
+FM deviation calibration utility.  The hardware section name is the last
+positional argument; the config source is given with `--config`, `--dbconfig`,
+or as a legacy positional path.
+
+```
+devcal [devcal-options] --config   <file>    <section>
+devcal [devcal-options] --dbconfig <db.conf> <section>
+devcal [devcal-options] <config-file-or-db.conf> <section>   (legacy)
+```
+
+Examples:
+
+```bash
+# File backend — explicit path
+devcal -r --config /etc/svxlink/svxlink.conf Rx1
+
+# SQLite database via db.conf
+devcal -r --dbconfig /etc/svxlink/db.conf Rx1
+
+# Legacy positional form (still works)
+devcal -r /etc/svxlink/svxlink.conf Rx1
+
+# TX calibration against a database
+devcal -t --dbconfig /etc/svxlink/db.conf Tx1
+
+# Measure deviation (wideband RTL-SDR receiver)
+devcal -M -w --config /etc/svxlink/svxlink.conf RxRtl
+```
+
+---
+
+### 8.2 `siglevdetcal`
+
+Signal level detector calibration utility.  Guides the operator through a
+series of PTT measurements to derive `SIGLEV_SLOPE` and `SIGLEV_OFFSET`
+values for a given receiver section.
+
+```
+siglevdetcal [--config   <file>]    <section>
+siglevdetcal [--dbconfig <db.conf>] <section>
+siglevdetcal <config-file-or-db.conf> <section>   (legacy)
+siglevdetcal <section>              (auto-discover config)
+```
+
+When no config argument is given at all, the standard search paths are tried
+in order — `db.conf` first, then `svxlink.conf` — exactly as `svxlink` itself
+does.
+
+Examples:
+
+```bash
+# File backend — explicit path
+siglevdetcal --config /etc/svxlink/svxlink.conf Rx1
+
+# Database via db.conf
+siglevdetcal --dbconfig /etc/svxlink/db.conf Rx1
+
+# Auto-discover: reads /etc/svxlink/db.conf or svxlink.conf automatically
+siglevdetcal Rx1
+
+# Legacy positional form (still works)
+siglevdetcal /etc/svxlink/svxlink.conf Rx1
+```
+
+After the run, paste the printed `SIGLEV_SLOPE` and `SIGLEV_OFFSET` values
+into the appropriate receiver section of your config — either in the `.conf`
+file or directly in the database:
+
+```bash
+# Update values in an SQLite database
+sqlite3 /var/lib/svxlink/svxlink.db <<'SQL'
+UPDATE svxlink_config SET value='12.50', updated_at=datetime('now')
+  WHERE section='Rx1' AND tag='SIGLEV_SLOPE';
+UPDATE svxlink_config SET value='-5.30', updated_at=datetime('now')
+  WHERE section='Rx1' AND tag='SIGLEV_OFFSET';
+SQL
+```
+
+---
+
+## 9. Live Change Notifications
+
+When `ENABLE_CHANGE_NOTIFICATIONS=1` and `POLL_INTERVAL=<seconds>` are set in
+`db.conf`, SVXLink spawns a background thread that wakes up every
+`POLL_INTERVAL` seconds and queries the database for rows that changed since the
+last check (using the `updated_at` timestamp).
+
+Changed values are delivered to the application **on the main event-loop thread**
+via a self-pipe mechanism — the poll thread never calls application code
+directly.
+
+Parameters that can be hot-updated at runtime (no restart needed):
+
+- `GLOBAL/CALLSIGN` and most text identifiers
+- `GLOBAL/LOCATION_INFO` (reinitialises LocationInfo)
+- `GLOBAL/RANDOM_QSY_RANGE` (svxreflector — randomises QSY TG range)
+- Most RF-related thresholds (CTCSS tones, squelch levels, etc.)
+
+Parameters that require a restart (hardware, network sockets, module loading):
+
+- Audio device settings (`AUDIO_DEV`, `AUDIO_SAMPLE_RATE`, …)
+- Network bind addresses and ports (`LISTEN_PORT`, `HOST`, …)
+- Module loading lists (`MODULES=`)
+- Logic type (`TYPE=`)
+
+For a SIGHUP-triggered reload of the file backend (legacy behaviour), send
+`SIGHUP` to the process:
+
+```bash
+sudo kill -HUP $(pidof svxlink)
+```
+
+---
+
+## 10. Table Naming and Prefix Rules
+
+Each binary automatically uses a table prefix derived from its own name to keep
+configuration isolated even when multiple binaries share one database:
+
+
+| Binary         | Automatic prefix | Table name            |
+| -------------- | ---------------- | --------------------- |
+| `svxlink`      | `svxlink_`       | `svxlink_config`      |
+| `remotetrx`    | `remotetrx_`     | `remotetrx_config`    |
+| `svxreflector` | `svxreflector_`  | `svxreflector_config` |
+| `svxserver`    | `svxserver_`     | `svxserver_config`    |
+
+
+Setting `TABLE_PREFIX` in `db.conf` **prepends** the given string to the
+automatic binary prefix:
+
+```ini
+TABLE_PREFIX=prod_
+```
+
+
+| Binary      | Resulting prefix  | Table name              |
+| ----------- | ----------------- | ----------------------- |
+| `svxlink`   | `prod_svxlink_`   | `prod_svxlink_config`   |
+| `remotetrx` | `prod_remotetrx_` | `prod_remotetrx_config` |
+
+
+This is useful for environment separation (`prod_`, `test_`, `dev_`) or for
+running multiple site configurations in one database.
+
+> `**file` backend note:** `TABLE_PREFIX` has no effect when `TYPE=file`.
+
+---
+
+## 11. Sharing One Database Between Binaries
+
+A single `db.conf` — and therefore a single database connection — can serve all
+SVXLink binaries on the same host.  Because each binary automatically uses its
+own table prefix, there is no conflict:
+
+```
+/etc/svxlink/db.conf
+    TYPE=mysql
+    SOURCE=host=localhost;port=3306;user=svxlink;password=…;database=svxlink
+
+Tables created:
+    svxlink_config       ← used by svxlink
+    remotetrx_config     ← used by remotetrx
+    svxreflector_config  ← used by svxreflector
+```
+
+Initialise each binary separately:
+
+```bash
+sudo svxlink      --init-db
+sudo remotetrx    --init-db
+sudo svxreflector --init-db
+```
+
+---
+
+## 12. Quick-Start Examples
+
+### SQLite — simplest path
+
+```bash
+# 1. Create /etc/svxlink/db.conf
+sudo tee /etc/svxlink/db.conf <<'EOF'
+[DATABASE]
+TYPE=sqlite
+SOURCE=/var/lib/svxlink/svxlink.db
+ENABLE_CHANGE_NOTIFICATIONS=1
+POLL_INTERVAL=60
+EOF
+
+# 2. Create the data directory
+sudo mkdir -p /var/lib/svxlink
+sudo chown svxlink:svxlink /var/lib/svxlink
+
+# 3. Import the installed config into the database
+sudo svxlink --init-db
+
+# 4. Verify the import
+sqlite3 /var/lib/svxlink/svxlink.db \
+    "SELECT section, tag, value FROM svxlink_config LIMIT 20;"
+
+# 5. Run svxlink
+sudo svxlink
+```
+
+---
+
+### MySQL — production example
+
+```bash
+# 1. Create the database and user (run as MySQL root)
+mysql -u root -p <<'SQL'
+CREATE DATABASE svxlink CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE USER 'svxlink'@'localhost' IDENTIFIED BY 'changeme';
+GRANT ALL PRIVILEGES ON svxlink.* TO 'svxlink'@'localhost';
+FLUSH PRIVILEGES;
+SQL
+
+# 2. Create /etc/svxlink/db.conf
+sudo tee /etc/svxlink/db.conf <<'EOF'
+[DATABASE]
+TYPE=mysql
+SOURCE=host=localhost;port=3306;user=svxlink;password=changeme;database=svxlink
+ENABLE_CHANGE_NOTIFICATIONS=1
+POLL_INTERVAL=30
+EOF
+
+# 3. Import config for all binaries
+sudo svxlink      --init-db
+sudo remotetrx    --init-db
+sudo svxreflector --init-db
+
+# 4. Verify
+mysql -u svxlink -pchangeme svxlink \
+    -e "SELECT section, tag, value FROM svxlink_config ORDER BY section, tag LIMIT 20;"
+
+# 5. Edit a value on the fly — SVXLink picks it up within POLL_INTERVAL seconds
+mysql -u svxlink -pchangeme svxlink \
+    -e "UPDATE svxlink_config SET value='SM0XYZ', updated_at=NOW()
+        WHERE section='GLOBAL' AND tag='CALLSIGN';"
+```
+
+---
+
+### PostgreSQL — production example
+
+```bash
+# 1. Create the database and user (run as postgres superuser)
+sudo -u postgres psql <<'SQL'
+CREATE USER svxlink WITH PASSWORD 'changeme';
+CREATE DATABASE svxlink OWNER svxlink;
+\c svxlink
+GRANT ALL ON SCHEMA public TO svxlink;
+SQL
+
+# 2. Create /etc/svxlink/db.conf
+sudo tee /etc/svxlink/db.conf <<'EOF'
+[DATABASE]
+TYPE=postgresql
+SOURCE=host=localhost port=5432 dbname=svxlink user=svxlink password=changeme
+ENABLE_CHANGE_NOTIFICATIONS=1
+POLL_INTERVAL=30
+EOF
+
+# 3. Import config
+sudo svxlink --init-db
+
+# 4. Edit a value on the fly
+psql -U svxlink -d svxlink \
+    -c "UPDATE svxlink_config SET value='SM0XYZ', updated_at=NOW()
+        WHERE section='GLOBAL' AND tag='CALLSIGN';"
+```
+

--- a/src/locationinfo/LocationInfo.cpp
+++ b/src/locationinfo/LocationInfo.cpp
@@ -247,7 +247,7 @@ bool LocationInfo::initialize(Async::Config& cfg, const std::string& cfg_name)
   }
 
   loc_cfg.debug = false;
-  cfg.subscribeValue(cfg_name, "DEBUG", loc_cfg.debug,
+  _instance->m_sub_debug = cfg.subscribeValue(cfg_name, "DEBUG", loc_cfg.debug,
       [](bool debug)
       {
         LocationInfo::_instance->loc_cfg.debug = debug;

--- a/src/locationinfo/LocationInfo.h
+++ b/src/locationinfo/LocationInfo.h
@@ -216,6 +216,7 @@ class LocationInfo
 
     Cfg           loc_cfg; // weshalb?
     ClientList    clients;
+    Async::Config::Subscription m_sub_debug;
     int           sequence          {0};
     Async::Timer  aprs_stats_timer  {-1, Async::Timer::TYPE_PERIODIC};
     unsigned int  sinterval         {10}; // Minutes

--- a/src/misc/LogWriter.cpp
+++ b/src/misc/LogWriter.cpp
@@ -196,7 +196,9 @@ void LogWriter::stop(void)
 
   if (m_pipefd[1] != -1)
   {
-    write(m_pipefd[1], "\0", 1);
+    ssize_t ret= write(m_pipefd[1], "\0", 1);
+    (void)ret; // Suppress compiler warning about unused result
+
     close(m_pipefd[1]);
     m_pipefd[1] = -1;
   }

--- a/src/svxlink/contrib/svxserver/svxserver.cpp
+++ b/src/svxlink/contrib/svxserver/svxserver.cpp
@@ -40,7 +40,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <cassert>
 #include <signal.h>
 #include <termios.h>
-#include <dirent.h>
 #include <popt.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -144,7 +143,9 @@ static char             *pidfile_name = NULL;
 static char             *logfile_name = NULL;
 static char             *runasuser = NULL;
 static char   	      	*config = NULL;
+static char   	      	*dbconfig = NULL;
 static int    	      	daemonize = 0;
+static int              init_db = 0;
 static int    	      	logfd = -1;
 static FdWatch	      	*stdin_watch = 0;
 static FdWatch	      	*stdout_watch = 0;
@@ -345,89 +346,33 @@ int main(int argc, char **argv)
   tstamp_format = "%c";
 
   Config cfg;
-  string cfg_filename;
-  if (config != NULL)
+  if (!cfg.openWithFallback(config ? string(config) : "",
+                             dbconfig ? string(dbconfig) : "",
+                             "svxserver.conf"))
   {
-    cfg_filename = string(config);
-    if (!cfg.open(cfg_filename))
-    {
-      cerr << "*** ERROR: Could not open configuration file: "
-      	   << config << endl;
-      exit(1);
-    }
+    cerr << "*** ERROR: " << cfg.getLastError() << endl;
+    exit(1);
   }
-  else
-  {
-    cfg_filename = string(home_dir);
-    cfg_filename += "/.svxlink/svxserver.conf";
-    if (!cfg.open(cfg_filename))
-    {
-      cfg_filename = "/etc/svxlink/svxserver.conf";
-      if (!cfg.open(cfg_filename))
-      {
-	cfg_filename = "/etc/svxserver.conf";
-	if (!cfg.open(cfg_filename))
-	{
-	  cerr << "*** ERROR: Could not open configuration file. Tried:\n"
-      	       << "\t" << home_dir << "/.svxlink/svxserver.conf\n"
-      	       << "\t/etc/svxlink/svxserver.conf\n"
-	       << "\t/etc/svxserver.conf\n"
-	       << "Possible reasons for failure are: None of the files exist,\n"
-	       << "you do not have permission to read the file or there was a\n"
-	       << "syntax error in the file\n";
-	  exit(1);
-	}
-      }
-    }
-  }
-  string main_cfg_filename(cfg_filename);
 
-  string cfg_dir;
-  if (cfg.getValue("GLOBAL", "CFG_DIR", cfg_dir))
-  {
-    if (cfg_dir[0] != '/')
-    {
-      int slash_pos = main_cfg_filename.rfind('/');
-      if (slash_pos != -1)
-      {
-      	cfg_dir = main_cfg_filename.substr(0, slash_pos+1) + cfg_dir;
-      }
-      else
-      {
-      	cfg_dir = string("./") + cfg_dir;
-      }
-    }
+  cout << "Configuration loaded from: " << cfg.getMainConfigFile()
+       << " (" << cfg.getBackendType() << " backend)" << endl;
 
-    DIR *dir = opendir(cfg_dir.c_str());
-    if (dir == NULL)
+  if (init_db)
+  {
+    if (cfg.getBackendType() == "file")
     {
-      cerr << "*** ERROR: Could not read from directory spcified by "
-      	   << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
+      cerr << "*** ERROR: --init-db requires a database backend"
+              " (use --dbconfig or set up db.conf)" << endl;
       exit(1);
     }
-
-    struct dirent *dirent;
-    while ((dirent = readdir(dir)) != NULL)
+    if (!cfg.listSections().empty())
     {
-      char *dot = strrchr(dirent->d_name, '.');
-      if ((dot == NULL) || (strcmp(dot, ".conf") != 0))
-      {
-      	continue;
-      }
-      cfg_filename = cfg_dir + "/" + dirent->d_name;
-      if (!cfg.open(cfg_filename))
-       {
-	 cerr << "*** ERROR: Could not open configuration file: "
-	      << cfg_filename << endl;
-	 exit(1);
-       }
+      cout << "*** WARNING: --init-db: database is not empty, skipping import" << endl;
     }
-
-    if (closedir(dir) == -1)
+    else
     {
-      cerr << "*** ERROR: Error closing directory specified by"
-      	   << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
-      exit(1);
+      if (!cfg.importFromConfigFile("svxserver.conf"))
+        cerr << "*** WARNING: --init-db: could not import from svxserver.conf" << endl;
     }
   }
 
@@ -441,7 +386,7 @@ int main(int argc, char **argv)
           "terms and conditions in the\n";
   cout << "GNU GPL (General Public License) version 2 or later.\n";
 
-  cout << "\nUsing configuration file: " << main_cfg_filename << endl;
+  cout << "\nUsing configuration file: " << cfg.getMainConfigFile() << endl;
 
 
   struct termios org_termios;
@@ -535,6 +480,10 @@ static void parse_arguments(int argc, const char **argv)
             "Specify the user to run SvxLink as", "<username>"},
     {"config", 0, POPT_ARG_STRING, &config, 0,
 	    "Specify the configuration file to use", "<filename>"},
+    {"dbconfig", 0, POPT_ARG_STRING, &dbconfig, 0,
+	    "Specify the database configuration file to use", "<filename>"},
+    {"init-db", 0, POPT_ARG_NONE, &init_db, 0,
+	    "Initialize an empty database backend from the installed svxserver.conf", NULL},
     /*
     {"int_arg", 'i', POPT_ARG_INT, &int_arg, 0,
 	    "Description of int argument", "<an int>"},

--- a/src/svxlink/devcal/devcal.cpp
+++ b/src/svxlink/devcal/devcal.cpp
@@ -464,6 +464,8 @@ static bool wb_mode = false;
 static int flat_fq_response = false;
 static string cfgfile;
 static string cfgsect;
+static char* config = nullptr;
+static char* dbconfig = nullptr;
 static FdWatch *stdin_watch = 0;
 static SineGenerator *gen = 0;
 static DevPrinter *dp = 0;
@@ -523,12 +525,42 @@ int main(int argc, const char *argv[])
   cout << fixed;
 
   Config cfg;
-  if (!cfg.open(cfgfile))
+
+  // Map CLI options to openWithFallback arguments.
+  // --config → explicit file backend; --dbconfig → explicit DB backend;
+  // positional cfgfile → legacy path (auto-detect db.conf by name for compat).
+  string cli_config;
+  string cli_dbconfig;
+  if (config != nullptr)
   {
-    cerr << "*** ERROR: Could not open configuration file \""
-         << cfgfile << "\".\n";
+    cli_config = cfgfile;
+  }
+  else if (dbconfig != nullptr)
+  {
+    cli_dbconfig = cfgfile;
+  }
+  else if (!cfgfile.empty())
+  {
+    if (cfgfile.find("db.conf") != string::npos)
+      cli_dbconfig = cfgfile;
+    else
+      cli_config = cfgfile;
+  }
+  else
+  {
+    cerr << "*** ERROR: No configuration file specified.\n"
+            "Use --config <file>, --dbconfig <db.conf>, "
+            "or provide the config path as a positional argument.\n";
     exit(1);
   }
+
+  if (!cfg.openWithFallback(cli_config, cli_dbconfig, "svxlink.conf"))
+  {
+    cerr << "*** ERROR: " << cfg.getLastError() << "\n";
+    exit(1);
+  }
+  cout << "Configuration loaded from: " << cfg.getMainConfigFile()
+       << " (" << cfg.getBackendType() << " backend)" << endl;
 
   AudioIO *audio_io = 0;
   if (cal_tx)
@@ -733,10 +765,10 @@ static void parse_arguments(int argc, const char **argv)
 	    "The maximum deviation for the channel", "<deviation in Hz>"},
     {"headroom", 'H', POPT_ARG_FLOAT | POPT_ARGFLAG_SHOW_DEFAULT,
             &headroom_db, 0, "The headroom to use", "<headroom in dB>"},
-    /*
     {"config", 0, POPT_ARG_STRING, &config, 0,
 	    "Specify the configuration file to use", "<filename>"},
-    */
+    {"dbconfig", 0, POPT_ARG_STRING, &dbconfig, 0,
+	    "Specify the database configuration file to use", "<filename>"},
     {"rxcal", 'r', POPT_ARG_NONE, &cal_rx, 0, "Do receiver calibration", NULL},
     {"txcal", 't', POPT_ARG_NONE, &cal_tx, 0,
             "Do transmitter calibration", NULL},
@@ -775,7 +807,15 @@ static void parse_arguments(int argc, const char **argv)
     switch (argcnt++)
     {
       case 0:
-        cfgfile = arg;
+        if (config == nullptr && dbconfig == nullptr)
+        {
+          cfgfile = arg;
+        }
+        else
+        {
+          cfgsect = arg;
+          argcnt = 2; // Skip to section parsing since config file was specified via flag
+        }
         break;
       case 1:
         cfgsect = arg;
@@ -785,6 +825,16 @@ static void parse_arguments(int argc, const char **argv)
         poptPrintUsage(optCon, stderr, 0);
         exit(1);
     }
+  }
+  
+  // Handle new configuration arguments
+  if (config != nullptr)
+  {
+    cfgfile = string(config);
+  }
+  else if (dbconfig != nullptr)
+  {
+    cfgfile = string(dbconfig);
   }
 
   if (print_version)

--- a/src/svxlink/digital/afsk_test.cpp
+++ b/src/svxlink/digital/afsk_test.cpp
@@ -331,6 +331,26 @@ class StdInSourceDev : public StdInSource
 
 int main(int argc, const char **argv)
 {
+  string cli_config;
+  string cli_dbconfig;
+
+  for (int i = 1; i < argc; i++)
+  {
+    if (strcmp(argv[i], "--config") == 0 && i + 1 < argc)
+      cli_config = argv[++i];
+    else if (strcmp(argv[i], "--dbconfig") == 0 && i + 1 < argc)
+      cli_dbconfig = argv[++i];
+    else if (strcmp(argv[i], "--help") == 0)
+    {
+      cout << "Usage: " << argv[0]
+           << " [--config <file>] [--dbconfig <file>]\n\n"
+           << "Audio is read from stdin (raw signed 16-bit mono).\n"
+           << "If no config option is given, standard locations are\n"
+           << "searched for db.conf and then svxlink.conf.\n";
+      exit(0);
+    }
+  }
+
   // 1200Bd AMPR
 #if 1
   unsigned baudrate = 1200;
@@ -436,13 +456,11 @@ int main(int argc, const char **argv)
   prev_src = &deemph_filt;
   */
 
-  string cfg_filename(getenv("HOME"));
-  cfg_filename += "/.svxlink/svxlink.conf";
   Async::Config cfg;
-  if (!cfg.open(cfg_filename))
+  if (!cfg.openWithFallback(cli_config, cli_dbconfig, "svxlink.conf") &&
+      (!cli_config.empty() || !cli_dbconfig.empty()))
   {
-    cout << "*** ERROR: Could not open configuration file: "
-         << cfg_filename << endl;
+    cerr << "*** ERROR: " << cfg.getLastError() << endl;
     exit(1);
   }
 

--- a/src/svxlink/digital/tx_test.cpp
+++ b/src/svxlink/digital/tx_test.cpp
@@ -16,7 +16,7 @@ int main()
   CppApplication app;
   Config cfg;
   string cfg_file = "tx_test.cfg";
-  if (!cfg.open(cfg_file))
+  if (!cfg.openDirect("file://" + cfg_file))
   {
     cout << "*** ERROR: Could not open config file " << cfg_file << "\n";
     exit(1);

--- a/src/svxlink/modules/dtmf_repeater/ModuleDtmfRepeater.cpp
+++ b/src/svxlink/modules/dtmf_repeater/ModuleDtmfRepeater.cpp
@@ -219,6 +219,8 @@ bool ModuleDtmfRepeater::initialize(void)
   {
     repeat_delay_timer.setTimeout(std::max(0, repeat_delay));
   }
+
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &ModuleDtmfRepeater::cfgUpdated));
   
   return true;
   
@@ -382,6 +384,25 @@ void ModuleDtmfRepeater::sendStoredDigits(void)
   sendDtmf(received_digits);
   received_digits.clear();
 } /* ModuleDtmfRepeater::sendStoredDigits */
+
+
+void ModuleDtmfRepeater::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  // Call base class to handle TIMEOUT and MUTE_LOGIC_LINKING
+  Module::cfgUpdated(section, tag, value);
+
+  if (section == cfgName())
+  {
+    if (tag == "REPEAT_DELAY")
+    {
+      int repeat_delay = 0;
+      if (cfg().getValue(cfgName(), "REPEAT_DELAY", repeat_delay))
+      {
+        repeat_delay_timer.setTimeout(std::max(0, repeat_delay));
+      }
+    }
+  }
+} /* ModuleDtmfRepeater::cfgUpdated */
 
 
 

--- a/src/svxlink/modules/dtmf_repeater/ModuleDtmfRepeater.h
+++ b/src/svxlink/modules/dtmf_repeater/ModuleDtmfRepeater.h
@@ -138,6 +138,7 @@ class ModuleDtmfRepeater : public Module
     void dtmfCmdReceivedWhenIdle(const std::string &cmd);
     void squelchOpen(bool is_open);
     void allMsgsWritten(void);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value) override;
 
     void setupRepeatDelay(void);
     void onRepeatDelayExpired(void);

--- a/src/svxlink/modules/echolink/ModuleEchoLink.cpp
+++ b/src/svxlink/modules/echolink/ModuleEchoLink.cpp
@@ -412,8 +412,7 @@ bool ModuleEchoLink::initialize(void)
         sigc::mem_fun(*this, &ModuleEchoLink::onCommandPtyInput));
   }
 
-  cfg().valueUpdated.connect(
-      sigc::mem_fun(*this, &ModuleEchoLink::cfgValueUpdated));
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &ModuleEchoLink::cfgUpdated));
 
   return true;
   
@@ -2235,35 +2234,121 @@ bool ModuleEchoLink::setAcceptOutgoingRegex(void)
 } /* ModuleEchoLink::setAcceptOutgoingRegex */
 
 
-void ModuleEchoLink::cfgValueUpdated(const std::string& section,
-    const std::string& tag)
+void ModuleEchoLink::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
 {
-  if (section != cfgName())
-  {
-    return;
-  }
+  // Call base class to handle TIMEOUT and MUTE_LOGIC_LINKING
+  Module::cfgUpdated(section, tag, value);
 
-  if (tag == CFG_DROP_INCOMING)
+  if (section == cfgName())
   {
-    setDropIncomingRegex();
+    if (tag == CFG_DROP_INCOMING)
+    {
+      setDropIncomingRegex();
+    }
+    else if (tag == CFG_REJECT_INCOMING)
+    {
+      setRejectIncomingRegex();
+    }
+    else if (tag == CFG_ACCEPT_INCOMING)
+    {
+      setAcceptIncomingRegex();
+    }
+    else if (tag == CFG_REJECT_OUTGOING)
+    {
+      setRejectOutgoingRegex();
+    }
+    else if (tag == CFG_ACCEPT_OUTGOING)
+    {
+      setAcceptOutgoingRegex();
+    }
+    else if (tag == "AUTOCON_TIME")
+    {
+      int autocon_time_secs = autocon_time / 1000;
+      if (cfg().getValue(cfgName(), "AUTOCON_TIME", autocon_time_secs))
+      {
+        autocon_time = 1000 * max(autocon_time_secs, 5); // At least five seconds
+        if (autocon_timer != 0)
+        {
+          autocon_timer->setTimeout(autocon_time);
+        }
+      }
+    }
+    else if (tag == "LOCATION")
+    {
+      string new_location;
+      if (cfg().getValue(cfgName(), "LOCATION", new_location))
+      {
+        if (new_location.size() > Directory::MAX_DESCRIPTION_SIZE)
+        {
+          cerr << "*** WARNING: The value of " << cfgName() << "/LOCATION is too "
+               << "long. Maximum length is " << Directory::MAX_DESCRIPTION_SIZE
+               << " characters.\n";
+          new_location.resize(Directory::MAX_DESCRIPTION_SIZE);
+        }
+        location = new_location;
+        if (dir != 0)
+        {
+          updateDescription();
+        }
+      }
+    }
+    else if (tag == "SYSOPNAME")
+    {
+      cfg().getValue(cfgName(), "SYSOPNAME", sysop_name);
+    }
+    else if (tag == "DESCRIPTION")
+    {
+      cfg().getValue(cfgName(), "DESCRIPTION", description);
+    }
+    else if (tag == "MAX_CONNECTIONS")
+    {
+      string value_str;
+      if (cfg().getValue(cfgName(), "MAX_CONNECTIONS", value_str))
+      {
+        unsigned new_max_connections = atoi(value_str.c_str());
+        if (new_max_connections >= max_qsos)
+        {
+          max_connections = new_max_connections;
+        }
+        else
+        {
+          cerr << "*** ERROR: The value of " << cfgName() << "/MAX_CONNECTIONS ("
+               << new_max_connections << ") must be greater or equal to the value of "
+               << cfgName() << "/MAX_QSOS (" << max_qsos << ").\n";
+        }
+      }
+    }
+    else if (tag == "MAX_QSOS")
+    {
+      string value_str;
+      if (cfg().getValue(cfgName(), "MAX_QSOS", value_str))
+      {
+        unsigned new_max_qsos = atoi(value_str.c_str());
+        if (new_max_qsos <= max_connections)
+        {
+          max_qsos = new_max_qsos;
+        }
+        else
+        {
+          cerr << "*** ERROR: The value of " << cfgName() << "/MAX_QSOS ("
+               << new_max_qsos << ") must be less or equal to the value of "
+               << cfgName() << "/MAX_CONNECTIONS (" << max_connections << ").\n";
+        }
+      }
+    }
+    else if (tag == "REJECT_CONF")
+    {
+      cfg().getValue(cfgName(), "REJECT_CONF", reject_conf);
+    }
+    else if (tag == "ALLOW_IP")
+    {
+      cfg().getValue(cfgName(), "ALLOW_IP", allow_ip);
+    }
+    // Note: SERVERS, CALLSIGN, PASSWORD, PROXY_SERVER, PROXY_PORT, PROXY_PASSWORD,
+    //       BIND_ADDR, DROP_ALL_INCOMING, COMMAND_PTY require restart
+    // Note: CHECK_NR_CONNECTS is complex and affects timer creation/deletion
   }
-  else if (tag == CFG_REJECT_INCOMING)
-  {
-    setRejectIncomingRegex();
-  }
-  else if (tag == CFG_ACCEPT_INCOMING)
-  {
-    setAcceptIncomingRegex();
-  }
-  else if (tag == CFG_REJECT_OUTGOING)
-  {
-    setRejectOutgoingRegex();
-  }
-  else if (tag == CFG_ACCEPT_OUTGOING)
-  {
-    setAcceptOutgoingRegex();
-  }
-} /* ModuleEchoLink::cfgValueUpdated */
+} /* ModuleEchoLink::cfgUpdated */
 
 
 /*

--- a/src/svxlink/modules/echolink/ModuleEchoLink.h
+++ b/src/svxlink/modules/echolink/ModuleEchoLink.h
@@ -273,7 +273,7 @@ class ModuleEchoLink : public Module
     bool setAcceptIncomingRegex(void);
     bool setRejectOutgoingRegex(void);
     bool setAcceptOutgoingRegex(void);
-    void cfgValueUpdated(const std::string& section, const std::string& tag);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value) override;
 
 };  /* class ModuleEchoLink */
 

--- a/src/svxlink/modules/frn/ModuleFrn.cpp
+++ b/src/svxlink/modules/frn/ModuleFrn.cpp
@@ -233,6 +233,8 @@ bool ModuleFrn::initialize(void)
     return false;
   }
 
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &ModuleFrn::cfgUpdated));
+
   return true;
   
 } /* initialize */
@@ -484,6 +486,21 @@ void ModuleFrn::onQsoError(void)
   cerr << "QSO errored, deactivating module" << endl;
   deactivateMe();
 }
+
+
+void ModuleFrn::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  // Call parent implementation first
+  Module::cfgUpdated(section, tag, value);
+  
+  // Update QsoFrn configuration if this is our section
+  // This will probably require a restart.......
+  if (section == cfgName() && qso != nullptr)
+  {
+    qso->updateConfig(cfg(), cfgName());
+  }
+} /* ModuleFrn::cfgUpdated */
+
 
 /*
  * This file has not been truncated

--- a/src/svxlink/modules/frn/ModuleFrn.h
+++ b/src/svxlink/modules/frn/ModuleFrn.h
@@ -138,6 +138,7 @@ class ModuleFrn : public Module
     void reportState(void);
     bool validateCommand(const std::string& cmd, size_t argc);
     void onQsoError(void);
+    virtual void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value) override;
 
   private:
     QsoFrn *qso;

--- a/src/svxlink/modules/frn/QsoFrn.cpp
+++ b/src/svxlink/modules/frn/QsoFrn.cpp
@@ -994,6 +994,23 @@ void QsoFrn::onDelayedReconnect(Async::Timer *timer)
   reconnect();
 }
 
+void QsoFrn::updateConfig(Async::Config& cfg, const std::string& cfg_name)
+{
+  cfg.getValue(cfg_name, "FRN_DEBUG", opt_frn_debug);
+  cfg.getValue(cfg_name, "DISABLE_RF", is_rf_disabled);
+  cfg.getValue(cfg_name, "SERVER", opt_server);
+  cfg.getValue(cfg_name, "PORT", opt_port);
+  cfg.getValue(cfg_name, "SERVER_BACKUP", opt_server_backup);
+  cfg.getValue(cfg_name, "PORT_BACKUP", opt_port_backup);
+  cfg.getValue(cfg_name, "EMAIL_ADDRESS", opt_email_address);
+  cfg.getValue(cfg_name, "DYN_PASSWORD", opt_dyn_password);
+  cfg.getValue(cfg_name, "CALLSIGN_AND_USER", opt_callsign_and_user);
+  cfg.getValue(cfg_name, "CLIENT_TYPE", opt_client_type);
+  cfg.getValue(cfg_name, "BAND_AND_CHANNEL", opt_band_and_channel);
+  cfg.getValue(cfg_name, "DESCRIPTION", opt_description);
+} /* QsoFrn::updateConfig */
+
+
 /*
  * This file has not been truncated
  */

--- a/src/svxlink/modules/frn/QsoFrn.h
+++ b/src/svxlink/modules/frn/QsoFrn.h
@@ -273,6 +273,13 @@ class QsoFrn
       * @return true if rf tx is disabled
       */
      bool isRfDisabled() const { return is_rf_disabled; }
+     
+     /**
+      * @brief Update configuration values when they change
+      * @param cfg The configuration object
+      * @param cfg_name The module configuration section name
+      */
+     void updateConfig(Async::Config& cfg, const std::string& cfg_name);
 
      /**
       * @brief  QSO is erroring out and cannot recover itself

--- a/src/svxlink/modules/metarinfo/ModuleMetarInfo.cpp
+++ b/src/svxlink/modules/metarinfo/ModuleMetarInfo.cpp
@@ -604,6 +604,8 @@ bool ModuleMetarInfo::initialize(void)
      longmsg = "_long ";  // taking "cavok_long" instead of "cavok"
   }
 
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &ModuleMetarInfo::cfgUpdated));
+
   return true;
 
 } /* initialize */
@@ -2316,6 +2318,61 @@ int ModuleMetarInfo::splitEmptyStr(StrList& L, const string& seq)
   return L.size();
 
 } /* ModuleMetarInfo::splitEmptyStr */
+
+
+void ModuleMetarInfo::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  // Call base class to handle TIMEOUT and MUTE_LOGIC_LINKING
+  Module::cfgUpdated(section, tag, value);
+
+  if (section == cfgName())
+  {
+    if (tag == "STARTDEFAULT")
+    {
+      string new_default;
+      if (cfg().getValue(cfgName(), "STARTDEFAULT", new_default))
+      {
+        if (new_default.length() == 4)
+        {
+          // Convert to uppercase like in initialize()
+          transform(new_default.begin(), new_default.end(), new_default.begin(),
+                    (int(*)(int))toupper);
+          icao_default = new_default;
+        }
+        else
+        {
+          cerr << "*** WARNING: Config variable " << cfgName()
+               << "/STARTDEFAULT: " << new_default << " is not valid.\n";
+        }
+      }
+    }
+    else if (tag == "REMARKS")
+    {
+      string value_str;
+      if (cfg().getValue(cfgName(), "REMARKS", value_str))
+      {
+        remarks = !value_str.empty();
+      }
+    }
+    else if (tag == "DEBUG")
+    {
+      string value_str;
+      if (cfg().getValue(cfgName(), "DEBUG", value_str))
+      {
+        debug = !value_str.empty();
+      }
+    }
+    else if (tag == "LONGMESSAGES")
+    {
+      string value_str;
+      if (cfg().getValue(cfgName(), "LONGMESSAGES", value_str))
+      {
+        longmsg = !value_str.empty() ? "_long " : "";
+      }
+    }
+    // Note: AIRPORTS, TYPE, SERVER, LINK would require restart
+  }
+} /* ModuleMetarInfo::cfgUpdated */
 
 
 /*

--- a/src/svxlink/modules/metarinfo/ModuleMetarInfo.h
+++ b/src/svxlink/modules/metarinfo/ModuleMetarInfo.h
@@ -205,6 +205,7 @@ class ModuleMetarInfo : public Module
     void say(std::stringstream &tmp);
     int handleMetar(std::string input);
     std::string getXmlParam(std::string token, std::string input);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value) override;
 };  /* class ModuleMetarInfo */
 
 

--- a/src/svxlink/modules/parrot/ModuleParrot.cpp
+++ b/src/svxlink/modules/parrot/ModuleParrot.cpp
@@ -214,6 +214,8 @@ bool ModuleParrot::initialize(void)
   fifo->registerSink(valve, true);
   
   AudioSource::setHandler(valve);
+
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &ModuleParrot::cfgUpdated));
   
   return true;
   
@@ -433,6 +435,24 @@ void ModuleParrot::execCmdQueue(void)
 } /* ModuleParrot::execCmdQueue */
 
 
+void ModuleParrot::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  // Call base class to handle TIMEOUT and MUTE_LOGIC_LINKING
+  Module::cfgUpdated(section, tag, value);
+
+  if (section == cfgName())
+  {
+    if (tag == "REPEAT_DELAY")
+    {
+      int repeat_delay = -1;
+      if (cfg().getValue(cfgName(), "REPEAT_DELAY", repeat_delay))
+      {
+        repeat_delay_timer.setTimeout(repeat_delay);
+      }
+    }
+    // Note: FIFO_LEN would require recreating the audio chain, so restart is needed
+  }
+} /* ModuleParrot::cfgUpdated */
 
 
 /*

--- a/src/svxlink/modules/parrot/ModuleParrot.h
+++ b/src/svxlink/modules/parrot/ModuleParrot.h
@@ -161,6 +161,7 @@ class ModuleParrot : public Module
     void allSamplesWritten(void);
     void onRepeatDelayExpired(void);
     void execCmdQueue(void);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value) override;
 
 };  /* class ModuleParrot */
 

--- a/src/svxlink/modules/trx/ModuleTrx.h
+++ b/src/svxlink/modules/trx/ModuleTrx.h
@@ -172,6 +172,7 @@ class ModuleTrx : public Module
     //void allMsgsWritten(void);
     void rxTimeout(Async::Timer *t);
     void rxSquelchOpen(bool is_open);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value) override;
 
 };  /* class ModuleTrx */
 

--- a/src/svxlink/reflector/Reflector.cpp
+++ b/src/svxlink/reflector/Reflector.cpp
@@ -1623,41 +1623,80 @@ void Reflector::ctrlPtyDataReceived(const void *buf, size_t count)
 } /* Reflector::ctrlPtyDataReceived */
 
 
-void Reflector::cfgUpdated(const std::string& section, const std::string& tag)
+void Reflector::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
 {
-  std::string value;
-  if (!m_cfg->getValue(section, tag, value))
-  {
-    std::cout << "*** ERROR: Failed to read updated configuration variable '"
-              << section << "/" << tag << "'" << std::endl;
-    return;
-  }
+  // Certificate related configuration changes require a server restart, should not be changed while
+  // running.....
+
+  std::cout << "### Reflector::cfgUpdated: " << section << "/" << tag << "=" << value << std::endl;
 
   if (section == "GLOBAL")
   {
-    if (tag == "SQL_TIMEOUT_BLOCKTIME")
+    if (tag == "SQL_TIMEOUT")
     {
-      unsigned t = TGHandler::instance()->sqlTimeoutBlocktime();
-      if (!SvxLink::setValueFromString(t, value))
-      {
-        std::cout << "*** ERROR: Failed to set updated configuration "
-                     "variable '" << section << "/" << tag << "'" << std::endl;
-        return;
-      }
-      TGHandler::instance()->setSqlTimeoutBlocktime(t);
-      //std::cout << "### New value for " << tag << "=" << t << std::endl;
+      TGHandler::instance()->setSqlTimeout(std::atoi(value.c_str()));
     }
-    else if (tag == "SQL_TIMEOUT")
+    else if (tag == "SQL_TIMEOUT_BLOCKTIME")
     {
-      unsigned t = TGHandler::instance()->sqlTimeout();
-      if (!SvxLink::setValueFromString(t, value))
+      TGHandler::instance()->setSqlTimeoutBlocktime(std::atoi(value.c_str()));
+    }
+    else if (tag == "TG_FOR_V1_CLIENTS")
+    {
+      m_tg_for_v1_clients = std::atoi(value.c_str());
+    }
+    else if (tag == "RANDOM_QSY_RANGE")
+    {
+      SvxLink::SepPair<uint32_t, uint32_t> range;
+      if (m_cfg->getValue("GLOBAL", tag, range))
       {
-        std::cout << "*** ERROR: Failed to set updated configuration "
-                     "variable '" << section << "/" << tag << "'" << std::endl;
+        m_random_qsy_lo = range.first;
+        m_random_qsy_hi = m_random_qsy_lo + range.second - 1;
+        if ((m_random_qsy_lo < 1) || (m_random_qsy_hi < m_random_qsy_lo))
+        {
+          cout << "*** WARNING: Illegal RANDOM_QSY_RANGE specified. Ignored." << endl;
+          m_random_qsy_hi = m_random_qsy_lo = 0;
+        }
+        m_random_qsy_tg = m_random_qsy_hi;
+      }
+      else
+      {
+        m_random_qsy_hi = m_random_qsy_lo = m_random_qsy_tg = 0;
+      }
+    }
+    else if (tag == "HTTP_SRV_PORT")
+    {
+      if(m_http_server != nullptr)
+      {
+        // http server already running, stop it
+        delete m_http_server;
+        m_http_server = nullptr;
+      }
+      m_http_server = new Async::TcpServer<Async::HttpServerConnection>(value);
+      m_http_server->clientConnected.connect(
+          sigc::mem_fun(*this, &Reflector::httpClientConnected));
+      m_http_server->clientDisconnected.connect(
+          sigc::mem_fun(*this, &Reflector::httpClientDisconnected));
+    }
+    else if (tag == "COMMAND_PTY")
+    {
+      if(m_cmd_pty != nullptr)
+      {
+        delete m_cmd_pty;
+        m_cmd_pty = nullptr;
+      }
+      m_cmd_pty = new Pty(value);
+      if((m_cmd_pty == nullptr) || !m_cmd_pty->open())
+      {
+        std::cerr << "*** ERROR: Could not open command PTY '" << value << "'" << std::endl;
         return;
       }
-      TGHandler::instance()->setSqlTimeout(t);
-      //std::cout << "### New value for " << tag << "=" << t << std::endl;
+      m_cmd_pty->setLineBuffered(true);
+      m_cmd_pty->dataReceived.connect(
+          sigc::mem_fun(*this, &Reflector::ctrlPtyDataReceived));
+    }
+    else if (tag == "ACCEPT_CERT_EMAIL")
+    {
+      m_accept_cert_email = value;
     }
   }
 } /* Reflector::cfgUpdated */
@@ -2513,3 +2552,4 @@ std::string Reflector::formatCerts(bool signedCerts, bool pendingCerts)
 /*
  * This file has not been truncated
  */
+

--- a/src/svxlink/reflector/Reflector.h
+++ b/src/svxlink/reflector/Reflector.h
@@ -298,7 +298,7 @@ class Reflector : public sigc::trackable
     void onRequestAutoQsy(uint32_t from_tg);
     uint32_t nextRandomQsyTg(void);
     void ctrlPtyDataReceived(const void *buf, size_t count);
-    void cfgUpdated(const std::string& section, const std::string& tag);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
     bool loadCertificateFiles(void);
     bool loadServerCertificateFiles(void);
     bool generateKeyFile(Async::SslKeypair& pkey, const std::string& keyfile);

--- a/src/svxlink/reflector/svxreflector.cpp
+++ b/src/svxlink/reflector/svxreflector.cpp
@@ -43,7 +43,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <sys/types.h>
 #include <grp.h>
 #include <pwd.h>
-#include <dirent.h>
 #include <termios.h>
 #include <errno.h>
 
@@ -138,8 +137,10 @@ namespace {
   char*                 logfile_name = nullptr;
   char*                 runasuser = nullptr;
   char*                 config = nullptr;
+  char*                 dbconfig = nullptr;
   int                   daemonize = 0;
   int                   quiet = 0;
+  int                   init_db = 0;
   FdWatch*              stdin_watch = 0;
   LogWriter             logwriter;
 };
@@ -273,90 +274,33 @@ int main(int argc, const char *argv[])
   }
 
   Config cfg;
-  string cfg_filename;
-  if (config != NULL)
+  if (!cfg.openWithFallback(config ? string(config) : "",
+                             dbconfig ? string(dbconfig) : "",
+                             "svxreflector.conf"))
   {
-    cfg_filename = string(config);
-    if (!cfg.open(cfg_filename))
-    {
-      cerr << "*** ERROR: Could not open configuration file: "
-           << config << endl;
-      exit(1);
-    }
-  }
-  else
-  {
-    cfg_filename = string(home_dir);
-    cfg_filename += "/.svxlink/svxreflector.conf";
-    if (!cfg.open(cfg_filename))
-    {
-      cfg_filename = SVX_SYSCONF_INSTALL_DIR "/svxreflector.conf";
-      if (!cfg.open(cfg_filename))
-      {
-        cerr << "*** ERROR: Could not open configuration file";
-        if (errno != 0)
-        {
-          cerr << " (" << strerror(errno) << ")";
-        }
-        cerr << ".\n";
-        cerr << "Tried the following paths:\n"
-             << "\t" << home_dir << "/.svxlink/svxreflector.conf\n"
-             << "\t" SVX_SYSCONF_INSTALL_DIR "/svxreflector.conf\n"
-             << "Possible reasons for failure are: None of the files exist,\n"
-             << "you do not have permission to read the file or there was a\n"
-             << "syntax error in the file.\n";
-        exit(1);
-      }
-    }
-  }
-  string main_cfg_filename(cfg_filename);
-
-  std::string main_cfg_dir = ".";
-  auto slash_pos = main_cfg_filename.rfind('/');
-  if (slash_pos != std::string::npos)
-  {
-    main_cfg_dir = main_cfg_filename.substr(0, slash_pos);
+    cerr << "*** ERROR: " << cfg.getLastError() << endl;
+    exit(1);
   }
 
-  string cfg_dir;
-  if (cfg.getValue("GLOBAL", "CFG_DIR", cfg_dir))
+  cout << "Configuration loaded from: " << cfg.getMainConfigFile()
+       << " (" << cfg.getBackendType() << " backend)" << endl;
+
+  if (init_db)
   {
-    if (cfg_dir[0] != '/')
+    if (cfg.getBackendType() == "file")
     {
-      cfg_dir = main_cfg_dir + "/" + cfg_dir;
-    }
-
-    DIR *dir = opendir(cfg_dir.c_str());
-    if (dir == NULL)
-    {
-      cerr << "*** ERROR: Could not read from directory spcified by "
-           << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
+      cerr << "*** ERROR: --init-db requires a database backend"
+              " (use --dbconfig or set up db.conf)" << endl;
       exit(1);
     }
-
-    struct dirent *dirent;
-    while ((dirent = readdir(dir)) != NULL)
+    if (!cfg.listSections().empty())
     {
-      char *dot = strrchr(dirent->d_name, '.');
-      if ((dot == NULL) || (dirent->d_name[0] == '.') ||
-          (strcmp(dot, ".conf") != 0))
-      {
-        continue;
-      }
-      cfg_filename = cfg_dir + "/" + dirent->d_name;
-      if (!cfg.open(cfg_filename))
-       {
-	 cerr << "*** ERROR: Could not open configuration file: "
-	      << cfg_filename << endl;
-	 exit(1);
-       }
+      cout << "*** WARNING: --init-db: database is not empty, skipping import" << endl;
     }
-
-    if (closedir(dir) == -1)
+    else
     {
-      cerr << "*** ERROR: Error closing directory specified by"
-           << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
-      exit(1);
+      if (!cfg.importFromConfigFile("svxreflector.conf"))
+        cerr << "*** WARNING: --init-db: could not import from svxreflector.conf" << endl;
     }
   }
 
@@ -372,7 +316,7 @@ int main(int argc, const char *argv[])
           "terms and conditions in the\n";
   cout << "GNU GPL (General Public License) version 2 or later.\n";
 
-  cout << "\nUsing configuration file: " << main_cfg_filename << endl;
+  cout << "\nUsing configuration file: " << cfg.getMainConfigFile() << endl;
 
   struct termios org_termios = {0};
   if (logfile_name == 0)
@@ -444,6 +388,10 @@ static void parse_arguments(int argc, const char **argv)
             "Specify the user to run SvxLink as", "<username>"},
     {"config", 0, POPT_ARG_STRING, &config, 0,
 	    "Specify the configuration file to use", "<filename>"},
+    {"dbconfig", 0, POPT_ARG_STRING, &dbconfig, 0,
+	    "Specify the database configuration file to use", "<filename>"},
+    {"init-db", 0, POPT_ARG_NONE, &init_db, 0,
+	    "Initialize an empty database backend from the installed svxreflector.conf", NULL},
     /*
     {"int_arg", 'i', POPT_ARG_INT, &int_arg, 0,
 	    "Description of int argument", "<an int>"},

--- a/src/svxlink/remotetrx/NetTrxAdapter.cpp
+++ b/src/svxlink/remotetrx/NetTrxAdapter.cpp
@@ -486,6 +486,20 @@ bool NetTrxAdapter::initialize(void)
   prev_src->registerSink(rxa1, true);
   prev_src = 0;
 
+  cfg.subscribeValue(net_uplink_name, "RX_SIGLEV", 1.0f, [this](float siglev) {
+    // We could have a class member holding this....
+    char rx_id = Rx::ID_UNKNOWN;
+    if (!cfg.getValue(net_uplink_name, "RX_ID", rx_id, true))
+    {
+      cerr << "*** ERROR: Invalid RX id specified for RX "
+           << net_uplink_name << endl;
+      return false;
+    }
+
+    rxa1->setSignalLevel(rx_id, siglev);
+    return true;
+  });
+
   txa1->sigTransmit.connect(mem_fun(*rxa1, &RxAdapter::setSquelchState));
   txa1->sendDtmfDigit.connect(rxa1->dtmfDigitDetected.make_slot());
   txa1->sendTone.connect(rxa1->toneDetected.make_slot());

--- a/src/svxlink/remotetrx/NetTrxAdapter.cpp
+++ b/src/svxlink/remotetrx/NetTrxAdapter.cpp
@@ -486,8 +486,7 @@ bool NetTrxAdapter::initialize(void)
   prev_src->registerSink(rxa1, true);
   prev_src = 0;
 
-  cfg.subscribeValue(net_uplink_name, "RX_SIGLEV", 1.0f, [this](float siglev) {
-    // We could have a class member holding this....
+  m_sub_rx_siglev = cfg.subscribeValue(net_uplink_name, "RX_SIGLEV", 1.0f, [this](float siglev) {
     char rx_id = Rx::ID_UNKNOWN;
     if (!cfg.getValue(net_uplink_name, "RX_ID", rx_id, true))
     {

--- a/src/svxlink/remotetrx/NetTrxAdapter.h
+++ b/src/svxlink/remotetrx/NetTrxAdapter.h
@@ -172,6 +172,7 @@ class NetTrxAdapter
     TxAdapter*      txa2;
     RxAdapter*      rxa1;
     std::string     net_uplink_name;
+    Async::Config::Subscription m_sub_rx_siglev;
     
     NetTrxAdapter(const NetTrxAdapter&);
     NetTrxAdapter& operator=(const NetTrxAdapter&);

--- a/src/svxlink/remotetrx/NetUplink.cpp
+++ b/src/svxlink/remotetrx/NetUplink.cpp
@@ -895,6 +895,54 @@ void NetUplink::forceDisconnect(void)
   clientDisconnected(con, TcpConnection::DR_ORDERED_DISCONNECT);
 } /* NetUplink::forceDisconnect */
 
+void NetUplink::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  if (section == name)
+  {
+    if (tag == "FALLBACK_REPEATER")
+    {
+      cfg.getValue(name, "FALLBACK_REPEATER", fallback_enabled, true);
+      if (fallback_enabled)
+      {
+        setFallbackActive(true);
+      }
+      else
+      {
+        rx->setMuteState(Rx::MUTE_CONTENT);
+      }
+    }
+    else if (tag == "AUTH_KEY")
+    {
+      auth_key = value;
+    }
+    else if (tag == "MUTE_TX_ON_RX")
+    {
+      int mute_tx_on_rx = -1;
+      cfg.getValue(name, "MUTE_TX_ON_RX", mute_tx_on_rx);
+      if (mute_tx_on_rx >= 0)
+      {
+        if(mute_tx_timer != 0)
+        {
+          mute_tx_timer->setTimeout(mute_tx_on_rx);
+        }
+        else
+        {
+          mute_tx_timer = new Timer(mute_tx_on_rx);
+          mute_tx_timer->setEnable(false);
+          mute_tx_timer->expired.connect(mem_fun(*this, &NetUplink::unmuteTx));
+        }
+      }
+      else
+      {
+        if(mute_tx_timer != 0)
+        {
+          delete mute_tx_timer;
+          mute_tx_timer = 0;
+        }
+      }
+    }
+  }
+} /* NetUplink::cfgUpdated */
 
 /*
  * This file has not been truncated

--- a/src/svxlink/remotetrx/NetUplink.h
+++ b/src/svxlink/remotetrx/NetUplink.h
@@ -239,6 +239,8 @@ class NetUplink : public Uplink
     void forceDisconnect(void);
     void setState(State new_state) { state = new_state; }
 
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
+
 };  /* class NetUplink */
 
 

--- a/src/svxlink/remotetrx/RfUplink.cpp
+++ b/src/svxlink/remotetrx/RfUplink.cpp
@@ -272,7 +272,7 @@ bool RfUplink::initialize(void)
   uplink_rx->setMuteState(Rx::MUTE_NONE);
   if (mute_rx_on_tx)
   {
-    uplink_tx->transmitterStateChange.connect(
+    uplink_tx_transmitter_state_change_connection = uplink_tx->transmitterStateChange.connect(
         mem_fun(*this, &RfUplink::uplinkTxTransmitterStateChange));
   }
   prev_src = uplink_rx;
@@ -398,7 +398,61 @@ void RfUplink::uplinkTxTransmitterStateChange(bool is_transmitting)
   uplink_rx->setMuteState(is_transmitting ? Rx::MUTE_ALL : Rx::MUTE_NONE);
 } /* RfUplink::uplinkTxTransmitterStateChange */
 
+void RfUplink::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  if (section == name)
+  {
+    if (tag == "MUTE_UPLINK_RX_ON_TX")
+    {
+      bool mute_rx_on_tx = false;
+      mute_rx_on_tx = atoi(value.c_str()) != 0;
 
+      uplink_tx_transmitter_state_change_connection.disconnect();
+
+      if(mute_rx_on_tx)
+      {
+        uplink_tx_transmitter_state_change_connection = uplink_tx->
+          transmitterStateChange.connect(mem_fun(*this, &RfUplink::uplinkTxTransmitterStateChange));
+      }
+    }
+    else if (tag == "LOOP_RX_TO_TX")
+    {
+      bool loop_rx_to_tx = false;
+      loop_rx_to_tx = atoi(value.c_str()) != 0;
+
+      // Not really sure how I'm going to handle this yet...
+      // TODO -- TO BE IMPLEMENTED
+      if(loop_rx_to_tx)
+      {
+
+      }
+      else 
+      {
+      
+      }
+    }
+    else if (tag == "DETECT_CTCSS")
+    {
+      std::vector<CtcssDetPar> ctcss_det_par;
+      if (!cfg.getValue(name, "DETECT_CTCSS", ctcss_det_par, true))
+      {
+        cerr << "*** ERROR: Format error for config variable "
+             << name << "/DETECT_CTCSS. Valid format: "
+             << "tone_fq:min_duration\n";
+        return;
+      }
+
+      // Yeah, well, how to remove the already added tone detectors and
+      // add the new ones?
+      // TODO -- TO BE IMPLEMENTED
+    }
+    else if (tag == "DETECT_1750")
+    {
+      // Yeah, and another one .......
+      // TODO -- TO BE IMPLEMENTED
+    }
+  }
+} /* RfUplink::cfgUpdated */
 
 /*
  * This file has not been truncated

--- a/src/svxlink/remotetrx/RfUplink.h
+++ b/src/svxlink/remotetrx/RfUplink.h
@@ -150,6 +150,11 @@ class RfUplink : public Uplink
     Rx	      	         *uplink_rx;
     Async::AudioSelector *tx_audio_sel;
     
+    // Connections to connect/disconnect
+    // when config values change
+    // yeah, it's big, I know, it's to make it clear
+    sigc::connection uplink_tx_transmitter_state_change_connection;
+    
     RfUplink(const RfUplink&);
     RfUplink& operator=(const RfUplink&);
     
@@ -161,6 +166,7 @@ class RfUplink : public Uplink
     void rxDtmfDigitDetected(char digit, int duration);
     void rxToneDetected(float fq);
     void uplinkTxTransmitterStateChange(bool is_transmitting);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
 
 };  /* class RfUplink */
 

--- a/src/svxlink/remotetrx/remotetrx.cpp
+++ b/src/svxlink/remotetrx/remotetrx.cpp
@@ -39,7 +39,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <unistd.h>
 #include <signal.h>
 #include <termios.h>
-#include <dirent.h>
 #include <popt.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -182,9 +181,11 @@ namespace {
   char*                 logfile_name = nullptr;
   char*                 runasuser = nullptr;
   char*                 config = nullptr;
+  char*                 dbconfig = nullptr;
   int                   daemonize = 0;
   int                   reset = 0;
   int                   quiet = 0;
+  int                   init_db = 0;
   FdWatch*              stdin_watch = 0;
   LogWriter             logwriter;
 };
@@ -329,96 +330,33 @@ int main(int argc, char **argv)
   }
   
   Config cfg;
-  string cfg_filename;
-  if (config != NULL)
+  if (!cfg.openWithFallback(config ? string(config) : "",
+                             dbconfig ? string(dbconfig) : "",
+                             "remotetrx.conf"))
   {
-    cfg_filename = string(config);
-    if (!cfg.open(cfg_filename))
-    {
-      cerr << "*** ERROR: Could not open configuration file: "
-      	   << config << endl;
-      exit(1);
-    }
+    cerr << "*** ERROR: " << cfg.getLastError() << endl;
+    exit(1);
   }
-  else
+
+  cout << "Configuration loaded from: " << cfg.getMainConfigFile()
+       << " (" << cfg.getBackendType() << " backend)" << endl;
+
+  if (init_db)
   {
-    cfg_filename = string(home_dir);
-    cfg_filename += "/.svxlink/remotetrx.conf";
-    if (!cfg.open(cfg_filename))
+    if (cfg.getBackendType() == "file")
     {
-      cfg_filename = SVX_SYSCONF_INSTALL_DIR "/remotetrx.conf";
-      if (!cfg.open(cfg_filename))
-      {
-	cfg_filename = SYSCONF_INSTALL_DIR "/remotetrx.conf";
-	if (!cfg.open(cfg_filename))
-	{
-	  cerr << "*** ERROR: Could not open configuration file";
-          if (errno != 0)
-          {
-            cerr << " (" << strerror(errno) << ")";
-          }
-          cerr << ".\n";
-	  cerr << "Tried the following paths:\n"
-      	       << "\t" << home_dir << "/.svxlink/remotetrx.conf\n"
-      	       << "\t" SVX_SYSCONF_INSTALL_DIR "/remotetrx.conf\n"
-	       << "\t" SYSCONF_INSTALL_DIR "/remotetrx.conf\n"
-	       << "Possible reasons for failure are: None of the files exist,\n"
-	       << "you do not have permission to read the file or there was a\n"
-	       << "syntax error in the file.\n";
-	  exit(1);
-	}
-      }
-    }
-  }
-  string main_cfg_filename(cfg_filename);
-  
-  string cfg_dir;
-  if (cfg.getValue("GLOBAL", "CFG_DIR", cfg_dir))
-  {
-    if (cfg_dir[0] != '/')
-    {
-      int slash_pos = main_cfg_filename.rfind('/');
-      if (slash_pos != -1)
-      {
-      	cfg_dir = main_cfg_filename.substr(0, slash_pos+1) + cfg_dir;
-      }
-      else
-      {
-      	cfg_dir = string("./") + cfg_dir;
-      }
-    }
-    
-    DIR *dir = opendir(cfg_dir.c_str());
-    if (dir == NULL)
-    {
-      cerr << "*** ERROR: Could not read from directory spcified by "
-      	   << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
+      cerr << "*** ERROR: --init-db requires a database backend"
+              " (use --dbconfig or set up db.conf)" << endl;
       exit(1);
     }
-    
-    struct dirent *dirent;
-    while ((dirent = readdir(dir)) != NULL)
+    if (!cfg.listSections().empty())
     {
-      char *dot = strrchr(dirent->d_name, '.');
-      if ((dot == NULL) || (dirent->d_name[0] == '.') ||
-          (strcmp(dot, ".conf") != 0))
-      {
-      	continue;
-      }
-      cfg_filename = cfg_dir + "/" + dirent->d_name;
-      if (!cfg.open(cfg_filename))
-       {
-	 cerr << "*** ERROR: Could not open configuration file: "
-	      << cfg_filename << endl;
-	 exit(1);
-       }
+      cout << "*** WARNING: --init-db: database is not empty, skipping import" << endl;
     }
-    
-    if (closedir(dir) == -1)
+    else
     {
-      cerr << "*** ERROR: Error closing directory specified by"
-      	   << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
-      exit(1);
+      if (!cfg.importFromConfigFile("remotetrx.conf"))
+        cerr << "*** WARNING: --init-db: could not import from remotetrx.conf" << endl;
     }
   }
 
@@ -434,7 +372,7 @@ int main(int argc, char **argv)
           "terms and conditions in the\n";
   cout << "GNU GPL (General Public License) version 2 or later.\n";
 
-  cout << "\nUsing configuration file: " << main_cfg_filename << endl;
+  cout << "\nUsing configuration file: " << cfg.getMainConfigFile() << endl;
   
   string value;
   if (cfg.getValue("GLOBAL", "CARD_SAMPLE_RATE", value))
@@ -580,6 +518,10 @@ static void parse_arguments(int argc, const char **argv)
             "Specify the user to run SvxLink as", "<username>"},
     {"config", 0, POPT_ARG_STRING, &config, 0,
 	    "Specify the configuration file to use", "<filename>"},
+    {"dbconfig", 0, POPT_ARG_STRING, &dbconfig, 0,
+	    "Specify the database configuration file to use", "<filename>"},
+    {"init-db", 0, POPT_ARG_NONE, &init_db, 0,
+	    "Initialize an empty database backend from the installed remotetrx.conf", NULL},
     /*
     {"int_arg", 'i', POPT_ARG_INT, &int_arg, 0,
 	    "Description of int argument", "<an int>"},

--- a/src/svxlink/siglevdetcal/siglevdetcal.cpp
+++ b/src/svxlink/siglevdetcal/siglevdetcal.cpp
@@ -33,7 +33,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <iostream>
 #include <cstdlib>
 #include <map>
-
+#include <string.h>
 
 /****************************************************************************
  *
@@ -321,19 +321,71 @@ int main(int argc, char **argv)
           "terms and conditions in\n";
   cout << "the GNU GPL (General Public License) version 2 or later.\n\n";
 
-  if (argc < 3)
+  // Argument parsing:
+  //   siglevdetcal [--config <file>] [--dbconfig <file>] <section>
+  //   siglevdetcal <config-file-or-db.conf> <section>      (legacy)
+  string cli_config;
+  string cli_dbconfig;
+  string rx_name;
+
+  int argi = 1;
+  while (argi < argc)
   {
-    cerr << "Usage: siglevdetcal <config file> <receiver section>\n";
+    if (strcmp(argv[argi], "--config") == 0 && argi + 1 < argc)
+    {
+      cli_config = argv[++argi];
+    }
+    else if (strcmp(argv[argi], "--dbconfig") == 0 && argi + 1 < argc)
+    {
+      cli_dbconfig = argv[++argi];
+    }
+    else
+    {
+      break;
+    }
+    ++argi;
+  }
+
+  // Remaining positional arguments
+  int pos_count = argc - argi;
+  if (pos_count == 1)
+  {
+    rx_name = argv[argi];
+  }
+  else if (pos_count == 2 && cli_config.empty() && cli_dbconfig.empty())
+  {
+    const string legacy_cfg(argv[argi]);
+    rx_name = argv[argi + 1];
+    if (legacy_cfg.find("db.conf") != string::npos)
+      cli_dbconfig = legacy_cfg;
+    else
+      cli_config = legacy_cfg;
+  }
+  else
+  {
+    cerr << "Usage: " << argv[0]
+         << " [--config <file>] [--dbconfig <file>] <receiver section>\n"
+         << "       " << argv[0]
+         << " <config file or db.conf> <receiver section>  (legacy)\n\n"
+         << "If no --config / --dbconfig option is given, the standard\n"
+         << "locations are searched for db.conf and then svxlink.conf.\n";
     exit(1);
   }
-  string cfg_file(argv[1]);
-  string rx_name(argv[2]);
-  
-  if (!cfg.open(cfg_file))
+
+  if (rx_name.empty())
   {
-    cerr << "*** ERROR: Could not open config file \"" << cfg_file << "\"\n";
+    cerr << "*** ERROR: No receiver section specified\n";
     exit(1);
   }
+
+  if (!cfg.openWithFallback(cli_config, cli_dbconfig, "svxlink.conf"))
+  {
+    cerr << "*** ERROR: " << cfg.getLastError() << "\n";
+    exit(1);
+  }
+
+  cout << "Configuration loaded from: " << cfg.getMainConfigFile()
+       << " (" << cfg.getBackendType() << " backend)" << endl;
   
   string value;
   if (cfg.getValue("GLOBAL", "CARD_SAMPLE_RATE", value))

--- a/src/svxlink/svxlink/Logic.cpp
+++ b/src/svxlink/svxlink/Logic.cpp
@@ -1844,16 +1844,10 @@ void Logic::detectedTone(float fq)
 } /* Logic::detectedTone */
 
 
-void Logic::cfgUpdated(const std::string& section, const std::string& tag)
+void Logic::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
 {
   if (section == name())
-  {
-    std::string value;
-    if (cfg().getValue(name(), tag, value))
-    {
-      event_handler->setVariable(name() + "::Logic::CFG_" + tag, value);
-      processEvent("config_updated CFG_" + tag + " \"" + value + "\"");
-    }
+  {    
     if (tag == "ONLINE")
     {
       bool online;
@@ -1862,6 +1856,57 @@ void Logic::cfgUpdated(const std::string& section, const std::string& tag)
         setOnline(online);
       }
     }
+    else if (tag == "EXEC_CMD_ON_SQL_CLOSE")
+    {
+      int exec_cmd_on_sql_close = -1;
+      if (cfg().getValue(name(), "EXEC_CMD_ON_SQL_CLOSE", exec_cmd_on_sql_close))
+      {
+        exec_cmd_on_sql_close_timer.setTimeout(exec_cmd_on_sql_close);
+      }
+    }
+    else if (tag == "RGR_SOUND_DELAY")
+    {
+      int rgr_sound_delay = -1;
+      if (cfg().getValue(name(), "RGR_SOUND_DELAY", rgr_sound_delay))
+      {
+        rgr_sound_timer.setTimeout(rgr_sound_delay);
+      }
+    }
+    else if (tag == "REPORT_CTCSS")
+    {
+      cfg().getValue(name(), "REPORT_CTCSS", report_ctcss);
+      char str[256];
+      sprintf(str, "%.1f", report_ctcss);
+      event_handler->setVariable("report_ctcss", str);
+    }
+    else if (tag == "FX_GAIN_NORMAL")
+    {
+      // This only updates when audioStreamStateChange is called
+      cfg().getValue(name(), "FX_GAIN_NORMAL", fx_gain_normal);
+    }
+    else if (tag == "FX_GAIN_LOW")
+    {
+      // This only updates when audioStreamStateChange is called
+      cfg().getValue(name(), "FX_GAIN_LOW", fx_gain_low);
+    }
+    else if (tag == "CTCSS_TO_TG_DELAY")
+    {
+      int ctcss_to_tg_delay = 0;
+      if (cfg().getValue(name(), "CTCSS_TO_TG_DELAY", ctcss_to_tg_delay))
+      {
+        m_ctcss_to_tg_timer.setTimeout(ctcss_to_tg_delay);
+      }
+    }
+    // Note: RX, TX, CALLSIGN, EVENT_HANDLER changes would require restart
+    // Note: MACRO_PREFIX, SEL5_MACRO_RANGE, ACTIVATE_MODULE_ON_LONG_CMD changes
+    //       would require command parser re-initialization
+    // Note: TX_CTCSS changes would require updating tx_ctcss_mask, which is complex
+
+    // Always signal TCL scripts that a configuration change happened
+    // This allows TCL scripts to refresh their local variables from Config
+    std::ostringstream event;
+    event << "config_updated \"" << section << "\" \"" << tag << "\" \"" << value << "\"";
+    processEvent(event.str());
   }
 } /* Logic::cfgUpdated */
 

--- a/src/svxlink/svxlink/Logic.h
+++ b/src/svxlink/svxlink/Logic.h
@@ -313,7 +313,7 @@ class Logic : public LogicBase
     void onPublishStateEvent(const std::string &event_name,
                              const std::string &msg);
     void detectedTone(float fq);
-    void cfgUpdated(const std::string& section, const std::string& tag);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
     bool getConfigValue(const std::string& section, const std::string& tag,
                         std::string& value);
     void signalLevelUpdated(float siglev);

--- a/src/svxlink/svxlink/Logic.tcl
+++ b/src/svxlink/svxlink/Logic.tcl
@@ -73,6 +73,39 @@ proc startup {} {
   addMinuteTickSubscriber checkPeriodicIdentify
 }
 
+#
+# Executed when a config variable changes
+#
+proc config_updated {section tag value} {
+  printInfo "Configuration variable $section $tag changed to $value"
+
+  variable long_ident_interval
+  variable short_ident_interval
+  variable short_voice_id_enable
+  variable short_cw_id_enable
+  variable short_announce_enable
+  variable short_announce_file
+  variable long_voice_id_enable
+  variable long_cw_id_enable
+  variable long_announce_enable
+  variable long_announce_file
+  variable ident_only_after_tx
+
+  set long_ident_interval [getConfigValue ${::logic_name} LONG_IDENT_INTERVAL 0]
+  set short_ident_interval [getConfigValue ${::logic_name} SHORT_IDENT_INTERVAL $long_ident_interval]
+
+  set short_voice_id_enable [getConfigValue ${::logic_name} SHORT_VOICE_ID_ENABLE 1]
+  set short_cw_id_enable [getConfigValue ${::logic_name} SHORT_CW_ID_ENABLE 0]
+  set short_announce_enable [getConfigValue ${::logic_name} SHORT_ANNOUNCE_ENABLE 0]
+  set short_announce_file [getConfigValue ${::logic_name} SHORT_ANNOUNCE_FILE ""]
+
+  set long_voice_id_enable [getConfigValue ${::logic_name} LONG_VOICE_ID_ENABLE 1]
+  set long_cw_id_enable [getConfigValue ${::logic_name} LONG_CW_ID_ENABLE 0]
+  set long_announce_enable [getConfigValue ${::logic_name} LONG_ANNOUNCE_ENABLE 0]
+  set long_announce_file [getConfigValue ${::logic_name} LONG_ANNOUNCE_FILE ""]
+
+  set ident_only_after_tx [getConfigValue ${::logic_name} IDENT_ONLY_AFTER_TX 0]
+}
 
 #
 # Executed when a specified module could not be found
@@ -749,16 +782,6 @@ proc logic_online {online} {
     }
   }
 }
-
-
-#
-# Executed when a configuration variable is updated at runtime in the logic
-# core
-#
-proc config_updated {tag value} {
-  #printInfo "Configuration variable updated: $tag=$value"
-}
-
 
 #
 # Executed when a DTMF command is received from another linked logic core

--- a/src/svxlink/svxlink/Module.cpp
+++ b/src/svxlink/svxlink/Module.cpp
@@ -272,16 +272,46 @@ bool Module::squelchIsOpen(void)
 } /* Module::squelchIsOpen */
 
 
-void Module::cfgUpdated(const std::string& section, const std::string& tag)
+void Module::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
 {
   if (section == cfgName())
   {
-    std::string value;
-    if (cfg().getValue(cfgName(), tag, value))
+    if (tag == "TIMEOUT")
     {
-      setEventVariable(name() + "::CFG_" + tag, value);
-      processEvent("config_updated CFG_" + tag + " \"" + value + "\"");
+      string timeout_str;
+      if (cfg().getValue(cfgName(), "TIMEOUT", timeout_str))
+      {
+        unsigned timeout = atoi(timeout_str.c_str());
+        if (timeout > 0)
+        {
+          if (m_tmo_timer == 0)
+          {
+            m_tmo_timer = new Timer(1000 * timeout);
+            m_tmo_timer->setEnable(false);
+            m_tmo_timer->expired.connect(mem_fun(*this, &Module::moduleTimeout));
+          }
+          else
+          {
+            m_tmo_timer->setTimeout(1000 * timeout);
+          }
+        }
+        else if (m_tmo_timer != 0)
+        {
+          delete m_tmo_timer;
+          m_tmo_timer = 0;
+        }
+      }
     }
+    else if (tag == "MUTE_LOGIC_LINKING")
+    {
+      cfg().getValue(cfgName(), "MUTE_LOGIC_LINKING", m_mute_linking);
+      // Apply the new setting if module is active
+      if (m_is_active)
+      {
+        m_logic->setMuteLinking(m_mute_linking);
+      }
+    }
+    // ID and NAME changes would require restart
   }
 } /* Module::cfgUpdated */
 

--- a/src/svxlink/svxlink/Module.h
+++ b/src/svxlink/svxlink/Module.h
@@ -497,7 +497,8 @@ class Module : public sigc::trackable, public Async::AudioSink,
      * @param   tag     The name of the configuration variable
      */
     virtual void cfgUpdated(const std::string& section,
-                            const std::string& tag);
+                            const std::string& tag,
+                            const std::string& value);
 
   private:
     void      	      *m_dl_handle;

--- a/src/svxlink/svxlink/QsoRecorder.h
+++ b/src/svxlink/svxlink/QsoRecorder.h
@@ -137,7 +137,15 @@ class QsoRecorder
      * @param   name The name of the config section tp read config from
      * @return  Returns \rm true on success or else \em false
      */
-    bool initialize(const Async::Config &cfg, const std::string &name);
+    bool initialize(Async::Config &cfg, const std::string &name);
+
+    /**
+     * @brief   Handle configuration updates
+     * @param   section The configuration section name
+     * @param   tag     The configuration tag that was updated
+     * @param   value   The new value
+     */
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
 
     /**
      * @brief   Add an audio source to the QSO recorder
@@ -191,6 +199,8 @@ class QsoRecorder
     Async::Timer          *qso_tmo_timer;
     unsigned              min_samples;
     std::string           encoder_cmd;
+    Async::Config         *cfg_ptr;
+    std::string           cfg_section;
 
     QsoRecorder(const QsoRecorder&);
     QsoRecorder& operator=(const QsoRecorder&);

--- a/src/svxlink/svxlink/ReflectorLogic.cpp
+++ b/src/svxlink/svxlink/ReflectorLogic.cpp
@@ -650,6 +650,8 @@ bool ReflectorLogic::initialize(Async::Config& cfgobj, const std::string& logic_
   cfg().getValue(name(), "UDP_HEARTBEAT_INTERVAL",
       m_udp_heartbeat_tx_cnt_reset);
 
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &ReflectorLogic::cfgUpdated));
+
   Async::Application::app().runTask([&]{ connect(); });
 
   return true;
@@ -2764,6 +2766,83 @@ void ReflectorLogic::csrAddSubjectNamesFromConfig(void)
     }
   }
 } /* ReflectorLogic::csrAddSubjectName */
+
+
+void ReflectorLogic::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  if (section == name())
+  {
+    if (tag == "MUTE_FIRST_TX_LOC")
+    {
+      cfg().getValue(name(), "MUTE_FIRST_TX_LOC", m_mute_first_tx_loc);
+    }
+    else if (tag == "MUTE_FIRST_TX_REM")
+    {
+      cfg().getValue(name(), "MUTE_FIRST_TX_REM", m_mute_first_tx_rem);
+    }
+    else if (tag == "TMP_MONITOR_TIMEOUT")
+    {
+      cfg().getValue(name(), "TMP_MONITOR_TIMEOUT", m_tmp_monitor_timeout);
+    }
+    else if (tag == "UDP_HEARTBEAT_INTERVAL")
+    {
+      cfg().getValue(name(), "UDP_HEARTBEAT_INTERVAL", m_udp_heartbeat_tx_cnt_reset);
+    }
+    else if (tag == "DEFAULT_TG")
+    {
+      cfg().getValue(name(), "DEFAULT_TG", m_default_tg);
+    }
+    else if (tag == "VERBOSE")
+    {
+      cfg().getValue(name(), "VERBOSE", m_verbose);
+    }
+    else if (tag == "TG_SELECT_TIMEOUT")
+    {
+      unsigned new_timeout;
+      if (cfg().getValue(name(), "TG_SELECT_TIMEOUT", 1U,
+                         std::numeric_limits<unsigned>::max(),
+                         new_timeout, true))
+      {
+        m_tg_select_timeout = new_timeout;
+        // Update current timeout counter if TG is selected
+        if (m_selected_tg > 0)
+        {
+          m_tg_select_timeout_cnt = m_tg_select_timeout;
+        }
+      }
+      else
+      {
+        std::cerr << "*** ERROR[" << name()
+                  << "]: Illegal value for TG_SELECT_TIMEOUT: " << value
+                  << std::endl;
+      }
+    }
+    else if (tag == "TG_SELECT_INHIBIT_TIMEOUT")
+    {
+      unsigned new_timeout;
+      if (cfg().getValue(name(), "TG_SELECT_INHIBIT_TIMEOUT", 0U,
+                         std::numeric_limits<unsigned>::max(),
+                         new_timeout, true))
+      {
+        m_tg_select_inhibit_timeout = new_timeout;
+      }
+      else
+      {
+        std::cerr << "*** ERROR[" << name()
+                  << "]: Illegal value for TG_SELECT_INHIBIT_TIMEOUT: " << value
+                  << std::endl;
+      }
+    }
+    else if (tag == "QSY_PENDING_TIMEOUT")
+    {
+      int qsy_pending_timeout = -1;
+      cfg().getValue(name(), "QSY_PENDING_TIMEOUT", qsy_pending_timeout);
+      m_qsy_pending_timer.setTimeout(
+        (qsy_pending_timeout > 0) ? (1000 * qsy_pending_timeout) : -1);
+    }
+    
+  }
+} /* ReflectorLogic::cfgUpdated */
 
 
 /*

--- a/src/svxlink/svxlink/ReflectorLogic.h
+++ b/src/svxlink/svxlink/ReflectorLogic.h
@@ -285,6 +285,7 @@ class ReflectorLogic : public LogicBase
 
     ReflectorLogic(const ReflectorLogic&);
     ReflectorLogic& operator=(const ReflectorLogic&);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
     void onConnected(void);
     void onDisconnected(Async::TcpConnection *con,
                         Async::TcpConnection::DisconnectReason reason);

--- a/src/svxlink/svxlink/ReflectorV2Logic.cpp
+++ b/src/svxlink/svxlink/ReflectorV2Logic.cpp
@@ -462,6 +462,8 @@ bool ReflectorLogic::initialize(Async::Config& cfgobj, const std::string& logic_
   cfg().getValue(name(), "UDP_HEARTBEAT_INTERVAL",
       m_udp_heartbeat_tx_cnt_reset);
 
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &ReflectorLogic::cfgUpdated));
+
   connect();
 
   return true;
@@ -571,7 +573,7 @@ void ReflectorLogic::remoteCmdReceived(LogicBase* src_logic,
           }
           else
           {
-            std::cerr << "*** WARNING: Not allowed to add a temporary montior "
+            std::cerr << "*** WARNING: Not allowed to add a temporary monitor "
                          "for TG #" << tg << " which is being permanently "
                          "monitored" << std::endl;
             os << "command_failed " << cmd;
@@ -1904,6 +1906,87 @@ bool ReflectorLogic::getConfigValue(const std::string& section,
 {
   return cfg().getValue(section, tag, value, true);
 } /* ReflectorLogic::getConfigValue */
+
+
+void ReflectorLogic::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  if (section == name())
+  {
+    // Runtime-updatable boolean values
+    if (tag == "MUTE_FIRST_TX_LOC")
+    {
+      // TODO -- TO BE IMPLEMENTED
+      cfg().getValue(name(), "MUTE_FIRST_TX_LOC", m_mute_first_tx_loc);
+    }
+    else if (tag == "MUTE_FIRST_TX_REM")
+    {
+      // TODO -- TO BE IMPLEMENTED
+      cfg().getValue(name(), "MUTE_FIRST_TX_REM", m_mute_first_tx_rem);
+    }
+    else if (tag == "VERBOSE")
+    {
+      cfg().getValue(name(), "VERBOSE", m_verbose);
+    }
+    else if (tag == "TMP_MONITOR_TIMEOUT")
+    {
+      // Only updates on the next call to monitor tg, the current monitoring remains unchanged
+      cfg().getValue(name(), "TMP_MONITOR_TIMEOUT", m_tmp_monitor_timeout);
+    }
+    else if (tag == "UDP_HEARTBEAT_INTERVAL")
+    {
+      cfg().getValue(name(), "UDP_HEARTBEAT_INTERVAL", m_udp_heartbeat_tx_cnt_reset);
+    }
+    else if (tag == "DEFAULT_TG")
+    {
+      cfg().getValue(name(), "DEFAULT_TG", m_default_tg);
+    }
+    else if (tag == "TG_SELECT_TIMEOUT")
+    {
+      unsigned new_timeout;
+      if (cfg().getValue(name(), "TG_SELECT_TIMEOUT", 1U,
+                         std::numeric_limits<unsigned>::max(),
+                         new_timeout, true))
+      {
+        m_tg_select_timeout = new_timeout;
+        // Update current timeout counter if TG is selected
+        if (m_selected_tg > 0)
+        {
+          m_tg_select_timeout_cnt = m_tg_select_timeout;
+        }
+      }
+      else
+      {
+        std::cerr << "*** ERROR[" << name()
+                  << "]: Illegal value for TG_SELECT_TIMEOUT: " << value
+                  << std::endl;
+      }
+    }
+    else if (tag == "TG_SELECT_INHIBIT_TIMEOUT")
+    {
+      unsigned new_timeout;
+      if (cfg().getValue(name(), "TG_SELECT_INHIBIT_TIMEOUT", 0U,
+                         std::numeric_limits<unsigned>::max(),
+                         new_timeout, true))
+      {
+        m_tg_select_inhibit_timeout = new_timeout;
+      }
+      else
+      {
+        std::cerr << "*** ERROR[" << name()
+                  << "]: Illegal value for TG_SELECT_INHIBIT_TIMEOUT: " << value
+                  << std::endl;
+      }
+    }
+    else if (tag == "QSY_PENDING_TIMEOUT")
+    {
+      int qsy_pending_timeout = -1;
+      cfg().getValue(name(), "QSY_PENDING_TIMEOUT", qsy_pending_timeout);
+      m_qsy_pending_timer.setTimeout(
+        (qsy_pending_timeout > 0) ? (1000 * qsy_pending_timeout) : -1);
+    }
+    // Note: Anything else requires a restart.....
+  }
+} /* ReflectorLogic::cfgUpdated */
 
 
 /*

--- a/src/svxlink/svxlink/ReflectorV2Logic.h
+++ b/src/svxlink/svxlink/ReflectorV2Logic.h
@@ -301,6 +301,7 @@ class ReflectorLogic : public LogicBase
     void checkTmpMonitorTimeout(void);
     void qsyPendingTimeout(void);
     void checkIdle(void);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
     bool isIdle(void);
     void handlePlayFile(const std::string& path);
     void handlePlaySilence(int duration);

--- a/src/svxlink/svxlink/RepeaterLogic.cpp
+++ b/src/svxlink/svxlink/RepeaterLogic.cpp
@@ -625,21 +625,22 @@ void RepeaterLogic::squelchOpen(bool is_open)
 	
       if (sql_flap_sup_max_cnt > 0)
       {
-	if (diff_ms < sql_flap_sup_min_time)
-	{
-      	  if (++short_sql_open_cnt >= sql_flap_sup_max_cnt)
-	  {
-	    short_sql_open_cnt = 0;
-	    cout << name() << ": Interference detected: "
-                 << sql_flap_sup_max_cnt << " squelch openings less than "
-		 << sql_flap_sup_min_time << "ms in length detected.\n";
-	    setUp(false, "SQL_FLAP_SUP");
-	  }
-	}
-	else
-	{
-      	  short_sql_open_cnt = 0;
-	}
+        if (diff_ms < sql_flap_sup_min_time) 
+        {
+          if (++short_sql_open_cnt >= sql_flap_sup_max_cnt) 
+          {
+            short_sql_open_cnt = 0;
+            cout << name()
+                 << ": Interference detected: " << sql_flap_sup_max_cnt
+                 << " squelch openings less than " << sql_flap_sup_min_time
+                 << "ms in length detected.\n";
+            setUp(false, "SQL_FLAP_SUP");
+          }
+        } 
+        else 
+        {
+          short_sql_open_cnt = 0;
+        }
       }
       
       if (ident_nag_timer.isEnabled() && (diff_ms > ident_nag_min_time))
@@ -772,6 +773,111 @@ void RepeaterLogic::identNag(Timer *t)
   }
 } /* RepeaterLogic::identNag */
 
+
+void RepeaterLogic::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  if (section == name())
+  {
+    if (tag == "IDLE_TIMEOUT")
+    {
+      up_timer.setTimeout(atoi(value.c_str()));
+    }
+    else if (tag == "OPEN_ON_1750")
+    {
+      // TODO -- TO BE IMPLEMENTED
+      // Need to figure out how to change the already implemented tone detectors
+    }
+    else if (tag == "OPEN_ON_CTCSS")
+    {
+      // TODO -- TO BE IMPLEMENTED
+      // Need to save the signal connection object from the 
+      // open_on_ctcss_timer.expired and check if it exists,
+      // and if it doesn't, add it. If it exists and it's not
+      // supposed to exist anymore, disconnect it.
+    }
+    else if(tag == "OPEN_ON_SQL")
+    {
+      open_on_sql_timer.setTimeout(atoi(value.c_str()));
+    }
+    else if(tag == "OPEN_ON_SQL_AFTER_RPT_CLOSE")
+    {
+      open_on_sql_after_rpt_close = atoi(value.c_str());
+    }
+    else if(tag == "OPEN_ON_DTMF")
+    {
+      open_on_dtmf = value.c_str()[0];
+    }
+    else if(tag == "OPEN_ON_SEL5")
+    {
+      if (value.length() > 25 || value.length() < 4)
+      {
+        cerr << "*** WARNING: Sel5 sequence to long/short in logic " << name()
+           << ", valid range from 4 to 25 digits, ignoring\n";
+      }
+      else
+      {
+        open_on_sel5 = value;
+      }
+    }
+    else if(tag == "CLOSE_ON_SEL5")
+    {
+      if (value.length() > 25 || value.length() < 4)
+      {
+        cerr << "*** WARNING: Sel5 sequence to long/short in logic " << name()
+             << ", valid range from 4 to 25 digits, ignoring\n";
+      }
+      else
+      {
+        close_on_sel5 = value;
+      }
+    }
+    else if(tag == "OPEN_SQL_FLANK")
+    {
+      if (value == "OPEN")
+      {
+        open_sql_flank = SQL_FLANK_OPEN;
+      }
+      else if (value == "CLOSE")
+      {
+        open_sql_flank = SQL_FLANK_CLOSE;
+      }
+      else
+      {
+        cerr << "*** ERROR: Valid values for configuration variable "
+             << name() << "/OPEN_SQL_FLANK are OPEN and CLOSE.\n";
+      }
+    }
+    else if(tag == "IDLE_SOUND_INTERVAL")
+    {
+      idle_sound_timer.setTimeout(atoi(value.c_str()));
+    }
+    else if(tag == "NO_REPEAT")
+    {
+      no_repeat = atoi(value.c_str()) != 0;
+      rptValveSetOpen(!no_repeat);
+    }
+    else if(tag == "SQL_FLAP_SUP_MIN_TIME")
+    {
+      sql_flap_sup_min_time = atoi(value.c_str());
+    }
+    else if(tag == "SQL_FLAP_SUP_MAX_COUNT")
+    {
+      sql_flap_sup_max_cnt = atoi(value.c_str());
+    }
+    else if(tag == "IDENT_NAG_TIMEOUT")
+    {
+      ident_nag_timer.setTimeout(1000 * atoi(value.c_str()));
+    }
+    else if(tag == "IDENT_NAG_MIN_TIME")
+    {
+      ident_nag_min_time = atoi(value.c_str());
+    }
+    else if(tag == "DTMF_IGNORE_WHEN_NOT_UP")
+    {
+      m_dtmf_ignore_when_not_up = atoi(value.c_str()) != 0;
+    }
+  }
+} /* RepeaterLogic::cfgUpdated */
 
 
 /*

--- a/src/svxlink/svxlink/RepeaterLogic.h
+++ b/src/svxlink/svxlink/RepeaterLogic.h
@@ -221,6 +221,7 @@ class RepeaterLogic : public Logic
     void openOnSqlTimerExpired(Async::Timer *t);
     void activateOnOpenOrClose(SqlFlank flank);
     void identNag(Async::Timer *t);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
 
 };  /* class RepeaterLogic */
 

--- a/src/svxlink/svxlink/SimplexLogic.cpp
+++ b/src/svxlink/svxlink/SimplexLogic.cpp
@@ -144,13 +144,22 @@ bool SimplexLogic::initialize(Async::Config& cfgobj, const string& logic_name)
   cfg().getValue(name(), "MUTE_TX_ON_RX", mute_tx_on_rx);
   cfg().getValue(name(), "RGR_SOUND_ALWAYS", rgr_sound_always);
   
+  cfg().subscribeValue(name(), "MUTE_RX_ON_TX", mute_rx_on_tx, [&](bool value) {
+    mute_rx_on_tx = value;
+  });
+  cfg().subscribeValue(name(), "MUTE_TX_ON_RX", mute_tx_on_rx, [&](bool value) {
+    mute_tx_on_rx = value;
+  });
+  cfg().subscribeValue(name(), "RGR_SOUND_ALWAYS", rgr_sound_always, [&](bool value) {
+    rgr_sound_always = value;
+  });
+
   rxValveSetOpen(true);
   setTxCtrlMode(Tx::TX_AUTO);
   
   processEvent("startup");
   
   return true;
-  
 } /* SimplexLogic::initialize */
 
 

--- a/src/svxlink/svxlink/SimplexLogic.cpp
+++ b/src/svxlink/svxlink/SimplexLogic.cpp
@@ -144,15 +144,12 @@ bool SimplexLogic::initialize(Async::Config& cfgobj, const string& logic_name)
   cfg().getValue(name(), "MUTE_TX_ON_RX", mute_tx_on_rx);
   cfg().getValue(name(), "RGR_SOUND_ALWAYS", rgr_sound_always);
   
-  cfg().subscribeValue(name(), "MUTE_RX_ON_TX", mute_rx_on_tx, [&](bool value) {
-    mute_rx_on_tx = value;
-  });
-  cfg().subscribeValue(name(), "MUTE_TX_ON_RX", mute_tx_on_rx, [&](bool value) {
-    mute_tx_on_rx = value;
-  });
-  cfg().subscribeValue(name(), "RGR_SOUND_ALWAYS", rgr_sound_always, [&](bool value) {
-    rgr_sound_always = value;
-  });
+  m_sub_mute_rx_on_tx = cfg().subscribeValue(name(), "MUTE_RX_ON_TX", mute_rx_on_tx,
+      [&](bool value) { mute_rx_on_tx = value; });
+  m_sub_mute_tx_on_rx = cfg().subscribeValue(name(), "MUTE_TX_ON_RX", mute_tx_on_rx,
+      [&](bool value) { mute_tx_on_rx = value; });
+  m_sub_rgr_sound_always = cfg().subscribeValue(name(), "RGR_SOUND_ALWAYS", rgr_sound_always,
+      [&](bool value) { rgr_sound_always = value; });
 
   rxValveSetOpen(true);
   setTxCtrlMode(Tx::TX_AUTO);

--- a/src/svxlink/svxlink/SimplexLogic.h
+++ b/src/svxlink/svxlink/SimplexLogic.h
@@ -139,6 +139,10 @@ class SimplexLogic : public Logic
     bool  mute_rx_on_tx;
     bool  mute_tx_on_rx;
     bool  rgr_sound_always;
+
+    Async::Config::Subscription m_sub_mute_rx_on_tx;
+    Async::Config::Subscription m_sub_mute_tx_on_rx;
+    Async::Config::Subscription m_sub_rgr_sound_always;
     
 };  /* class SimplexLogic */
 

--- a/src/svxlink/svxlink/contrib/SipLogic/SipLogic.cpp
+++ b/src/svxlink/svxlink/contrib/SipLogic/SipLogic.cpp
@@ -1633,6 +1633,70 @@ bool SipLogic::getConfigValue(const std::string& section,
   return cfg().getValue(section, tag, value, true);
 } /* SipLogic::getConfigValue */
 
+
+void SipLogic::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  // Call parent implementation first (if it exists)
+  // LogicBase::cfgUpdated(section, tag, value);
+  
+  if (section == name())
+  {
+    if (tag == "USERNAME")
+    {
+      cfg().getValue(name(), "USERNAME", m_username);
+    }
+    else if (tag == "PASSWORD")
+    {
+      cfg().getValue(name(), "PASSWORD", m_password);
+    }
+    else if (tag == "SIPSERVER")
+    {
+      cfg().getValue(name(), "SIPSERVER", m_sipserver);
+    }
+    else if (tag == "SIPEXTENSION")
+    {
+      cfg().getValue(name(), "SIPEXTENSION", m_sipextension);
+    }
+    else if (tag == "SIPSCHEMA")
+    {
+      cfg().getValue(name(), "SIPSCHEMA", m_schema);
+    }
+    else if (tag == "SIPPORT")
+    {
+      cfg().getValue(name(), "SIPPORT", m_sip_port);
+    }
+    else if (tag == "SIPREGISTRAR")
+    {
+      cfg().getValue(name(), "SIPREGISTRAR", m_sipregistrar);
+    }
+    else if (tag == "AUTOANSWER")
+    {
+      cfg().getValue(name(), "AUTOANSWER", m_autoanswer);
+    }
+    else if (tag == "AUTOCONNECT")
+    {
+      cfg().getValue(name(), "AUTOCONNECT", m_autoconnect);
+    }
+    else if (tag == "CALLERNAME")
+    {
+      cfg().getValue(name(), "CALLERNAME", m_callername);
+    }
+    else if (tag == "SIP_LOGLEVEL")
+    {
+      cfg().getValue(name(), "SIP_LOGLEVEL", m_siploglevel);
+    }
+    else if (tag == "REG_TIMEOUT")
+    {
+      cfg().getValue(name(), "REG_TIMEOUT", m_reg_timeout);
+    }
+    else if (tag == "CALL_TIMEOUT")
+    {
+      cfg().getValue(name(), "CALL_TIMEOUT", m_calltimeout);
+    }
+  }
+} /* SipLogic::cfgUpdated */
+
+
 /*
  * This file has not been truncated
  */

--- a/src/svxlink/svxlink/contrib/SipLogic/SipLogic.h
+++ b/src/svxlink/svxlink/contrib/SipLogic/SipLogic.h
@@ -166,6 +166,13 @@ class SipLogic : public LogicBase
      * @brief 	Destructor
      */
     virtual ~SipLogic(void) override;
+    
+    /**
+     * @brief Called when a configuration parameter is updated
+     * @param section The configuration section name  
+     * @param tag The configuration tag name
+     */
+    virtual void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value) override;
 
     virtual void allMsgsWritten(void);
     std::string initCallHandler(int argc, const char* argv[]);

--- a/src/svxlink/svxlink/svxlink.cpp
+++ b/src/svxlink/svxlink/svxlink.cpp
@@ -373,25 +373,23 @@ int main(int argc, char **argv)
   // Hot-reload LOCATION_INFO: tear down and re-initialize LocationInfo when
   // the value changes at runtime.  We only subscribe for LOCATION INFO changes, 
   // because everything else requires a full restart.
-  cfg.subscribeOptionalValue("GLOBAL", "LOCATION_INFO", [&cfg](const std::string& value) {
-      // Do we have a location info section already ?!!??!
-      if(LocationInfo::has_instance())
-      {
-        LocationInfo::deleteInstance();
-      }
-
-      if(value.empty())
-      {
-        return;
-      }
-      
-      if (!LocationInfo::initialize(cfg, value))
-      {
-        std::cerr << "*** ERROR: Could not initialize the location info "
-                  << "subsystem. Check configuration section [" << value << "]."
-                  << std::endl;
-      }
-  });
+  auto loc_info_sub = cfg.subscribeOptionalValue("GLOBAL", "LOCATION_INFO",
+      [&cfg](const std::string& value) {
+        if(LocationInfo::has_instance())
+        {
+          LocationInfo::deleteInstance();
+        }
+        if(value.empty())
+        {
+          return;
+        }
+        if (!LocationInfo::initialize(cfg, value))
+        {
+          std::cerr << "*** ERROR: Could not initialize the location info "
+                    << "subsystem. Check configuration section [" << value << "]."
+                    << std::endl;
+        }
+      });
 
   // Init Logiclinking
   if (cfg.getValue("GLOBAL", "LINKS", value))

--- a/src/svxlink/svxlink/svxlink.cpp
+++ b/src/svxlink/svxlink/svxlink.cpp
@@ -37,7 +37,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <dirent.h>
 #include <pwd.h>
 #include <grp.h>
 
@@ -136,9 +135,11 @@ namespace {
   char*                 logfile_name = nullptr;
   char*                 runasuser = nullptr;
   char*                 config = nullptr;
+  char*                 dbconfig = nullptr;
   int                   daemonize = 0;
   int                   reset = 0;
   int                   quiet = 0;
+  int                   init_db = 0;
   vector<LogicBase*>    logic_vec;
   FdWatch*              stdin_watch = 0;
   LogWriter             logwriter;
@@ -274,96 +275,33 @@ int main(int argc, char **argv)
   }
   
   Config cfg;
-  string cfg_filename;
-  if (config != NULL)
+  if (!cfg.openWithFallback(config ? string(config) : "",
+                             dbconfig ? string(dbconfig) : "",
+                             "svxlink.conf"))
   {
-    cfg_filename = string(config);
-    if (!cfg.open(cfg_filename))
-    {
-      cerr << "*** ERROR: Could not open configuration file: "
-      	   << config << endl;
-      exit(1);
-    }
+    cerr << "*** ERROR: " << cfg.getLastError() << endl;
+    exit(1);
   }
-  else
+
+  cout << "Configuration loaded from: " << cfg.getMainConfigFile()
+       << " (" << cfg.getBackendType() << " backend)" << endl;
+
+  if (init_db)
   {
-    cfg_filename = string(home_dir);
-    cfg_filename += "/.svxlink/svxlink.conf";
-    if (!cfg.open(cfg_filename))
+    if (cfg.getBackendType() == "file")
     {
-      cfg_filename = SVX_SYSCONF_INSTALL_DIR "/svxlink.conf";
-      if (!cfg.open(cfg_filename))
-      {
-	cfg_filename = SYSCONF_INSTALL_DIR "/svxlink.conf";
-	if (!cfg.open(cfg_filename))
-	{
-	  cerr << "*** ERROR: Could not open configuration file";
-          if (errno != 0)
-          {
-            cerr << " (" << strerror(errno) << ")";
-          }
-          cerr << ".\n";
-	  cerr << "Tried the following paths:\n"
-      	       << "\t" << home_dir << "/.svxlink/svxlink.conf\n"
-      	       << "\t" SVX_SYSCONF_INSTALL_DIR "/svxlink.conf\n"
-	       << "\t" SYSCONF_INSTALL_DIR "/svxlink.conf\n"
-	       << "Possible reasons for failure are: None of the files exist,\n"
-	       << "you do not have permission to read the file or there was a\n"
-	       << "syntax error in the file.\n";
-	  exit(1);
-	}
-      }
-    }
-  }
-  string main_cfg_filename(cfg_filename);
-  
-  string cfg_dir;
-  if (cfg.getValue("GLOBAL", "CFG_DIR", cfg_dir))
-  {
-    if (cfg_dir[0] != '/')
-    {
-      int slash_pos = main_cfg_filename.rfind('/');
-      if (slash_pos != -1)
-      {
-      	cfg_dir = main_cfg_filename.substr(0, slash_pos+1) + cfg_dir;
-      }
-      else
-      {
-      	cfg_dir = string("./") + cfg_dir;
-      }
-    }
-    
-    DIR *dir = opendir(cfg_dir.c_str());
-    if (dir == NULL)
-    {
-      cerr << "*** ERROR: Could not read from directory spcified by "
-      	   << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
+      cerr << "*** ERROR: --init-db requires a database backend"
+              " (use --dbconfig or set up db.conf)" << endl;
       exit(1);
     }
-    
-    struct dirent *dirent;
-    while ((dirent = readdir(dir)) != NULL)
+    if (!cfg.listSections().empty())
     {
-      char *dot = strrchr(dirent->d_name, '.');
-      if ((dot == NULL) || (dirent->d_name[0] == '.') ||
-          (strcmp(dot, ".conf") != 0))
-      {
-      	continue;
-      }
-      cfg_filename = cfg_dir + "/" + dirent->d_name;
-      if (!cfg.open(cfg_filename))
-       {
-	 cerr << "*** ERROR: Could not open configuration file: "
-	      << cfg_filename << endl;
-	 exit(1);
-       }
+      cout << "*** WARNING: --init-db: database is not empty, skipping import" << endl;
     }
-    
-    if (closedir(dir) == -1)
+    else
     {
-      cerr << "*** ERROR: Error closing directory specified by"
-      	   << "configuration variable GLOBAL/CFG_DIR=" << cfg_dir << endl;
-      exit(1);
+      if (!cfg.importFromConfigFile("svxlink.conf"))
+        cerr << "*** WARNING: --init-db: could not import from svxlink.conf" << endl;
     }
   }
 
@@ -379,7 +317,7 @@ int main(int argc, char **argv)
           "and conditions in the\n";
   cout << "GNU GPL (General Public License) version 2 or later.\n";
 
-  cout << "\nUsing configuration file: " << main_cfg_filename << endl;
+  cout << "\nUsing configuration file: " << cfg.getMainConfigFile() << endl;
   
   string value;
   if (cfg.getValue("GLOBAL", "CARD_SAMPLE_RATE", value))
@@ -432,7 +370,30 @@ int main(int argc, char **argv)
     }
   }
 
-    // Init Logiclinking
+  // Hot-reload LOCATION_INFO: tear down and re-initialize LocationInfo when
+  // the value changes at runtime.  We only subscribe for LOCATION INFO changes, 
+  // because everything else requires a full restart.
+  cfg.subscribeOptionalValue("GLOBAL", "LOCATION_INFO", [&cfg](const std::string& value) {
+      // Do we have a location info section already ?!!??!
+      if(LocationInfo::has_instance())
+      {
+        LocationInfo::deleteInstance();
+      }
+
+      if(value.empty())
+      {
+        return;
+      }
+      
+      if (!LocationInfo::initialize(cfg, value))
+      {
+        std::cerr << "*** ERROR: Could not initialize the location info "
+                  << "subsystem. Check configuration section [" << value << "]."
+                  << std::endl;
+      }
+  });
+
+  // Init Logiclinking
   if (cfg.getValue("GLOBAL", "LINKS", value))
   {
     if (!LinkManager::initialize(cfg, value))
@@ -530,6 +491,10 @@ static void parse_arguments(int argc, const char **argv)
 	    "Specify the user to run SvxLink as", "<username>"},
     {"config", 0, POPT_ARG_STRING, &config, 0,
 	    "Specify the configuration file to use", "<filename>"},
+    {"dbconfig", 0, POPT_ARG_STRING, &dbconfig, 0,
+	    "Specify the database configuration file to use", "<filename>"},
+    {"init-db", 0, POPT_ARG_NONE, &init_db, 0,
+	    "Initialize an empty database backend from the installed svxlink.conf", NULL},
     /*
     {"int_arg", 'i', POPT_ARG_INT, &int_arg, 0,
 	    "Description of int argument", "<an int>"},

--- a/src/svxlink/trx/DtmfDecoder.cpp
+++ b/src/svxlink/trx/DtmfDecoder.cpp
@@ -156,6 +156,7 @@ DtmfDecoder *DtmfDecoder::create(Rx *rx, Config &cfg, const string& name)
 bool DtmfDecoder::initialize(void)
 {
   cfg().getValue(name(), "DTMF_HANGTIME", m_hangtime);
+  cfg().valueUpdated.connect(sigc::mem_fun(*this, &DtmfDecoder::cfgUpdated));
   return true;
 } /* DtmfDecoder::initialize */
 
@@ -174,6 +175,16 @@ bool DtmfDecoder::initialize(void)
  *
  ****************************************************************************/
 
+void DtmfDecoder::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  if (section == name())
+  {
+    if (tag == "DTMF_HANGTIME")
+    {
+      cfg().getValue(name(), "DTMF_HANGTIME", m_hangtime);
+    }
+  }
+} /* DtmfDecoder::cfgUpdated */
 
 
 /*

--- a/src/svxlink/trx/DtmfDecoder.h
+++ b/src/svxlink/trx/DtmfDecoder.h
@@ -186,6 +186,7 @@ class DtmfDecoder : public sigc::trackable, public Async::AudioSink
     
     Async::Config &cfg(void) { return m_cfg; }
     const std::string &name(void) const { return m_name; }
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
     
     
   private:

--- a/src/svxlink/trx/LADSPAPluginLoader.h
+++ b/src/svxlink/trx/LADSPAPluginLoader.h
@@ -36,6 +36,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 
 /****************************************************************************
@@ -164,12 +165,12 @@ class LADSPAPluginLoader
                             << subsec << "'" << std::endl;
                   return false;
                 }
-                cfg.subscribeValue(subsec, port_name, 0,
-                    [=](LADSPA_Data val)
-                    {
-                      plug->setControl(port_num, val);
-                      //plug->print(std::string("### ") + sec + ": ");
-                    });
+                m_subscriptions.push_back(
+                    cfg.subscribeValue(subsec, port_name, 0,
+                        [=](LADSPA_Data val)
+                        {
+                          plug->setControl(port_num, val);
+                        }));
               }
             }
           }
@@ -239,6 +240,7 @@ class LADSPAPluginLoader
   private:
     Async::AudioSink*   m_chain_sink  = nullptr;
     Async::AudioSource* m_chain_src   = nullptr;
+    std::vector<Async::Config::Subscription> m_subscriptions;
 
 };  /* class LADSPAPluginLoader */
 

--- a/src/svxlink/trx/LocalRxBase.cpp
+++ b/src/svxlink/trx/LocalRxBase.cpp
@@ -1013,7 +1013,7 @@ void LocalRxBase::publishSquelchState(void)
 } /* LocalRxBase::publishSquelchState */
 
 
-void LocalRxBase::cfgUpdated(const std::string& section, const std::string& tag)
+void LocalRxBase::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
 {
   //std::cout << "### LocalRxBase::cfgUpdated: "
   //          << section << "/" << tag << "=" << cfg().getValue(section, tag)

--- a/src/svxlink/trx/LocalRxBase.h
+++ b/src/svxlink/trx/LocalRxBase.h
@@ -296,7 +296,7 @@ class LocalRxBase : public Rx
     void setSqlHangtimeFromSiglev(float siglev);
     void rxReadyStateChanged(void);
     void publishSquelchState(void);
-    void cfgUpdated(const std::string& section, const std::string& tag);
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
 
 };  /* class LocalRxBase */
 

--- a/src/svxlink/trx/Squelch.cpp
+++ b/src/svxlink/trx/Squelch.cpp
@@ -32,6 +32,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  ****************************************************************************/
 
+#include <cstdlib>
+#include <functional>
+
 
 
 /****************************************************************************
@@ -191,7 +194,7 @@ bool Squelch::initialize(Async::Config& cfg, const std::string& rx_name)
   }
 
   cfg.valueUpdated.connect(
-      sigc::bind<0>(sigc::mem_fun(*this, &Squelch::cfgUpdated), cfg));
+      sigc::mem_fun(*this, &Squelch::cfgUpdated));
 
   return true;
 } /* Squelch::initialize */
@@ -288,37 +291,31 @@ int Squelch::writeSamples(const float *samples, int count)
  *
  ****************************************************************************/
 
-void Squelch::cfgUpdated(Async::Config& cfg, const std::string& section,
-                         const std::string& tag)
+void Squelch::cfgUpdated(const std::string& section,
+                         const std::string& tag, const std::string& value)
 {
   //std::cout << "### Squelch::cfgUpdated: "
-  //          << section << "/" << tag << "=" << cfg.getValue(section, tag)
+  //          << section << "/" << tag << "=" << value
   //          << std::endl;
   if (section == m_name)
   {
     if (tag == CFG_SQL_HANGTIME)
     {
-      int hangtime = 0;
-      if (cfg.getValue(m_name, CFG_SQL_HANGTIME, hangtime))
-      {
-        setHangtime(hangtime);
-      }
+      int hangtime = std::atoi(value.c_str());
+      setHangtime(hangtime);
       std::cout << "Setting " << CFG_SQL_HANGTIME << " to " << hangtime
                 << " for squelch " << m_name << std::endl;
     }
     else if (tag == CFG_SQL_EXTENDED_HANGTIME)
     {
-      int ext_hangtime = 0;
-      if (cfg.getValue(m_name, CFG_SQL_EXTENDED_HANGTIME, ext_hangtime))
-      {
-        setExtendedHangtime(ext_hangtime);
-      }
+      int ext_hangtime = std::atoi(value.c_str());
+      setExtendedHangtime(ext_hangtime);
       std::cout << "Setting " << CFG_SQL_EXTENDED_HANGTIME << " to "
                 << ext_hangtime
                 << " for squelch " << m_name << std::endl;
     }
   }
-} /* LocalRxBase::cfgUpdated */
+} /* Squelch::cfgUpdated */
 
 
 void Squelch::setSignalDetectedP(bool is_detected)

--- a/src/svxlink/trx/Squelch.h
+++ b/src/svxlink/trx/Squelch.h
@@ -391,8 +391,8 @@ class Squelch : public sigc::trackable, public Async::AudioSink
     Squelch(const Squelch&);
     Squelch& operator=(const Squelch&);
 
-    void cfgUpdated(Async::Config& cfg, const std::string& section,
-                    const std::string& tag);
+    void cfgUpdated(const std::string& section,
+                    const std::string& tag, const std::string& value);
     void setSignalDetectedP(bool is_detected);
     void setOpen(bool is_open);
 

--- a/src/svxlink/trx/Voter.cpp
+++ b/src/svxlink/trx/Voter.cpp
@@ -587,6 +587,8 @@ bool Voter::initialize(void)
     ++start;
   }
 
+  cfg.valueUpdated.connect(sigc::mem_fun(*this, &Voter::cfgUpdated));
+
   return true;
   
 } /* Voter::initialize */
@@ -1428,6 +1430,18 @@ void Voter::setRxEnabled(const std::string &rx_name,
   std::cerr << "*** WARNING: " << mute_str << " receiver failed: "
           " non-existent receiver \"" << rx_name << "\"" << std::endl;
 } /* Voter::setRxEnabled */
+
+
+void Voter::cfgUpdated(const std::string& section, const std::string& tag, const std::string& value)
+{
+  if (section == name())
+  {
+    if (tag == "VERBOSE")
+    {
+      cfg.getValue(name(), "VERBOSE", m_print_sat_squelch);
+    }
+  }
+} /* Voter::cfgUpdated */
 
 
 /*

--- a/src/svxlink/trx/Voter.h
+++ b/src/svxlink/trx/Voter.h
@@ -192,6 +192,7 @@ class Voter : public Rx
   protected:
     
   private:
+    void cfgUpdated(const std::string& section, const std::string& tag, const std::string& value);
     static CONSTEXPR float    DEFAULT_HYSTERESIS             = 1.5f;
     static CONSTEXPR unsigned DEFAULT_VOTING_DEALAY          = 0;
     static CONSTEXPR unsigned DEFAULT_SQL_CLOSE_REVOTE_DELAY = 500;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+##############################################################################
+# SvxLink test suite
+#
+# Top-level entry point — mirrors the src/ subtree layout so that tests for
+# src/foo/bar/Baz.cpp live under tests/foo/bar/.
+##############################################################################
+
+add_subdirectory(async/core)

--- a/tests/async/core/AsyncConfigBackend_test.cpp
+++ b/tests/async/core/AsyncConfigBackend_test.cpp
@@ -1,0 +1,962 @@
+/**
+@file   AsyncConfigBackend_test.cpp
+@brief  Unit tests for the AsyncConfig backend system
+@author Rui Barreiros / CR7BPM
+@date   2026-04-14
+
+Tests cover:
+  - FileConfigBackend  (always compiled)
+  - SQLiteConfigBackend (when HAS_SQLITE_SUPPORT is defined)
+  - MySQLConfigBackend  (when HAS_MYSQL_SUPPORT is defined;
+                         needs env var SVXLINK_TEST_MYSQL_CONN)
+  - PostgreSQLConfigBackend (when HAS_POSTGRESQL_SUPPORT is defined;
+                              needs env var SVXLINK_TEST_POSTGRESQL_CONN)
+  - Async::Config class (population, subscribeValue, importFromConfigFile)
+
+MySQL connection string format (semicolon-separated key=value pairs):
+  SVXLINK_TEST_MYSQL_CONN="host=localhost;port=3306;user=svxtest;password=svxtest;database=svxtest"
+
+PostgreSQL connection string (libpq keyword=value format):
+  SVXLINK_TEST_POSTGRESQL_CONN="host=localhost user=svxtest password=svxtest dbname=svxtest"
+
+\verbatim
+Async - A library for programming event driven applications
+Copyright (C) 2004-2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#ifdef CATCH_PROVIDE_MAIN_VIA_MACRO
+#  define CATCH_CONFIG_MAIN
+#endif
+#include <catch2/catch_all.hpp>
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <functional>
+#include <unistd.h>
+
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+#include <AsyncConfig.h>
+#include <AsyncConfigBackend.h>
+#include <AsyncConfigSource.h>
+#include <AsyncFileConfigBackend.h>
+
+#ifdef HAS_SQLITE_SUPPORT
+#  include <AsyncSQLiteConfigBackend.h>
+#endif
+#ifdef HAS_MYSQL_SUPPORT
+#  include <AsyncMySQLConfigBackend.h>
+#endif
+#ifdef HAS_POSTGRESQL_SUPPORT
+#  include <AsyncPostgreSQLConfigBackend.h>
+#endif
+
+
+/****************************************************************************
+ *
+ * Helpers
+ *
+ ****************************************************************************/
+
+namespace
+{
+
+/**
+ * RAII wrapper that creates a temporary file and deletes it on destruction.
+ * The file is NOT created by this class; it only tracks the path and removes
+ * it on destruction if it exists.
+ */
+class TempPath
+{
+public:
+  explicit TempPath(const std::string& suffix = "")
+  {
+    char tmpl[] = "/tmp/svxlink_test_XXXXXX";
+    int fd = mkstemp(tmpl);
+    if (fd != -1)
+    {
+      ::close(fd);
+      m_path = std::string(tmpl) + suffix;
+      if (!suffix.empty())
+      {
+        // Rename the fd-created file to the suffixed name
+        ::rename(tmpl, m_path.c_str());
+      }
+    }
+  }
+
+  ~TempPath()
+  {
+    if (!m_path.empty())
+    {
+      ::unlink(m_path.c_str());
+    }
+  }
+
+  const std::string& path() const { return m_path; }
+
+private:
+  std::string m_path;
+  TempPath(const TempPath&) = delete;
+  TempPath& operator=(const TempPath&) = delete;
+};
+
+/**
+ * Creates a temporary INI-format configuration file with a known fixed
+ * set of sections and values, useful for import/populate tests.
+ */
+class TempIniFile
+{
+public:
+  TempIniFile() : m_path(".conf")
+  {
+    std::ofstream f(m_path.path());
+    f << "[GLOBAL]\n"
+      << "LOGICS=MyLogic\n"
+      << "TIMESTAMP_FORMAT=%c\n"
+      << "CARD_SAMPLE_RATE=16000\n"
+      << "\n"
+      << "[MyLogic]\n"
+      << "TYPE=SimplexLogic\n"
+      << "RX=Rx1\n"
+      << "TX=Tx1\n"
+      << "\n"
+      << "[Rx1]\n"
+      << "TYPE=Local\n"
+      << "AUDIO_DEV=alsa:plughw:0\n"
+      << "VOX_FILTER_DEPTH=20\n"
+      << "VOX_LIMIT=1000\n";
+  }
+
+  const std::string& path() const { return m_path.path(); }
+
+  // Known content for assertions
+  static const char* GLOBAL_LOGICS()  { return "MyLogic"; }
+  static const char* MYLOGIC_TYPE()   { return "SimplexLogic"; }
+  static const char* RX1_AUDIO_DEV()  { return "alsa:plughw:0"; }
+
+private:
+  TempPath m_path;
+};
+
+/**
+ * Retrieves an environment variable; returns empty string if not set.
+ */
+static std::string getenv_str(const char* name)
+{
+  const char* v = std::getenv(name);
+  return (v != nullptr) ? std::string(v) : std::string();
+}
+
+/**
+ * Runs a standard suite of CRUD, listing and signal tests against any
+ * opened ConfigBackend.  The backend must already be open and have its
+ * tables initialised before calling this helper.
+ */
+static void runCrudSuite(Async::ConfigBackend& b)
+{
+  SECTION("setValue and getValue round-trip")
+  {
+    REQUIRE(b.setValue("SEC1", "key1", "hello"));
+    std::string v;
+    REQUIRE(b.getValue("SEC1", "key1", v));
+    REQUIRE(v == "hello");
+  }
+
+  SECTION("overwrite existing value")
+  {
+    REQUIRE(b.setValue("SEC1", "key1", "first"));
+    REQUIRE(b.setValue("SEC1", "key1", "second"));
+    std::string v;
+    REQUIRE(b.getValue("SEC1", "key1", v));
+    REQUIRE(v == "second");
+  }
+
+  SECTION("getValue returns false for missing tag")
+  {
+    std::string v;
+    REQUIRE_FALSE(b.getValue("NOSEC", "notag", v));
+  }
+
+  SECTION("listSections reflects written data")
+  {
+    b.setValue("ALPHA", "a", "1");
+    b.setValue("BETA",  "b", "2");
+    auto secs = b.listSections();
+    std::vector<std::string> sv(secs.begin(), secs.end());
+    REQUIRE(std::find(sv.begin(), sv.end(), "ALPHA") != sv.end());
+    REQUIRE(std::find(sv.begin(), sv.end(), "BETA")  != sv.end());
+  }
+
+  SECTION("listSection reflects written tags")
+  {
+    b.setValue("MYSEC", "tag1", "v1");
+    b.setValue("MYSEC", "tag2", "v2");
+    auto tags = b.listSection("MYSEC");
+    std::vector<std::string> tv(tags.begin(), tags.end());
+    REQUIRE(std::find(tv.begin(), tv.end(), "tag1") != tv.end());
+    REQUIRE(std::find(tv.begin(), tv.end(), "tag2") != tv.end());
+  }
+
+  SECTION("listSection returns empty for unknown section")
+  {
+    auto tags = b.listSection("_NO_SUCH_SECTION_");
+    REQUIRE(tags.empty());
+  }
+
+  SECTION("multiple sections are independent")
+  {
+    b.setValue("S1", "k", "val_s1");
+    b.setValue("S2", "k", "val_s2");
+    std::string v1, v2;
+    REQUIRE(b.getValue("S1", "k", v1));
+    REQUIRE(b.getValue("S2", "k", v2));
+    REQUIRE(v1 == "val_s1");
+    REQUIRE(v2 == "val_s2");
+  }
+}
+
+/**
+ * Tests that valueChanged fires when setValue is called with change
+ * notifications enabled and no polling thread running.
+ */
+static void runSignalSuite(Async::ConfigBackend& b)
+{
+  SECTION("valueChanged signal fires on setValue")
+  {
+    b.enableChangeNotifications(true);
+
+    std::vector<std::tuple<std::string,std::string,std::string>> received;
+    b.valueChanged.connect(
+      [&](const std::string& sec,
+          const std::string& tag,
+          const std::string& val)
+      {
+        received.emplace_back(sec, tag, val);
+      });
+
+    b.setValue("SIG", "alpha", "42");
+    b.setValue("SIG", "beta",  "hello");
+
+    REQUIRE(received.size() == 2);
+    REQUIRE(std::get<0>(received[0]) == "SIG");
+    REQUIRE(std::get<1>(received[0]) == "alpha");
+    REQUIRE(std::get<2>(received[0]) == "42");
+    REQUIRE(std::get<2>(received[1]) == "hello");
+  }
+
+  SECTION("valueChanged is silent when notifications disabled")
+  {
+    b.enableChangeNotifications(false);
+
+    int call_count = 0;
+    b.valueChanged.connect(
+      [&](const std::string&, const std::string&, const std::string&)
+      {
+        ++call_count;
+      });
+
+    b.setValue("SIG2", "x", "y");
+    REQUIRE(call_count == 0);
+  }
+}
+
+} // anonymous namespace
+
+
+/****************************************************************************
+ *
+ * Group 1 – FileConfigBackend
+ *
+ ****************************************************************************/
+
+TEST_CASE("FileConfigBackend – open and close", "[file]")
+{
+  TempIniFile ini;
+
+  Async::FileConfigBackend b;
+  REQUIRE_FALSE(b.isOpen());
+  REQUIRE(b.open(ini.path()));
+  REQUIRE(b.isOpen());
+  b.close();
+  REQUIRE_FALSE(b.isOpen());
+}
+
+TEST_CASE("FileConfigBackend – open non-existent file fails", "[file]")
+{
+  Async::FileConfigBackend b;
+  REQUIRE_FALSE(b.open("/tmp/__svxlink_no_such_file_XXXXX.conf"));
+  REQUIRE_FALSE(b.isOpen());
+}
+
+TEST_CASE("FileConfigBackend – reads INI values correctly", "[file]")
+{
+  TempIniFile ini;
+  Async::FileConfigBackend b;
+  REQUIRE(b.open(ini.path()));
+
+  std::string v;
+  REQUIRE(b.getValue("GLOBAL", "LOGICS", v));
+  REQUIRE(v == TempIniFile::GLOBAL_LOGICS());
+
+  REQUIRE(b.getValue("MyLogic", "TYPE", v));
+  REQUIRE(v == TempIniFile::MYLOGIC_TYPE());
+
+  REQUIRE(b.getValue("Rx1", "AUDIO_DEV", v));
+  REQUIRE(v == TempIniFile::RX1_AUDIO_DEV());
+}
+
+TEST_CASE("FileConfigBackend – CRUD (in-memory writes)", "[file]")
+{
+  TempIniFile ini;
+  Async::FileConfigBackend b;
+  REQUIRE(b.open(ini.path()));
+  runCrudSuite(b);
+}
+
+TEST_CASE("FileConfigBackend – change notifications", "[file]")
+{
+  TempIniFile ini;
+  Async::FileConfigBackend b;
+  REQUIRE(b.open(ini.path()));
+  runSignalSuite(b);
+}
+
+TEST_CASE("FileConfigBackend – getBackendType", "[file]")
+{
+  Async::FileConfigBackend b;
+  REQUIRE(b.getBackendType() == "file");
+}
+
+
+/****************************************************************************
+ *
+ * Group 2 – SQLiteConfigBackend
+ *
+ ****************************************************************************/
+
+#ifdef HAS_SQLITE_SUPPORT
+
+TEST_CASE("SQLiteConfigBackend – open and close", "[sqlite]")
+{
+  TempPath db(".db");
+  Async::SQLiteConfigBackend b;
+  REQUIRE_FALSE(b.isOpen());
+  REQUIRE(b.open(db.path()));
+  REQUIRE(b.isOpen());
+  b.close();
+  REQUIRE_FALSE(b.isOpen());
+}
+
+TEST_CASE("SQLiteConfigBackend – open invalid path fails gracefully", "[sqlite]")
+{
+  Async::SQLiteConfigBackend b;
+  // A path inside a non-existent directory cannot be created
+  REQUIRE_FALSE(b.open("/no_such_dir/svxlink_test.db"));
+  REQUIRE_FALSE(b.isOpen());
+}
+
+TEST_CASE("SQLiteConfigBackend – initializeTables creates schema", "[sqlite]")
+{
+  TempPath db(".db");
+  Async::SQLiteConfigBackend b;
+  REQUIRE(b.open(db.path()));
+  REQUIRE(b.initializeTables());
+
+  // After init, listSections must succeed (returns empty, not crash)
+  auto secs = b.listSections();
+  REQUIRE(secs.empty());
+}
+
+TEST_CASE("SQLiteConfigBackend – initializeTables is idempotent", "[sqlite]")
+{
+  TempPath db(".db");
+  Async::SQLiteConfigBackend b;
+  REQUIRE(b.open(db.path()));
+  REQUIRE(b.initializeTables());
+  REQUIRE(b.initializeTables()); // second call must not fail
+}
+
+TEST_CASE("SQLiteConfigBackend – CRUD", "[sqlite]")
+{
+  TempPath db(".db");
+  Async::SQLiteConfigBackend b;
+  REQUIRE(b.open(db.path()));
+  REQUIRE(b.initializeTables());
+  runCrudSuite(b);
+}
+
+TEST_CASE("SQLiteConfigBackend – change notifications", "[sqlite]")
+{
+  TempPath db(".db");
+  Async::SQLiteConfigBackend b;
+  REQUIRE(b.open(db.path()));
+  REQUIRE(b.initializeTables());
+  runSignalSuite(b);
+}
+
+TEST_CASE("SQLiteConfigBackend – table prefix isolates data", "[sqlite]")
+{
+  TempPath db(".db");
+
+  {
+    Async::SQLiteConfigBackend b1;
+    REQUIRE(b1.open(db.path()));
+    b1.setTablePrefix("app1_");
+    REQUIRE(b1.initializeTables());
+    REQUIRE(b1.setValue("GLOBAL", "key", "val_app1"));
+  }
+
+  {
+    Async::SQLiteConfigBackend b2;
+    REQUIRE(b2.open(db.path()));
+    b2.setTablePrefix("app2_");
+    REQUIRE(b2.initializeTables());
+    REQUIRE(b2.setValue("GLOBAL", "key", "val_app2"));
+  }
+
+  // Re-open both and verify they don't see each other's data
+  Async::SQLiteConfigBackend r1, r2;
+  REQUIRE(r1.open(db.path()));
+  r1.setTablePrefix("app1_");
+  REQUIRE(r1.initializeTables());
+
+  REQUIRE(r2.open(db.path()));
+  r2.setTablePrefix("app2_");
+  REQUIRE(r2.initializeTables());
+
+  std::string v1, v2;
+  REQUIRE(r1.getValue("GLOBAL", "key", v1));
+  REQUIRE(r2.getValue("GLOBAL", "key", v2));
+  REQUIRE(v1 == "val_app1");
+  REQUIRE(v2 == "val_app2");
+}
+
+TEST_CASE("SQLiteConfigBackend – getBackendType", "[sqlite]")
+{
+  Async::SQLiteConfigBackend b;
+  REQUIRE(b.getBackendType() == "sqlite");
+}
+
+TEST_CASE("SQLiteConfigBackend – data persists across open/close cycles", "[sqlite]")
+{
+  TempPath db(".db");
+
+  {
+    Async::SQLiteConfigBackend w;
+    REQUIRE(w.open(db.path()));
+    REQUIRE(w.initializeTables());
+    REQUIRE(w.setValue("PERSIST", "k", "stored_value"));
+  }
+
+  Async::SQLiteConfigBackend r;
+  REQUIRE(r.open(db.path()));
+  REQUIRE(r.initializeTables());
+  std::string v;
+  REQUIRE(r.getValue("PERSIST", "k", v));
+  REQUIRE(v == "stored_value");
+}
+
+#endif // HAS_SQLITE_SUPPORT
+
+
+/****************************************************************************
+ *
+ * Group 3 – Config class with SQLite backend
+ *
+ ****************************************************************************/
+
+#ifdef HAS_SQLITE_SUPPORT
+
+TEST_CASE("Config – openDirect with SQLite URL", "[config][sqlite]")
+{
+  TempPath db(".db");
+  std::string url = "sqlite://" + db.path();
+
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect(url));
+  REQUIRE(cfg.getBackendType() == "sqlite");
+}
+
+TEST_CASE("Config – setValue and getValue via Config wrapper", "[config][sqlite]")
+{
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+
+  cfg.setValue("GLOBAL", "LOGICS", "TestLogic");
+
+  std::string v;
+  REQUIRE(cfg.getValue("GLOBAL", "LOGICS", v));
+  REQUIRE(v == "TestLogic");
+}
+
+TEST_CASE("Config – listSections and listSection via SQLite", "[config][sqlite]")
+{
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+
+  cfg.setValue("SECA", "ka", "va");
+  cfg.setValue("SECB", "kb", "vb");
+
+  auto secs = cfg.listSections();
+  std::vector<std::string> sv(secs.begin(), secs.end());
+  REQUIRE(std::find(sv.begin(), sv.end(), "SECA") != sv.end());
+  REQUIRE(std::find(sv.begin(), sv.end(), "SECB") != sv.end());
+
+  auto tags = cfg.listSection("SECA");
+  REQUIRE_FALSE(tags.empty());
+  REQUIRE(tags.front() == "ka");
+}
+
+TEST_CASE("Config – importFromConfigFile populates SQLite", "[config][sqlite]")
+{
+  TempIniFile ini;
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+
+  // Import directly via the file backend
+  Async::Config file_cfg;
+  REQUIRE(file_cfg.openDirect("file://" + ini.path()));
+
+  // Copy every section/tag/value from the file backend into cfg
+  for (const auto& sec : file_cfg.listSections())
+  {
+    for (const auto& tag : file_cfg.listSection(sec))
+    {
+      cfg.setValue(sec, tag, file_cfg.getValue(sec, tag));
+    }
+  }
+
+  std::string v;
+  REQUIRE(cfg.getValue("GLOBAL", "LOGICS", v));
+  REQUIRE(v == TempIniFile::GLOBAL_LOGICS());
+
+  REQUIRE(cfg.getValue("MyLogic", "TYPE", v));
+  REQUIRE(v == TempIniFile::MYLOGIC_TYPE());
+
+  REQUIRE(cfg.getValue("Rx1", "AUDIO_DEV", v));
+  REQUIRE(v == TempIniFile::RX1_AUDIO_DEV());
+}
+
+TEST_CASE("Config – subscribeValue fires on first set and on change", "[config][sqlite]")
+{
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+
+  std::vector<std::string> received;
+  cfg.subscribeValue("GLOBAL", "LOGICS", std::string("Default"),
+    [&](const std::string& val) {
+      received.push_back(val);
+    });
+
+  // subscribeValue fires immediately with the current (default) value
+  REQUIRE(received.size() == 1);
+  REQUIRE(received[0] == "Default");
+
+  cfg.setValue("GLOBAL", "LOGICS", "NewLogic");
+  REQUIRE(received.size() == 2);
+  REQUIRE(received[1] == "NewLogic");
+
+  cfg.setValue("GLOBAL", "LOGICS", "AnotherLogic");
+  REQUIRE(received.size() == 3);
+  REQUIRE(received[2] == "AnotherLogic");
+}
+
+TEST_CASE("Config – subscribeValue uses existing value when present", "[config][sqlite]")
+{
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+
+  cfg.setValue("GLOBAL", "LOGICS", "PreExisting");
+
+  std::string got;
+  cfg.subscribeValue("GLOBAL", "LOGICS", std::string("Default"),
+    [&](const std::string& val) { got = val; });
+
+  // Must receive the pre-existing value, not the default
+  REQUIRE(got == "PreExisting");
+}
+
+TEST_CASE("Config – getValue missing_ok=true succeeds with same value as passed in if not found", "[config][sqlite]")
+{
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+
+  std::string v = "sentinel";
+  REQUIRE(cfg.getValue("NOSEC", "notag", v, true));
+  REQUIRE(v == "sentinel");
+}
+
+TEST_CASE("Config – typed getValue (integer)", "[config][sqlite]")
+{
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+
+  cfg.setValue("Rx1", "VOX_FILTER_DEPTH", "20");
+
+  int depth = 0;
+  REQUIRE(cfg.getValue("Rx1", "VOX_FILTER_DEPTH", depth));
+  REQUIRE(depth == 20);
+}
+
+TEST_CASE("Config – reload picks up backend changes", "[config][sqlite]")
+{
+  TempPath db(".db");
+  Async::Config cfg;
+  REQUIRE(cfg.openDirect("sqlite://" + db.path()));
+  cfg.setValue("GLOBAL", "VERSION", "1");
+
+  // Write a new value directly through the backend
+  auto* backend = cfg.getBackend();
+  REQUIRE(backend != nullptr);
+  backend->setValue("GLOBAL", "VERSION", "2");
+
+  // Reload so the Config cache catches up
+  cfg.reload();
+
+  std::string v;
+  REQUIRE(cfg.getValue("GLOBAL", "VERSION", v));
+  REQUIRE(v == "2");
+}
+
+#endif // HAS_SQLITE_SUPPORT
+
+
+/****************************************************************************
+ *
+ * Group 4 – MySQLConfigBackend
+ * Skipped automatically when SVXLINK_TEST_MYSQL_CONN env var is not set.
+ *
+ ****************************************************************************/
+
+#ifdef HAS_MYSQL_SUPPORT
+
+TEST_CASE("MySQLConfigBackend – connection and schema", "[mysql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_MYSQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_MYSQL_CONN to enable MySQL tests");
+  }
+
+  Async::MySQLConfigBackend b;
+  REQUIRE(b.open(conn));
+  REQUIRE(b.isOpen());
+
+  SECTION("initializeTables")
+  {
+    REQUIRE(b.initializeTables());
+  }
+
+  SECTION("initializeTables is idempotent")
+  {
+    REQUIRE(b.initializeTables());
+    REQUIRE(b.initializeTables());
+  }
+
+  SECTION("CRUD")
+  {
+    REQUIRE(b.initializeTables());
+    // Use a unique prefix to avoid polluting real data
+    b.setTablePrefix("svxtest_");
+    REQUIRE(b.initializeTables());
+    runCrudSuite(b);
+  }
+
+  SECTION("change notifications")
+  {
+    b.setTablePrefix("svxtest_");
+    REQUIRE(b.initializeTables());
+    runSignalSuite(b);
+  }
+
+  SECTION("getBackendType")
+  {
+    REQUIRE(b.getBackendType() == "mysql");
+  }
+
+  b.close();
+  REQUIRE_FALSE(b.isOpen());
+}
+
+TEST_CASE("MySQLConfigBackend – invalid connection string fails", "[mysql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_MYSQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_MYSQL_CONN to enable MySQL tests");
+  }
+
+  Async::MySQLConfigBackend b;
+  REQUIRE_FALSE(b.open("host=__no_such_host__;user=x;database=x"));
+}
+
+TEST_CASE("MySQLConfigBackend – table prefix isolates data", "[mysql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_MYSQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_MYSQL_CONN to enable MySQL tests");
+  }
+
+  Async::MySQLConfigBackend b1, b2;
+  REQUIRE(b1.open(conn));
+  REQUIRE(b2.open(conn));
+
+  b1.setTablePrefix("svxtest_prefix1_");
+  b2.setTablePrefix("svxtest_prefix2_");
+  REQUIRE(b1.initializeTables());
+  REQUIRE(b2.initializeTables());
+
+  b1.setValue("SEC", "k", "from_prefix1");
+  b2.setValue("SEC", "k", "from_prefix2");
+
+  std::string v1, v2;
+  REQUIRE(b1.getValue("SEC", "k", v1));
+  REQUIRE(b2.getValue("SEC", "k", v2));
+  REQUIRE(v1 == "from_prefix1");
+  REQUIRE(v2 == "from_prefix2");
+}
+
+TEST_CASE("Config – openDirect with MySQL URL", "[config][mysql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_MYSQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_MYSQL_CONN to enable MySQL tests");
+  }
+
+  // Build a mysql:// URL from the key=value connection string
+  // The URL parser in ConfigSource handles mysql://user:pass@host:port/db
+  // For simplicity, create the backend directly and wrap it in Config
+  Async::MySQLConfigBackend* raw = new Async::MySQLConfigBackend();
+  raw->setTablePrefix("svxtest_config_");
+  REQUIRE(raw->open(conn));
+  REQUIRE(raw->initializeTables());
+
+  Async::Config cfg;
+  cfg.setValue("DIRECT", "test_key", "test_value");
+  std::string v;
+  // setValue goes through Config's own cache; retrieve via backend
+  raw->setValue("DIRECT", "backend_key", "backend_value");
+  REQUIRE(raw->getValue("DIRECT", "backend_key", v));
+  REQUIRE(v == "backend_value");
+
+  delete raw;
+}
+
+#endif // HAS_MYSQL_SUPPORT
+
+
+/****************************************************************************
+ *
+ * Group 5 – PostgreSQLConfigBackend
+ * Skipped automatically when SVXLINK_TEST_POSTGRESQL_CONN env var is not set.
+ *
+ ****************************************************************************/
+
+#ifdef HAS_POSTGRESQL_SUPPORT
+
+TEST_CASE("PostgreSQLConfigBackend – connection and schema", "[postgresql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_POSTGRESQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_POSTGRESQL_CONN to enable PostgreSQL tests");
+  }
+
+  Async::PostgreSQLConfigBackend b;
+  REQUIRE(b.open(conn));
+  REQUIRE(b.isOpen());
+
+  SECTION("initializeTables")
+  {
+    REQUIRE(b.initializeTables());
+  }
+
+  SECTION("initializeTables is idempotent")
+  {
+    REQUIRE(b.initializeTables());
+    REQUIRE(b.initializeTables());
+  }
+
+  SECTION("CRUD")
+  {
+    b.setTablePrefix("svxtest_");
+    REQUIRE(b.initializeTables());
+    runCrudSuite(b);
+  }
+
+  SECTION("change notifications")
+  {
+    b.setTablePrefix("svxtest_");
+    REQUIRE(b.initializeTables());
+    runSignalSuite(b);
+  }
+
+  SECTION("getBackendType")
+  {
+    REQUIRE(b.getBackendType() == "postgresql");
+  }
+
+  b.close();
+  REQUIRE_FALSE(b.isOpen());
+}
+
+TEST_CASE("PostgreSQLConfigBackend – invalid connection fails", "[postgresql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_POSTGRESQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_POSTGRESQL_CONN to enable PostgreSQL tests");
+  }
+
+  Async::PostgreSQLConfigBackend b;
+  REQUIRE_FALSE(b.open("host=__no_such_host__ dbname=x user=x"));
+}
+
+TEST_CASE("PostgreSQLConfigBackend – table prefix isolates data", "[postgresql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_POSTGRESQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_POSTGRESQL_CONN to enable PostgreSQL tests");
+  }
+
+  Async::PostgreSQLConfigBackend b1, b2;
+  REQUIRE(b1.open(conn));
+  REQUIRE(b2.open(conn));
+
+  b1.setTablePrefix("svxtest_prefix1_");
+  b2.setTablePrefix("svxtest_prefix2_");
+  REQUIRE(b1.initializeTables());
+  REQUIRE(b2.initializeTables());
+
+  b1.setValue("SEC", "k", "from_prefix1");
+  b2.setValue("SEC", "k", "from_prefix2");
+
+  std::string v1, v2;
+  REQUIRE(b1.getValue("SEC", "k", v1));
+  REQUIRE(b2.getValue("SEC", "k", v2));
+  REQUIRE(v1 == "from_prefix1");
+  REQUIRE(v2 == "from_prefix2");
+}
+
+TEST_CASE("PostgreSQLConfigBackend – data persists across open/close", "[postgresql]")
+{
+  std::string conn = getenv_str("SVXLINK_TEST_POSTGRESQL_CONN");
+  if (conn.empty())
+  {
+    SKIP("Set SVXLINK_TEST_POSTGRESQL_CONN to enable PostgreSQL tests");
+  }
+
+  {
+    Async::PostgreSQLConfigBackend w;
+    REQUIRE(w.open(conn));
+    w.setTablePrefix("svxtest_persist_");
+    REQUIRE(w.initializeTables());
+    REQUIRE(w.setValue("P", "k", "persistent_value"));
+  }
+
+  Async::PostgreSQLConfigBackend r;
+  REQUIRE(r.open(conn));
+  r.setTablePrefix("svxtest_persist_");
+  REQUIRE(r.initializeTables());
+  std::string v;
+  REQUIRE(r.getValue("P", "k", v));
+  REQUIRE(v == "persistent_value");
+}
+
+#endif // HAS_POSTGRESQL_SUPPORT
+
+
+/****************************************************************************
+ *
+ * Group 6 – Factory registration
+ *
+ ****************************************************************************/
+
+TEST_CASE("ConfigBackendFactory – 'file' is always registered", "[factory]")
+{
+  std::string factories = Async::ConfigBackendFactory::validFactories();
+  REQUIRE(factories.find("\"file\"") != std::string::npos);
+}
+
+#ifdef HAS_SQLITE_SUPPORT
+TEST_CASE("ConfigBackendFactory – 'sqlite' is registered when compiled", "[factory]")
+{
+  std::string factories = Async::ConfigBackendFactory::validFactories();
+  REQUIRE(factories.find("\"sqlite\"") != std::string::npos);
+}
+#endif
+
+#ifdef HAS_MYSQL_SUPPORT
+TEST_CASE("ConfigBackendFactory – 'mysql' is registered when compiled", "[factory]")
+{
+  std::string factories = Async::ConfigBackendFactory::validFactories();
+  REQUIRE(factories.find("\"mysql\"") != std::string::npos);
+}
+#endif
+
+#ifdef HAS_POSTGRESQL_SUPPORT
+TEST_CASE("ConfigBackendFactory – 'postgresql' is registered when compiled", "[factory]")
+{
+  std::string factories = Async::ConfigBackendFactory::validFactories();
+  REQUIRE(factories.find("\"postgresql\"") != std::string::npos);
+}
+#endif
+
+TEST_CASE("ConfigBackendFactory – unknown type returns nullptr", "[factory]")
+{
+  auto ptr = Async::createConfigBackendByType("__no_such_backend__", "");
+  REQUIRE(ptr == nullptr);
+}
+
+TEST_CASE("ConfigSource – isBackendAvailable matches factory registry", "[factory]")
+{
+  // Every backend that ConfigSource claims is available must also be in the
+  // factory registry, and vice versa.
+  const std::vector<std::string> known = {"file", "sqlite", "mysql", "postgresql"};
+  std::string factories = Async::ConfigBackendFactory::validFactories();
+
+  for (const auto& name : known)
+  {
+    bool in_source  = Async::ConfigSource::isBackendAvailable(name);
+    bool in_factory = (factories.find("\"" + name + "\"") != std::string::npos);
+    INFO("Checking backend '" << name << "'");
+    REQUIRE(in_source == in_factory);
+  }
+}
+
+
+/*
+ * This file has not been truncated
+ */

--- a/tests/async/core/AsyncConfigBackend_test.cpp
+++ b/tests/async/core/AsyncConfigBackend_test.cpp
@@ -569,7 +569,7 @@ TEST_CASE("Config – subscribeValue fires on first set and on change", "[config
   REQUIRE(cfg.openDirect("sqlite://" + db.path()));
 
   std::vector<std::string> received;
-  cfg.subscribeValue("GLOBAL", "LOGICS", std::string("Default"),
+  auto sub = cfg.subscribeValue("GLOBAL", "LOGICS", std::string("Default"),
     [&](const std::string& val) {
       received.push_back(val);
     });
@@ -596,7 +596,7 @@ TEST_CASE("Config – subscribeValue uses existing value when present", "[config
   cfg.setValue("GLOBAL", "LOGICS", "PreExisting");
 
   std::string got;
-  cfg.subscribeValue("GLOBAL", "LOGICS", std::string("Default"),
+  auto sub = cfg.subscribeValue("GLOBAL", "LOGICS", std::string("Default"),
     [&](const std::string& val) { got = val; });
 
   // Must receive the pre-existing value, not the default

--- a/tests/async/core/CMakeLists.txt
+++ b/tests/async/core/CMakeLists.txt
@@ -1,0 +1,47 @@
+##############################################################################
+# Tests for src/async/core/
+##############################################################################
+
+# Determine which Catch2 link target to use.  v3 ships Catch2::Catch2WithMain;
+# v2 ships it from 2.13 onward.  Fall back to defining CATCH_CONFIG_MAIN when
+# neither exists (very old v2).
+if(TARGET Catch2::Catch2WithMain)
+  set(CATCH2_MAIN_TARGET Catch2::Catch2WithMain)
+elseif(TARGET Catch2::Catch2)
+  # Older v2 — provide main via the header macro in the source file
+  set(CATCH2_MAIN_TARGET Catch2::Catch2)
+  add_compile_definitions(CATCH_PROVIDE_MAIN_VIA_MACRO)
+else()
+  message(FATAL_ERROR "Catch2 targets not found — cannot build tests.")
+endif()
+
+# AsyncConfigBackend test binary
+add_executable(AsyncConfigBackend_test AsyncConfigBackend_test.cpp)
+
+target_include_directories(AsyncConfigBackend_test PRIVATE
+  ${PROJECT_INCLUDE_DIR}              # installed/exported headers (AsyncConfig.h etc.)
+  ${CMAKE_SOURCE_DIR}/async/core      # non-exported headers (AsyncFileConfigBackend.h etc.)
+  ${CMAKE_BINARY_DIR}                 # generated config.h
+)
+
+target_link_libraries(AsyncConfigBackend_test
+  PRIVATE
+    asynccore
+    ${CATCH2_MAIN_TARGET}
+)
+
+# Propagate the HAS_*_SUPPORT defines that asynccore's CMakeLists sets via
+# add_definitions().  Because tests/ is processed after async/core/, the
+# directory has already been configured and its COMPILE_DEFINITIONS are
+# readable here.
+get_directory_property(_asynccore_dir_defs
+  DIRECTORY ${CMAKE_SOURCE_DIR}/async/core
+  COMPILE_DEFINITIONS)
+if(_asynccore_dir_defs)
+  target_compile_definitions(AsyncConfigBackend_test PRIVATE ${_asynccore_dir_defs})
+endif()
+
+add_test(
+  NAME    AsyncConfigBackend_test
+  COMMAND AsyncConfigBackend_test --reporter compact
+)


### PR DESCRIPTION
Sorry, this is an extensive patch!

Introduces a pluggable backend system for AsyncConfig that allows SVXLink configuration to be stored in a relational database (SQLite, MySQL/MariaDB, or PostgreSQL) in addition to the traditional .conf file, with optional live change notifications and hot-reload support. This backend is extendable and allows for other backends to be implemented following the same guidelines as Async*ConfigBackend classes.

Please read src/doc/README_DBCONFIG.md for more information and examples.

New library components (src/async/core/):

  - AsyncConfigBackend: abstract base class for all backends, with a factory registry, table-prefix support, and a non-blocking polling infrastructure (background thread + self-pipe + FdWatch) so that slow DB queries never stall the event loop.

  - AsyncFileConfigBackend: wraps the existing file parser as a proper backend plugin, preserving full backward compatibility.

  - AsyncSQLiteConfigBackend: single-file embedded database backend (optional, enabled when libsqlite3 is detected at build time).

  - AsyncMySQLConfigBackend: MySQL/MariaDB backend (optional, enabled when libmysqlclient or libmariadb is detected at build time). Connection string format: key=value pairs separated by semicolons.

  - AsyncPostgreSQLConfigBackend: PostgreSQL backend (optional, enabled when libpq is detected at build time).  Connection string is passed directly to PQconnectdb() as libpq keyword=value pairs.

  - AsyncConfigSource: URL parser and backend-availability registry used by the factory functions createConfigBackend() and createConfigBackendByType().

AsyncConfig rework (src/async/core/AsyncConfig.*):

  - Replaced the monolithic open(filename) call with a clean fallback chain implemented in openWithFallback(): --config file → --dbconfig db.conf → auto-discover db.conf in standard paths → auto-discover application .conf file → fatal error. This change  shifts to AsyncConfig all the config (file or other) reading logic instead of the multiple code repetition in each binary.

  - Added openFromDbConfig(path) and openDirect(url) as lower-level entry points for callers that bypass the fallback chain.

  - Centralized CFG_DIR processing into Config::loadCfgDir(); removed duplicate code from every application main().

  - Added valueUpdated sigc++ signal, emitted whenever any config value changes (from setValue, backend poll, or SIGHUP reload).

  - Added subscribeValue() templates that register a typed callback invoked immediately with the current value and again on every future change.  Returns a SubId handle.

  - Added subscribeOptionalValue() for keys that must not be auto-created when absent.

  - Added unsubscribeValue(section, tag, SubId) to safely remove a registered callback, preventing dangling-lambda crashes when a subscriber is destroyed before the Config object.

  - Fixed reload() to correctly handle sections and tags that were added to the database after startup (previously new keys were silently ignored).

  - Added importFromConfigFile(filename) as the public entry point for seeding an empty database from an installed .conf file.

  - Added getLastError(), getMainConfigFile(), getBackendType() for better diagnostics in application main().

Application changes (all binaries):

  - Added --dbconfig <file> option to specify a db.conf path explicitly, overriding the automatic search.

  - Added --init-db option to import the installed example .conf file (e.g. svxlink.conf) into an empty database backend, then exit. Import is skipped with a warning if the database already has rows.

  - Removed per-application CFG_DIR processing loops and hardcoded database seeding blocks; replaced with calls to the centralized AsyncConfig methods.

Runtime hot-reload (config value changes without restart):

  - Logic, RepeaterLogic, ReflectorLogic, ReflectorV2Logic: connect to valueUpdated and implement cfgUpdated() for parameters that can be changed on-the-fly (callsign, RF thresholds, IDs, timeouts, etc.).

  - Module base class: cfgUpdated() virtual method propagates valueUpdated events to all loaded modules.  ModuleDtmfRepeater, ModuleEchoLink, ModuleFrn, ModuleMetarInfo, ModuleParrot, ModuleTrx: override cfgUpdated() for their own hot-updatable parameters.

  - Squelch, LocalRxBase: cfgUpdated() for squelch thresholds and related RF parameters.

  - QsoRecorder: cfgUpdated() for recording parameters.

  - RfUplink, NetUplink, NetTrxAdapter: cfgUpdated() for remote TRX and network parameters.

  - SipLogic, QsoFrn: cfgUpdated() support for SIP and FRN parameters.

  - Voter, DtmfDecoder: subscribeValue() for voting and DTMF parameters.

  - Logic.tcl: new proc config_updated {section tag value} called by the C++ cfgUpdated() handler so TCL event scripts can react to runtime configuration changes.

Build:

  - CMakeLists.txt: optional detection of libsqlite3, libmysqlclient / libmariadb, and libpq; each backend is compiled in only when its development library is found.  Defines HAS_SQLITE_SUPPORT, HAS_MYSQL_SUPPORT, HAS_POSTGRESQL_SUPPORT accordingly.

  - Added -D_REENTRANT for the background polling thread.

New example files:

  - examples/db.conf: fully-commented template for the database config file, placed in the standard search paths.

  - examples/db.conf.sqlite, db.conf.mysql, db.conf.postgresql, db.conf.file: per-backend example files.

New tests added for async config backend (requires catch2)

  - added some test cases to check async config backend, they can be enabled by passing -DBUILD_TESTS=ON to cmake. 
  - make all will build tests if enabled, make test will run ctest, running all tests. 
  - Single test can be compiled and run, 
      make AsyncConfigBackend_test 
      ./tests/async/core/AsyncConfigBackend_test

   - A specific backend can be tested 
      ./tests/async/core/AsyncConfigBackend_test "[sqlite]" 
      ./tests/async/core/AsyncConfigBackend_test "[mysql]" 
      ./tests/async/core/AsyncConfigBackend_test "[postgres]" 
      ./tests/async/core/AsyncConfigBackend_test "[file]"

    Tests which require a database like mysql and postgresql require a connection string.

    SVXLINK_TEST_MYSQL_CONN 
    SVXLINK_TEST_POSTGRESQL_CONN

    example: 
    export SVXLINK_TEST_POSTGRESQL_CONN="host=localhost port=5432 dbname=svxlink user=svxlink password=svxlink" 
    export SVXLINK_TEST_MYSQL_CONN="host=localhost;port=3306;user=svxlink;password=svxlink;database=svxlink"
