### PR TITLE
Add a CTest-based unit/component test suite

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@
 ##############################################################################
 cmake_minimum_required(VERSION 3.7...3.30)
 project(svxlink C CXX)
-#enable_testing()
+enable_testing()
 
 # The path to the project global include directory
 set(PROJECT_INCLUDE_DIR ${PROJECT_BINARY_DIR}/include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,9 @@ set(RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 # Add project local CMake module directory
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
+# Conflict-free unit-test auto-discovery helper (svxlink_add_tests)
+include(SvxLinkAddTests)
+
 # Optional parts
 option(USE_QT "Build Qt applications and libs" ON)
 option(BUILD_STATIC_LIBS "Build static libraries in addition to dynamic" OFF)

--- a/src/async/audio/AudioClipperTest.cpp
+++ b/src/async/audio/AudioClipperTest.cpp
@@ -1,0 +1,118 @@
+/**
+@file    AudioClipperTest.cpp
+@brief   Unit tests for AudioClipper amplitude clipping.
+@author  Mark Rose
+@date    2026-06-06
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioSink.h>
+#include <AsyncAudioClipper.h>
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+class PushSource : public AudioSource
+{
+  public:
+    int push(const vector<float>& s) { return sinkWriteSamples(s.data(), s.size()); }
+    void resumeOutput(void) override {}
+    void allSamplesFlushed(void) override {}
+};
+
+class Capture : public AudioSink
+{
+  public:
+    int writeSamples(const float* s, int count) override
+    {
+      for (int i = 0; i < count; ++i) data.push_back(s[i]);
+      return count;
+    }
+    void flushSamples(void) override { sourceAllSamplesFlushed(); }
+    vector<float> data;
+};
+
+bool near(float a, float b, float tol = 0.0001f) { return fabs(a - b) < tol; }
+
+
+void test_clips_to_level(void)
+{
+  cout << "test_clips_to_level" << endl;
+  PushSource src;
+  AudioClipper clip(0.5f);
+  Capture cap;
+  src.registerSink(&clip);
+  clip.registerSink(&cap);
+
+  src.push({0.3f, 0.6f, -0.6f, 0.5f, -0.5f, 0.1f, 1.0f, -1.0f});
+  const float exp[] = {0.3f, 0.5f, -0.5f, 0.5f, -0.5f, 0.1f, 0.5f, -0.5f};
+  bool ok = cap.data.size() == 8;
+  for (size_t i = 0; ok && i < cap.data.size(); ++i)
+  {
+    ok = near(cap.data[i], exp[i]);
+  }
+  check(ok, "samples above +/-0.5 are clamped, others pass unchanged");
+}
+
+void test_default_level_unity(void)
+{
+  cout << "test_default_level_unity" << endl;
+  PushSource src;
+  AudioClipper clip;          // default clip level 1.0
+  Capture cap;
+  src.registerSink(&clip);
+  clip.registerSink(&cap);
+
+  src.push({0.9f, 1.5f, -2.0f});
+  check(cap.data.size() == 3 && near(cap.data[0], 0.9f) &&
+        near(cap.data[1], 1.0f) && near(cap.data[2], -1.0f),
+        "default clip level is 1.0");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+  test_clips_to_level();
+  test_default_level_unity();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All AudioClipper tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " AudioClipper test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/audio/AudioDelayLineTest.cpp
+++ b/src/async/audio/AudioDelayLineTest.cpp
@@ -1,0 +1,128 @@
+/**
+@file    AudioDelayLineTest.cpp
+@brief   Unit test for AudioDelayLine: audio is delayed by the configured time.
+@author  Mark Rose
+@date    2026-06-06
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioSink.h>
+#include <AsyncAudioDelayLine.h>
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+class PushSource : public AudioSource
+{
+  public:
+    int push(const vector<float>& s) { return sinkWriteSamples(s.data(), s.size()); }
+    void resumeOutput(void) override {}
+    void allSamplesFlushed(void) override {}
+};
+
+class Capture : public AudioSink
+{
+  public:
+    int writeSamples(const float* s, int count) override
+    {
+      for (int i = 0; i < count; ++i) data.push_back(s[i]);
+      return count;
+    }
+    void flushSamples(void) override { sourceAllSamplesFlushed(); }
+    vector<float> data;
+};
+
+
+void test_impulse_delayed(void)
+{
+  cout << "test_impulse_delayed" << endl;
+  const int len_ms = 10;
+  const int delay = len_ms * INTERNAL_SAMPLE_RATE / 1000;   // samples
+
+  PushSource src;
+  AudioDelayLine dl(len_ms);
+  Capture cap;
+  src.registerSink(&dl);
+  dl.registerSink(&cap);
+
+  // First block: an impulse at index 0; second block: silence. The delay line
+  // emits its (initially zero) buffer first, so the impulse should reappear at
+  // output index == delay.
+  vector<float> block1(delay, 0.0f);
+  block1[0] = 1.0f;
+  vector<float> block2(delay, 0.0f);
+  src.push(block1);
+  src.push(block2);
+
+  check(cap.data.size() == static_cast<size_t>(2 * delay),
+        "output sample count matches input");
+
+  // Locate the impulse in the output.
+  int peak_idx = -1;
+  for (size_t i = 0; i < cap.data.size(); ++i)
+  {
+    if (fabs(cap.data[i]) > 0.5f)
+    {
+      peak_idx = static_cast<int>(i);
+      break;
+    }
+  }
+  check(peak_idx == delay,
+        "impulse delayed by " + to_string(delay) + " samples (found at " +
+        to_string(peak_idx) + ")");
+
+  // Everything before the delay should be silence.
+  bool quiet_before = true;
+  for (int i = 0; i < delay; ++i)
+  {
+    if (fabs(cap.data[i]) > 1e-6f) quiet_before = false;
+  }
+  check(quiet_before, "output is silent until the delay elapses");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+  test_impulse_delayed();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All AudioDelayLine tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " AudioDelayLine test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/audio/AudioFilterTest.cpp
+++ b/src/async/audio/AudioFilterTest.cpp
@@ -1,0 +1,158 @@
+/**
+@file    AudioFilterTest.cpp
+@brief   Unit tests for AudioFilter frequency response.
+@author  Mark Rose
+@date    2026-06-06
+
+Feeds a single-tone signal through an AudioFilter and measures the steady-state
+output level (RMS) relative to the input. A lowpass filter should pass a tone
+well below the cutoff and strongly attenuate one well above it; a highpass
+filter should do the reverse.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioSink.h>
+#include <AsyncAudioFilter.h>
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+const int RATE = 16000;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+class PushSource : public AudioSource
+{
+  public:
+    int push(const vector<float>& s) { return sinkWriteSamples(s.data(), s.size()); }
+    void resumeOutput(void) override {}
+    void allSamplesFlushed(void) override {}
+};
+
+class Capture : public AudioSink
+{
+  public:
+    int writeSamples(const float* s, int count) override
+    {
+      for (int i = 0; i < count; ++i) data.push_back(s[i]);
+      return count;
+    }
+    void flushSamples(void) override { sourceAllSamplesFlushed(); }
+    vector<float> data;
+};
+
+double rms_tail(const vector<float>& v)
+{
+  // Measure the steady-state second half, skipping the filter's settling
+  // transient.
+  size_t start = v.size() / 2;
+  double sum = 0.0;
+  size_t n = 0;
+  for (size_t i = start; i < v.size(); ++i, ++n)
+  {
+    sum += static_cast<double>(v[i]) * v[i];
+  }
+  return n > 0 ? sqrt(sum / n) : 0.0;
+}
+
+// Run a `freq` Hz tone (amplitude 0.3) through `spec` and return the ratio of
+// output RMS to input RMS.
+double gain_ratio(const string& spec, float freq)
+{
+  const int n = 4800;            // ~0.3 s at 16 kHz, plenty of settling time
+  vector<float> in(n);
+  for (int i = 0; i < n; ++i)
+  {
+    in[i] = 0.3f * sinf(2.0f * M_PI * freq * i / RATE);
+  }
+  PushSource src;
+  AudioFilter filt(spec, RATE);
+  Capture cap;
+  src.registerSink(&filt);
+  filt.registerSink(&cap);
+  src.push(in);
+  double in_rms = 0.3 / sqrt(2.0);
+  return rms_tail(cap.data) / in_rms;
+}
+
+
+void test_lowpass(void)
+{
+  cout << "test_lowpass" << endl;
+  double passband = gain_ratio("LpBu8/2000", 500.0f);
+  double stopband = gain_ratio("LpBu8/2000", 6000.0f);
+  check(passband > 0.7, "lowpass passes 500 Hz (ratio " +
+        to_string(passband) + ")");
+  check(stopband < 0.1, "lowpass attenuates 6000 Hz (ratio " +
+        to_string(stopband) + ")");
+}
+
+void test_highpass(void)
+{
+  cout << "test_highpass" << endl;
+  double passband = gain_ratio("HpBu8/2000", 6000.0f);
+  double stopband = gain_ratio("HpBu8/2000", 500.0f);
+  check(passband > 0.7, "highpass passes 6000 Hz (ratio " +
+        to_string(passband) + ")");
+  check(stopband < 0.1, "highpass attenuates 500 Hz (ratio " +
+        to_string(stopband) + ")");
+}
+
+void test_bandpass(void)
+{
+  cout << "test_bandpass" << endl;
+  double inband = gain_ratio("BpBu8/1500-2500", 2000.0f);
+  double below = gain_ratio("BpBu8/1500-2500", 300.0f);
+  double above = gain_ratio("BpBu8/1500-2500", 6000.0f);
+  check(inband > 0.6, "bandpass passes 2000 Hz (ratio " +
+        to_string(inband) + ")");
+  check(below < 0.1 && above < 0.1,
+        "bandpass attenuates out-of-band tones");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+
+  test_lowpass();
+  test_highpass();
+  test_bandpass();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All AudioFilter tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " AudioFilter test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/audio/AudioFsfTest.cpp
+++ b/src/async/audio/AudioFsfTest.cpp
@@ -1,0 +1,153 @@
+/**
+@file    AudioFsfTest.cpp
+@brief   Unit test for AudioFsf (frequency sampling filter).
+@author  Mark Rose
+@date    2026-06-06
+
+Builds the bandpass FSF used by the AFSK modulator (N=128, passband centered on
+bin 44 = 5500 Hz at 16 kHz) and checks that an in-passband tone passes while an
+out-of-band tone is strongly attenuated.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioSink.h>
+#include <AsyncAudioFsf.h>
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+const int RATE = 16000;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+class PushSource : public AudioSource
+{
+  public:
+    int push(const vector<float>& s)
+    {
+      size_t off = 0;
+      while (off < s.size())
+      {
+        int wrote = sinkWriteSamples(s.data() + off, s.size() - off);
+        if (wrote <= 0) break;
+        off += wrote;
+      }
+      return off;
+    }
+    void resumeOutput(void) override {}
+    void allSamplesFlushed(void) override {}
+};
+
+class Capture : public AudioSink
+{
+  public:
+    int writeSamples(const float* s, int count) override
+    {
+      for (int i = 0; i < count; ++i) data.push_back(s[i]);
+      return count;
+    }
+    void flushSamples(void) override { sourceAllSamplesFlushed(); }
+    vector<float> data;
+};
+
+double rms_tail(const vector<float>& v)
+{
+  if (v.size() < 4) return 0.0;
+  size_t start = v.size() / 2;
+  double sum = 0.0;
+  size_t n = 0;
+  for (size_t i = start; i < v.size(); ++i, ++n)
+  {
+    sum += static_cast<double>(v[i]) * v[i];
+  }
+  return n > 0 ? sqrt(sum / n) : 0.0;
+}
+
+// The AFSK-modulator bandpass FSF: center bin 44 (5500 Hz), ~400 Hz wide.
+double fsf_gain(float freq)
+{
+  const size_t N = 128;
+  float coeff[N / 2 + 1];
+  memset(coeff, 0, sizeof(coeff));
+  coeff[42] = 0.39811024f;
+  coeff[43] = 1.0f;
+  coeff[44] = 1.0f;
+  coeff[45] = 1.0f;
+  coeff[46] = 0.39811024f;
+
+  PushSource src;
+  AudioFsf fsf(N, coeff);
+  Capture cap;
+  src.registerSink(&fsf);
+  fsf.registerSink(&cap);
+
+  const int n = 8000;
+  vector<float> in(n);
+  for (int i = 0; i < n; ++i)
+  {
+    in[i] = 0.3f * sinf(2.0f * M_PI * freq * i / RATE);
+  }
+  double in_rms = 0.3 / sqrt(2.0);
+  src.push(in);
+  return rms_tail(cap.data) / in_rms;
+}
+
+
+void test_passband_vs_stopband(void)
+{
+  cout << "test_passband_vs_stopband" << endl;
+  double inband = fsf_gain(5500.0f);
+  double stopband = fsf_gain(1000.0f);
+  check(inband > 0.3,
+        "passband tone (5500 Hz) passes (gain " + to_string(inband) + ")");
+  check(stopband < 0.1,
+        "out-of-band tone (1000 Hz) attenuated (gain " +
+        to_string(stopband) + ")");
+  check(inband > stopband * 5.0,
+        "passband gain is well above stopband gain");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+  test_passband_vs_stopband();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All AudioFsf tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " AudioFsf test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/audio/AudioPipeTest.cpp
+++ b/src/async/audio/AudioPipeTest.cpp
@@ -1,0 +1,169 @@
+/**
+@file    AudioPipeTest.cpp
+@brief   Unit tests for basic audio pipe components (Amp, Valve, Splitter).
+@author  Mark Rose
+@date    2026-06-06
+
+Pushes samples through individual audio pipe components and captures the output
+at a leaf sink to verify their behaviour: AudioAmp scales by its gain, AudioValve
+passes when open and blocks when closed, and AudioSplitter fans the same audio
+out to all registered sinks.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioSink.h>
+#include <AsyncAudioAmp.h>
+#include <AsyncAudioValve.h>
+#include <AsyncAudioSplitter.h>
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+// A source that pushes samples on demand. With a leaf sink that accepts every
+// sample there is no backpressure, so resumeOutput/allSamplesFlushed are no-ops.
+class PushSource : public AudioSource
+{
+  public:
+    int push(const vector<float>& s) { return sinkWriteSamples(s.data(), s.size()); }
+    void resumeOutput(void) override {}
+    void allSamplesFlushed(void) override {}
+};
+
+// A leaf sink that records everything written to it and accepts all samples.
+class Capture : public AudioSink
+{
+  public:
+    int writeSamples(const float* s, int count) override
+    {
+      for (int i = 0; i < count; ++i)
+      {
+        data.push_back(s[i]);
+      }
+      return count;
+    }
+    void flushSamples(void) override { sourceAllSamplesFlushed(); }
+    vector<float> data;
+};
+
+bool near(float a, float b, float tol = 0.001f) { return fabs(a - b) < tol; }
+
+
+void test_amp_scales(void)
+{
+  cout << "test_amp_scales" << endl;
+  PushSource src;
+  AudioAmp amp;
+  Capture cap;
+  src.registerSink(&amp);
+  amp.registerSink(&cap);
+
+  amp.setGain(0.0f);                       // 0 dB = unity
+  src.push({0.1f, 0.2f, 0.3f});
+  check(cap.data.size() == 3 &&
+        near(cap.data[0], 0.1f) && near(cap.data[2], 0.3f),
+        "0 dB gain passes samples unchanged");
+
+  cap.data.clear();
+  amp.setGain(6.0206f);                     // +6.02 dB ~ x2
+  src.push({0.1f});
+  check(cap.data.size() == 1 && near(cap.data[0], 0.2f, 0.005f),
+        "+6 dB doubles the amplitude");
+
+  cap.data.clear();
+  amp.setGain(-6.0206f);                    // -6.02 dB ~ x0.5
+  src.push({0.4f});
+  check(cap.data.size() == 1 && near(cap.data[0], 0.2f, 0.005f),
+        "-6 dB halves the amplitude");
+}
+
+void test_valve_open_close(void)
+{
+  cout << "test_valve_open_close" << endl;
+  PushSource src;
+  AudioValve valve;
+  Capture cap;
+  src.registerSink(&valve);
+  valve.registerSink(&cap);
+
+  valve.setOpen(true);
+  src.push({0.1f, 0.2f});
+  check(cap.data.size() == 2, "open valve passes samples");
+
+  cap.data.clear();
+  valve.setOpen(false);
+  src.push({0.3f, 0.4f, 0.5f});
+  check(cap.data.empty(), "closed valve blocks samples");
+
+  cap.data.clear();
+  valve.setOpen(true);
+  src.push({0.6f});
+  check(cap.data.size() == 1 && near(cap.data[0], 0.6f),
+        "valve passes again after reopening");
+}
+
+void test_splitter_fans_out(void)
+{
+  cout << "test_splitter_fans_out" << endl;
+  PushSource src;
+  AudioSplitter sp;
+  Capture a, b;
+  src.registerSink(&sp);
+  sp.addSink(&a);
+  sp.addSink(&b);
+
+  src.push({0.1f, 0.2f});
+  check(a.data.size() == 2 && b.data.size() == 2,
+        "both sinks receive the audio");
+  check(near(a.data[0], 0.1f) && near(b.data[1], 0.2f),
+        "both sinks receive identical samples");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;   // some audio components use the task dispatcher
+
+  test_amp_scales();
+  test_valve_open_close();
+  test_splitter_fans_out();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All audio pipe tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " audio pipe test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/audio/AudioReaderTest.cpp
+++ b/src/async/audio/AudioReaderTest.cpp
@@ -1,0 +1,110 @@
+/**
+@file    AudioReaderTest.cpp
+@brief   Unit test for AudioReader synchronous pull reads.
+@author  Mark Rose
+@date    2026-06-06
+
+AudioReader lets calling code pull samples synchronously from a connected
+source. This test wires a small data source to a reader and verifies that
+readSamples() pulls the queued samples in order, across multiple reads.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioReader.h>
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+// A source that writes its queued samples to the sink whenever the sink is
+// ready (resumeOutput). When the reader is not reading, the write returns 0,
+// which the AudioReader treats as "input stopped" and remembers to pull later.
+class DataSource : public AudioSource
+{
+  public:
+    vector<float> data;
+    size_t pos = 0;
+
+    void resumeOutput(void) override
+    {
+      while (pos < data.size())
+      {
+        int wrote = sinkWriteSamples(&data[pos], data.size() - pos);
+        if (wrote <= 0) break;
+        pos += wrote;
+      }
+    }
+    void allSamplesFlushed(void) override {}
+};
+
+bool near(float a, float b) { return fabs(a - b) < 0.0001f; }
+
+
+void test_pull_reads(void)
+{
+  cout << "test_pull_reads" << endl;
+  DataSource src;
+  AudioReader reader;
+  src.registerSink(&reader);
+  src.data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+
+  // Prime the handshake: the source offers data while the reader has no
+  // buffer, which marks the reader "input stopped" so the next readSamples
+  // pulls.
+  src.resumeOutput();
+
+  float buf[3];
+  int n1 = reader.readSamples(buf, 3);
+  check(n1 == 3 && near(buf[0], 1.0f) && near(buf[1], 2.0f) && near(buf[2], 3.0f),
+        "first read returns the first 3 samples");
+
+  int n2 = reader.readSamples(buf, 3);
+  check(n2 == 2 && near(buf[0], 4.0f) && near(buf[1], 5.0f),
+        "second read returns the remaining 2 samples");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+  test_pull_reads();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All AudioReader tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " AudioReader test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/audio/CMakeLists.txt
+++ b/src/async/audio/CMakeLists.txt
@@ -167,6 +167,16 @@ add_executable(AudioReaderTest AudioReaderTest.cpp)
 target_link_libraries(AudioReaderTest asynccpp asyncaudio asynccore)
 add_test(NAME AudioReaderTest COMMAND AudioReaderTest)
 
+# Unit test for AudioFilter frequency response
+add_executable(AudioFilterTest AudioFilterTest.cpp)
+target_link_libraries(AudioFilterTest asynccpp asyncaudio asynccore)
+add_test(NAME AudioFilterTest COMMAND AudioFilterTest)
+
+# Unit test for AudioFsf frequency sampling filter
+add_executable(AudioFsfTest AudioFsfTest.cpp)
+target_link_libraries(AudioFsfTest asynccpp asyncaudio asynccore)
+add_test(NAME AudioFsfTest COMMAND AudioFsfTest)
+
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})
 if (BUILD_STATIC_LIBS)

--- a/src/async/audio/CMakeLists.txt
+++ b/src/async/audio/CMakeLists.txt
@@ -147,35 +147,9 @@ if (BUILD_STATIC_LIBS)
   target_link_libraries(${LIBNAME}_static ${LIBS})
 endif(BUILD_STATIC_LIBS)
 
-# Unit test for basic audio pipe components
-add_executable(AudioPipeTest AudioPipeTest.cpp)
-target_link_libraries(AudioPipeTest asynccpp asyncaudio asynccore)
-add_test(NAME AudioPipeTest COMMAND AudioPipeTest)
-
-# Unit test for AudioClipper
-add_executable(AudioClipperTest AudioClipperTest.cpp)
-target_link_libraries(AudioClipperTest asynccpp asyncaudio asynccore)
-add_test(NAME AudioClipperTest COMMAND AudioClipperTest)
-
-# Unit test for AudioDelayLine
-add_executable(AudioDelayLineTest AudioDelayLineTest.cpp)
-target_link_libraries(AudioDelayLineTest asynccpp asyncaudio asynccore)
-add_test(NAME AudioDelayLineTest COMMAND AudioDelayLineTest)
-
-# Unit test for AudioReader synchronous pull reads
-add_executable(AudioReaderTest AudioReaderTest.cpp)
-target_link_libraries(AudioReaderTest asynccpp asyncaudio asynccore)
-add_test(NAME AudioReaderTest COMMAND AudioReaderTest)
-
-# Unit test for AudioFilter frequency response
-add_executable(AudioFilterTest AudioFilterTest.cpp)
-target_link_libraries(AudioFilterTest asynccpp asyncaudio asynccore)
-add_test(NAME AudioFilterTest COMMAND AudioFilterTest)
-
-# Unit test for AudioFsf frequency sampling filter
-add_executable(AudioFsfTest AudioFsfTest.cpp)
-target_link_libraries(AudioFsfTest asynccpp asyncaudio asynccore)
-add_test(NAME AudioFsfTest COMMAND AudioFsfTest)
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+svxlink_add_tests(LIBS asynccpp asyncaudio asynccore)
 
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/async/audio/CMakeLists.txt
+++ b/src/async/audio/CMakeLists.txt
@@ -147,6 +147,26 @@ if (BUILD_STATIC_LIBS)
   target_link_libraries(${LIBNAME}_static ${LIBS})
 endif(BUILD_STATIC_LIBS)
 
+# Unit test for basic audio pipe components
+add_executable(AudioPipeTest AudioPipeTest.cpp)
+target_link_libraries(AudioPipeTest asynccpp asyncaudio asynccore)
+add_test(NAME AudioPipeTest COMMAND AudioPipeTest)
+
+# Unit test for AudioClipper
+add_executable(AudioClipperTest AudioClipperTest.cpp)
+target_link_libraries(AudioClipperTest asynccpp asyncaudio asynccore)
+add_test(NAME AudioClipperTest COMMAND AudioClipperTest)
+
+# Unit test for AudioDelayLine
+add_executable(AudioDelayLineTest AudioDelayLineTest.cpp)
+target_link_libraries(AudioDelayLineTest asynccpp asyncaudio asynccore)
+add_test(NAME AudioDelayLineTest COMMAND AudioDelayLineTest)
+
+# Unit test for AudioReader synchronous pull reads
+add_executable(AudioReaderTest AudioReaderTest.cpp)
+target_link_libraries(AudioReaderTest asynccpp asyncaudio asynccore)
+add_test(NAME AudioReaderTest COMMAND AudioReaderTest)
+
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})
 if (BUILD_STATIC_LIBS)

--- a/src/async/core/AsyncMsgTest.cpp
+++ b/src/async/core/AsyncMsgTest.cpp
@@ -1,0 +1,148 @@
+/**
+@file    AsyncMsgTest.cpp
+@brief   Unit tests for the Async::Msg serialization framework.
+@author  Mark Rose
+@date    2026-06-06
+
+Async::Msg (with the ASYNC_MSG_MEMBERS macro) serializes structured messages to
+a byte stream. These tests round-trip messages containing scalars, strings, and
+nested containers (vector, map) and verify the values survive pack/unpack.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "AsyncMsg.h"
+
+using namespace std;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+
+// A message exercising scalars, a string, and nested containers.
+class TestMsg : public Async::Msg
+{
+  public:
+    uint32_t                 u32 = 0;
+    int16_t                  i16 = 0;
+    string                   str;
+    vector<int>              vec;
+    map<string, int>         mp;
+
+    ASYNC_MSG_MEMBERS(u32, i16, str, vec, mp)
+};
+
+template <typename T>
+bool round_trip(const T& out, T& in)
+{
+  stringstream ss;
+  return out.pack(ss) && in.unpack(ss);
+}
+
+
+void test_scalars_and_string(void)
+{
+  cout << "test_scalars_and_string" << endl;
+  TestMsg out;
+  out.u32 = 0xDEADBEEF;
+  out.i16 = -1234;
+  out.str = "hello, reflector";
+  TestMsg in;
+  check(round_trip(out, in), "message round-trips");
+  check(in.u32 == 0xDEADBEEF, "uint32 preserved");
+  check(in.i16 == -1234, "negative int16 preserved");
+  check(in.str == "hello, reflector", "string preserved");
+}
+
+void test_vector(void)
+{
+  cout << "test_vector" << endl;
+  TestMsg out;
+  out.vec = {1, 2, 3, -7, 1000000};
+  TestMsg in;
+  check(round_trip(out, in), "message with vector round-trips");
+  check(in.vec == out.vec, "vector<int> contents preserved");
+}
+
+void test_map(void)
+{
+  cout << "test_map" << endl;
+  TestMsg out;
+  out.mp = {{"a", 1}, {"b", 2}, {"c", 3}};
+  TestMsg in;
+  check(round_trip(out, in), "message with map round-trips");
+  check(in.mp == out.mp, "map<string,int> contents preserved");
+}
+
+void test_empty_containers(void)
+{
+  cout << "test_empty_containers" << endl;
+  TestMsg out;             // all containers empty, strings empty
+  TestMsg in;
+  in.vec = {9, 9};         // stale data that must be overwritten
+  in.str = "stale";
+  check(round_trip(out, in), "empty message round-trips");
+  check(in.vec.empty() && in.str.empty() && in.mp.empty(),
+        "empty containers/string overwrite stale data");
+}
+
+void test_truncated_stream_fails(void)
+{
+  cout << "test_truncated_stream_fails" << endl;
+  TestMsg out;
+  out.str = "abcdef";
+  out.vec = {1, 2, 3};
+  stringstream ss;
+  out.pack(ss);
+  string full = ss.str();
+  // Feed only the first few bytes; unpack must fail rather than succeed.
+  stringstream truncated(full.substr(0, full.size() / 3));
+  TestMsg in;
+  check(!in.unpack(truncated), "unpack of a truncated stream fails");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_scalars_and_string();
+  test_vector();
+  test_map();
+  test_empty_containers();
+  test_truncated_stream_fails();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All Async::Msg tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " Async::Msg test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/core/CMakeLists.txt
+++ b/src/async/core/CMakeLists.txt
@@ -58,6 +58,11 @@ if (BUILD_STATIC_LIBS)
   target_link_libraries(${LIBNAME}_static ${LIBS})
 endif(BUILD_STATIC_LIBS)
 
+# Unit test for Async::Config
+add_executable(ConfigTest ConfigTest.cpp)
+target_link_libraries(ConfigTest ${LIBNAME})
+add_test(NAME ConfigTest COMMAND ConfigTest)
+
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})
 if (BUILD_STATIC_LIBS)

--- a/src/async/core/CMakeLists.txt
+++ b/src/async/core/CMakeLists.txt
@@ -63,6 +63,10 @@ add_executable(ConfigTest ConfigTest.cpp)
 target_link_libraries(ConfigTest ${LIBNAME})
 add_test(NAME ConfigTest COMMAND ConfigTest)
 
+# Unit test for the Async::Msg serialization framework (header-only)
+add_executable(AsyncMsgTest AsyncMsgTest.cpp)
+add_test(NAME AsyncMsgTest COMMAND AsyncMsgTest)
+
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})
 if (BUILD_STATIC_LIBS)

--- a/src/async/core/CMakeLists.txt
+++ b/src/async/core/CMakeLists.txt
@@ -58,19 +58,9 @@ if (BUILD_STATIC_LIBS)
   target_link_libraries(${LIBNAME}_static ${LIBS})
 endif(BUILD_STATIC_LIBS)
 
-# Unit test for Async::Config
-add_executable(ConfigTest ConfigTest.cpp)
-target_link_libraries(ConfigTest ${LIBNAME})
-add_test(NAME ConfigTest COMMAND ConfigTest)
-
-# Unit test for the Async::Msg serialization framework (header-only)
-add_executable(AsyncMsgTest AsyncMsgTest.cpp)
-add_test(NAME AsyncMsgTest COMMAND AsyncMsgTest)
-
-# Unit test for the Async::StateMachine framework (header-only)
-add_executable(StateMachineTest StateMachineTest.cpp)
-target_link_libraries(StateMachineTest ${LIBNAME})
-add_test(NAME StateMachineTest COMMAND StateMachineTest)
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+svxlink_add_tests(LIBS ${LIBNAME})
 
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/async/core/CMakeLists.txt
+++ b/src/async/core/CMakeLists.txt
@@ -67,6 +67,11 @@ add_test(NAME ConfigTest COMMAND ConfigTest)
 add_executable(AsyncMsgTest AsyncMsgTest.cpp)
 add_test(NAME AsyncMsgTest COMMAND AsyncMsgTest)
 
+# Unit test for the Async::StateMachine framework (header-only)
+add_executable(StateMachineTest StateMachineTest.cpp)
+target_link_libraries(StateMachineTest ${LIBNAME})
+add_test(NAME StateMachineTest COMMAND StateMachineTest)
+
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})
 if (BUILD_STATIC_LIBS)

--- a/src/async/core/ConfigTest.cpp
+++ b/src/async/core/ConfigTest.cpp
@@ -1,0 +1,119 @@
+/**
+@file    ConfigTest.cpp
+@brief   Unit tests for Async::Config value get/set and type coercion.
+@author  Mark Rose
+@date    2026-06-06
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <algorithm>
+#include <iostream>
+#include <list>
+#include <string>
+
+#include "AsyncConfig.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+
+void test_string_round_trip(void)
+{
+  cout << "test_string_round_trip" << endl;
+  Config cfg;
+  cfg.setValue("S", "name", string("hello"));
+  string v;
+  check(cfg.getValue("S", "name", v) && v == "hello", "string get/set");
+}
+
+void test_typed_coercion(void)
+{
+  cout << "test_typed_coercion" << endl;
+  Config cfg;
+  cfg.setValue("S", "num", string("42"));
+  cfg.setValue("S", "flt", string("3.5"));
+
+  int i = 0;
+  check(cfg.getValue("S", "num", i) && i == 42, "int coercion '42' -> 42");
+  float f = 0.0f;
+  check(cfg.getValue("S", "flt", f) && f == 3.5f, "float coercion '3.5' -> 3.5");
+
+  cfg.setValue("S", "notnum", string("abc"));
+  int bad = -1;
+  check(!cfg.getValue("S", "notnum", bad),
+        "non-numeric value fails int coercion");
+}
+
+void test_missing_and_default(void)
+{
+  cout << "test_missing_and_default" << endl;
+  Config cfg;
+  int i = 99;
+  check(!cfg.getValue("S", "absent", i), "missing variable returns false");
+  check(i == 99, "value untouched when missing");
+
+  int j = 7;
+  check(cfg.getValue("S", "absent", j, /*missing_ok=*/true),
+        "missing_ok=true returns true for missing variable");
+  check(j == 7, "value untouched with missing_ok");
+}
+
+void test_list_section(void)
+{
+  cout << "test_list_section" << endl;
+  Config cfg;
+  cfg.setValue("Sec", "a", string("1"));
+  cfg.setValue("Sec", "b", string("2"));
+  cfg.setValue("Other", "c", string("3"));
+
+  list<string> tags = cfg.listSection("Sec");
+  bool has_a = find(tags.begin(), tags.end(), "a") != tags.end();
+  bool has_b = find(tags.begin(), tags.end(), "b") != tags.end();
+  check(tags.size() == 2 && has_a && has_b,
+        "listSection returns the tags of that section only");
+
+  list<string> none = cfg.listSection("Nonexistent");
+  check(none.empty(), "listSection of unknown section is empty");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_string_round_trip();
+  test_typed_coercion();
+  test_missing_and_default();
+  test_list_section();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All Config tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " Config test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/async/core/StateMachineTest.cpp
+++ b/src/async/core/StateMachineTest.cpp
@@ -1,0 +1,132 @@
+/**
+@file    StateMachineTest.cpp
+@brief   Unit tests for the Async::StateMachine hierarchical state machine.
+@author  Mark Rose
+@date    2026-06-06
+
+Builds a small hierarchical state machine and verifies start-up into the
+default substate, event-driven transitions, hierarchical isActive() queries,
+and context access/mutation from a state handler.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include "AsyncStateMachine.h"
+
+using namespace std;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+struct Context { int a = 0; };
+
+struct StateTop;
+struct StateDisconnected;
+struct StateConnected;
+struct StateConnectedA;
+struct StateConnectedB;
+
+struct StateTop : Async::StateTopBase<Context, StateTop>::Type
+{
+  static constexpr auto NAME = "Top";
+  void init(void) { setState<StateDisconnected>(); }
+  virtual void eventA(void) {}
+  virtual void eventB(void) {}
+};
+
+struct StateDisconnected : Async::StateBase<StateTop, StateDisconnected>
+{
+  static constexpr auto NAME = "Disconnected";
+  void eventA(void) override
+  {
+    ctx().a = 24;
+    setState<StateConnected>();
+  }
+};
+
+struct StateConnected : Async::StateBase<StateTop, StateConnected>
+{
+  static constexpr auto NAME = "Connected";
+  void init(void) { setState<StateConnectedA>(); }
+  void eventB(void) override { setState<StateConnectedB>(); }
+};
+
+struct StateConnectedA : Async::StateBase<StateConnected, StateConnectedA>
+{
+  static constexpr auto NAME = "ConnectedA";
+};
+
+struct StateConnectedB : Async::StateBase<StateConnected, StateConnectedB>
+{
+  static constexpr auto NAME = "ConnectedB";
+};
+
+
+void test_state_machine(void)
+{
+  cout << "test_state_machine" << endl;
+  Context ctx;
+  ctx.a = 42;
+  Async::StateMachine<Context, StateTop> sm(&ctx);
+
+  sm.start();
+  check(sm.isActive<StateDisconnected>(),
+        "starts in the default substate (Disconnected)");
+  check(!sm.isActive<StateConnected>(), "not in Connected at start");
+
+  sm.state().eventA();
+  check(ctx.a == 24, "event handler mutated the context");
+  check(!sm.isActive<StateDisconnected>(), "left Disconnected after eventA");
+  check(sm.isActive<StateConnectedA>(),
+        "entered Connected's default substate ConnectedA");
+
+  // eventB is defined on the superstate StateConnected, not on ConnectedA.
+  // Dispatching it while in ConnectedA exercises hierarchical event handling
+  // (a substate inherits its superstate's event handlers).
+  sm.state().eventB();
+  check(sm.isActive<StateConnectedB>(),
+        "superstate event handler (eventB) ran from substate -> ConnectedB");
+
+  sm.setState<StateDisconnected>();
+  check(sm.isActive<StateDisconnected>(),
+        "explicit setState returned to Disconnected");
+  check(!sm.isActive<StateConnected>(), "no longer in Connected");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_state_machine();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All StateMachine tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " StateMachine test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/cmake/Modules/SvxLinkAddTests.cmake
+++ b/src/cmake/Modules/SvxLinkAddTests.cmake
@@ -1,0 +1,45 @@
+# SvxLinkAddTests.cmake
+#
+# Conflict-free unit-test registration for SvxLink.
+#
+# svxlink_add_tests() auto-discovers every *Test.cpp file in the calling
+# directory and registers each as a CTest test named after the file (without
+# extension). Adding a new unit test then only requires dropping a new
+# <Name>Test.cpp file into the directory -- no edits to this file or to any
+# shared CMakeLists.txt are needed, so independent branches/PRs that each add
+# a test never conflict with one another.
+#
+# Common link libraries for the directory are passed via LIBS:
+#   svxlink_add_tests(LIBS asynccore asynccpp)
+#
+# A test that needs extra sources or libraries beyond the directory default
+# can declare them in an optional sidecar file <Name>Test.deps.cmake placed
+# next to the test source. The sidecar is include()d before the target is
+# created and may set:
+#   <Name>Test_EXTRA_SRCS  - extra source files to compile into the test
+#   <Name>Test_EXTRA_LIBS  - extra libraries to link
+# Because the sidecar is a separate per-test file, it is also conflict-free.
+
+function(svxlink_add_tests)
+  cmake_parse_arguments(SAT "" "" "LIBS" ${ARGN})
+
+  file(GLOB _svxlink_test_srcs CONFIGURE_DEPENDS
+       "${CMAKE_CURRENT_SOURCE_DIR}/*Test.cpp")
+
+  foreach(_src ${_svxlink_test_srcs})
+    get_filename_component(_name "${_src}" NAME_WE)
+
+    set(${_name}_EXTRA_SRCS "")
+    set(${_name}_EXTRA_LIBS "")
+    set(_sidecar "${CMAKE_CURRENT_SOURCE_DIR}/${_name}.deps.cmake")
+    if(EXISTS "${_sidecar}")
+      include("${_sidecar}")
+    endif()
+
+    add_executable(${_name} "${_src}" ${${_name}_EXTRA_SRCS})
+    if(SAT_LIBS OR ${_name}_EXTRA_LIBS)
+      target_link_libraries(${_name} ${SAT_LIBS} ${${_name}_EXTRA_LIBS})
+    endif()
+    add_test(NAME ${_name} COMMAND ${_name})
+  endforeach()
+endfunction()

--- a/src/locationinfo/CMakeLists.txt
+++ b/src/locationinfo/CMakeLists.txt
@@ -19,5 +19,9 @@ endforeach(incfile)
 add_library(${LIBNAME} STATIC ${LIBSRC})
 target_link_libraries(${LIBNAME} ${LIBS})
 
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+svxlink_add_tests(LIBS ${LIBNAME} ${LIBS})
+
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/misc/CMakeLists.txt
+++ b/src/misc/CMakeLists.txt
@@ -12,6 +12,11 @@ add_library(${LIBNAME} STATIC ${LIBSRC})
 set_target_properties(${LIBNAME} PROPERTIES OUTPUT_NAME ${LIBNAME})
 target_link_libraries(${LIBNAME} ${LIBS})
 
+# Unit test for the common string utilities
+add_executable(CommonTest CommonTest.cpp)
+target_link_libraries(CommonTest ${LIBNAME})
+add_test(NAME CommonTest COMMAND CommonTest)
+
 # Install targets
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})
 install(FILES ${EXPINC} DESTINATION ${SVX_INCLUDE_INSTALL_DIR})

--- a/src/misc/CMakeLists.txt
+++ b/src/misc/CMakeLists.txt
@@ -12,10 +12,9 @@ add_library(${LIBNAME} STATIC ${LIBSRC})
 set_target_properties(${LIBNAME} PROPERTIES OUTPUT_NAME ${LIBNAME})
 target_link_libraries(${LIBNAME} ${LIBS})
 
-# Unit test for the common string utilities
-add_executable(CommonTest CommonTest.cpp)
-target_link_libraries(CommonTest ${LIBNAME})
-add_test(NAME CommonTest COMMAND CommonTest)
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+svxlink_add_tests(LIBS ${LIBNAME})
 
 # Install targets
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/misc/CommonTest.cpp
+++ b/src/misc/CommonTest.cpp
@@ -1,0 +1,133 @@
+/**
+@file    CommonTest.cpp
+@brief   Unit tests for the SvxLink common string utilities (common.h).
+@author  Mark Rose
+@date    2026-06-06
+
+Covers setValueFromString (typed parse with full-consume semantics), splitStr
+(tokenising with delimiter sets, skipping tokens that don't parse) and SepPair
+(separated-pair stream in/out).
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "common.h"
+
+using namespace std;
+using namespace SvxLink;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+
+void test_set_value_from_string(void)
+{
+  cout << "test_set_value_from_string" << endl;
+  int i = 0;
+  check(setValueFromString(i, "42") && i == 42, "parse int '42'");
+  check(setValueFromString(i, "42 ") && i == 42, "trailing space consumed");
+  check(!setValueFromString(i, "42x"), "trailing junk rejected");
+  check(!setValueFromString(i, ""), "empty string rejected for int");
+
+  float f = 0.0f;
+  check(setValueFromString(f, "3.5") && f == 3.5f, "parse float '3.5'");
+
+  string s;
+  check(setValueFromString(s, "hello world") && s == "hello world",
+        "string overload copies verbatim (keeps spaces)");
+}
+
+void test_split_str_int(void)
+{
+  cout << "test_split_str_int" << endl;
+  vector<int> v;
+  size_t n = splitStr(v, "1,2,3", ",");
+  check(n == 3 && v.size() == 3 && v[0] == 1 && v[2] == 3,
+        "split '1,2,3' -> {1,2,3}");
+
+  splitStr(v, "1,,2", ",");
+  check(v.size() == 2 && v[0] == 1 && v[1] == 2,
+        "consecutive delimiters produce no empty tokens");
+
+  splitStr(v, "1,x,3", ",");
+  check(v.size() == 2 && v[0] == 1 && v[1] == 3,
+        "tokens that don't parse as int are skipped ('x')");
+}
+
+void test_split_str_string(void)
+{
+  cout << "test_split_str_string" << endl;
+  vector<string> v;
+  size_t n = splitStr(v, "a, b ,c", ", ");
+  check(n == 3 && v[0] == "a" && v[1] == "b" && v[2] == "c",
+        "split with ', ' delimiters trims spaces -> {a,b,c}");
+}
+
+void test_sep_pair(void)
+{
+  cout << "test_sep_pair" << endl;
+  {
+    istringstream is("100.5:1000");
+    SepPair<float, unsigned> p;
+    is >> p;
+    check(!is.fail() && p.first == 100.5f && p.second == 1000u,
+          "parse '100.5:1000' -> (100.5, 1000)");
+  }
+  {
+    ostringstream os;
+    SepPair<float, unsigned> p;
+    p.first = 12.0f;
+    p.second = 34u;
+    os << p;
+    check(os.str() == "12:34", "stream out -> '12:34'");
+  }
+  {
+    istringstream is("noseparator");
+    SepPair<float, unsigned> p;
+    is >> p;
+    check(is.fail(), "missing separator sets failbit");
+  }
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_set_value_from_string();
+  test_split_str_int();
+  test_split_str_string();
+  test_sep_pair();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All common.h tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " common.h test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/reflector/CMakeLists.txt
+++ b/src/svxlink/reflector/CMakeLists.txt
@@ -31,10 +31,9 @@ set_target_properties(svxreflector PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${RUNTIME_OUTPUT_DIRECTORY}
 )
 
-# Reflector protocol message pack/unpack round-trip test
-add_executable(ReflectorMsgTest ReflectorMsgTest.cpp)
-target_link_libraries(ReflectorMsgTest ${LIBS})
-add_test(NAME ReflectorMsgTest COMMAND ReflectorMsgTest)
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+svxlink_add_tests(LIBS ${LIBS})
 
 # Generate config file with correct paths
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxreflector.conf.in

--- a/src/svxlink/reflector/CMakeLists.txt
+++ b/src/svxlink/reflector/CMakeLists.txt
@@ -31,6 +31,11 @@ set_target_properties(svxreflector PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${RUNTIME_OUTPUT_DIRECTORY}
 )
 
+# Reflector protocol message pack/unpack round-trip test
+add_executable(ReflectorMsgTest ReflectorMsgTest.cpp)
+target_link_libraries(ReflectorMsgTest ${LIBS})
+add_test(NAME ReflectorMsgTest COMMAND ReflectorMsgTest)
+
 # Generate config file with correct paths
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxreflector.conf.in
   ${CMAKE_CURRENT_BINARY_DIR}/svxreflector.conf

--- a/src/svxlink/reflector/ReflectorMsgTest.cpp
+++ b/src/svxlink/reflector/ReflectorMsgTest.cpp
@@ -1,0 +1,127 @@
+/**
+@file    ReflectorMsgTest.cpp
+@brief   Round-trip (pack/unpack) tests for Reflector protocol messages.
+@author  Mark Rose
+@date    2026-06-06
+
+Reflector messages serialize via the Async::Msg framework. These tests pack a
+message to a stream, unpack it into a fresh instance, and verify the message
+type and field values survive the round-trip.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "ReflectorMsg.h"
+
+using namespace std;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+// Pack `out` into a stream and unpack it back into `in`. Returns false if
+// either step fails.
+template <typename T>
+bool round_trip(const T& out, T& in)
+{
+  stringstream ss;
+  if (!out.pack(ss))
+  {
+    return false;
+  }
+  return in.unpack(ss);
+}
+
+
+void test_proto_ver(void)
+{
+  cout << "test_proto_ver" << endl;
+  MsgProtoVer out(3, 1);
+  MsgProtoVer in(0, 0);
+  check(round_trip(out, in), "MsgProtoVer packs and unpacks");
+  check(in.type() == MsgProtoVer::TYPE, "type preserved (5)");
+  check(in.majorVer() == 3 && in.minorVer() == 1,
+        "major/minor preserved (3.1)");
+}
+
+void test_heartbeat_no_members(void)
+{
+  cout << "test_heartbeat_no_members" << endl;
+  MsgHeartbeat out;
+  MsgHeartbeat in;
+  check(round_trip(out, in), "MsgHeartbeat (no members) round-trips");
+  check(in.type() == MsgHeartbeat::TYPE, "type preserved (1)");
+}
+
+void test_error_string(void)
+{
+  cout << "test_error_string" << endl;
+  MsgError out("something failed");
+  MsgError in;
+  check(round_trip(out, in), "MsgError packs and unpacks");
+  check(in.message() == "something failed", "string field preserved");
+  check(in.type() == MsgError::TYPE, "type preserved (13)");
+}
+
+void test_node_list_vector(void)
+{
+  cout << "test_node_list_vector" << endl;
+  vector<string> nodes = {"SK3AB", "SM0SVX", "VE6HM"};
+  MsgNodeList out(nodes);
+  MsgNodeList in;
+  check(round_trip(out, in), "MsgNodeList packs and unpacks");
+  check(in.nodes() == nodes, "vector<string> field preserved");
+  check(in.type() == MsgNodeList::TYPE, "type preserved (101)");
+}
+
+void test_empty_node_list(void)
+{
+  cout << "test_empty_node_list" << endl;
+  MsgNodeList out;   // empty
+  MsgNodeList in(vector<string>{"stale"});
+  check(round_trip(out, in), "empty MsgNodeList round-trips");
+  check(in.nodes().empty(), "empty vector preserved (overwrites previous)");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_proto_ver();
+  test_heartbeat_no_members();
+  test_error_string();
+  test_node_list_vector();
+  test_empty_node_list();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All ReflectorMsg tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " ReflectorMsg test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -94,6 +94,11 @@ foreach(logic_name ${SVXLINK_LOGIC_CORES})
   #target_link_libraries(${logic_name}Logic ${LIBS})
 endforeach()
 
+# Build the CmdParser unit test (pure logic, only needs sigc++ via asynccore)
+add_executable(CmdParserTest CmdParserTest.cpp CmdParser.cpp)
+target_link_libraries(CmdParserTest asynccore)
+add_test(NAME CmdParserTest COMMAND CmdParserTest)
+
 # Generate config file with correct paths
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxlink.conf.in
   ${CMAKE_CURRENT_BINARY_DIR}/svxlink.conf

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -94,15 +94,11 @@ foreach(logic_name ${SVXLINK_LOGIC_CORES})
   #target_link_libraries(${logic_name}Logic ${LIBS})
 endforeach()
 
-# Build the CmdParser unit test (pure logic, only needs sigc++ via asynccore)
-add_executable(CmdParserTest CmdParserTest.cpp CmdParser.cpp)
-target_link_libraries(CmdParserTest asynccore)
-add_test(NAME CmdParserTest COMMAND CmdParserTest)
-
-# Build the DtmfDigitHandler unit test (needs Async::Timer/CppApplication)
-add_executable(DtmfDigitHandlerTest DtmfDigitHandlerTest.cpp DtmfDigitHandler.cpp)
-target_link_libraries(DtmfDigitHandlerTest asynccpp asynccore)
-add_test(NAME DtmfDigitHandlerTest COMMAND DtmfDigitHandlerTest)
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+# CmdParserTest and DtmfDigitHandlerTest compile an extra source each; those
+# are declared in <Name>.deps.cmake sidecars next to the test.
+svxlink_add_tests(LIBS asynccpp asynccore)
 
 # Smoke test: every TCL event script loads cleanly under tclsh
 add_test(NAME tcl_event_scripts_load

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -99,6 +99,11 @@ add_executable(CmdParserTest CmdParserTest.cpp CmdParser.cpp)
 target_link_libraries(CmdParserTest asynccore)
 add_test(NAME CmdParserTest COMMAND CmdParserTest)
 
+# Build the DtmfDigitHandler unit test (needs Async::Timer/CppApplication)
+add_executable(DtmfDigitHandlerTest DtmfDigitHandlerTest.cpp DtmfDigitHandler.cpp)
+target_link_libraries(DtmfDigitHandlerTest asynccpp asynccore)
+add_test(NAME DtmfDigitHandlerTest COMMAND DtmfDigitHandlerTest)
+
 # Generate config file with correct paths
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxlink.conf.in
   ${CMAKE_CURRENT_BINARY_DIR}/svxlink.conf

--- a/src/svxlink/svxlink/CMakeLists.txt
+++ b/src/svxlink/svxlink/CMakeLists.txt
@@ -104,6 +104,11 @@ add_executable(DtmfDigitHandlerTest DtmfDigitHandlerTest.cpp DtmfDigitHandler.cp
 target_link_libraries(DtmfDigitHandlerTest asynccpp asynccore)
 add_test(NAME DtmfDigitHandlerTest COMMAND DtmfDigitHandlerTest)
 
+# Smoke test: every TCL event script loads cleanly under tclsh
+add_test(NAME tcl_event_scripts_load
+  COMMAND ${CMAKE_COMMAND} -E env python3
+          ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/test_tcl_loads.py)
+
 # Generate config file with correct paths
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxlink.conf.in
   ${CMAKE_CURRENT_BINARY_DIR}/svxlink.conf

--- a/src/svxlink/svxlink/CmdParserTest.cpp
+++ b/src/svxlink/svxlink/CmdParserTest.cpp
@@ -1,0 +1,181 @@
+/**
+@file    CmdParserTest.cpp
+@brief   Unit tests for the CmdParser DTMF command dispatcher.
+@author  Mark Rose
+@date    2026-06-06
+
+CmdParser matches a received command string against registered commands using
+longest-prefix matching (unless a command requires an exact match), and invokes
+the matching Command with the remaining characters as the sub command. These
+tests exercise that logic directly; CmdParser has no Async/event-loop deps.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include "CmdParser.h"
+
+using namespace std;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+// A Command that records how many times it was invoked and the last sub
+// command it received.
+class RecCmd : public Command
+{
+  public:
+    RecCmd(CmdParser* parser, const string& cmd, bool exact = false)
+      : Command(parser, cmd)
+    {
+      if (exact)
+      {
+        setExactMatch(true);
+      }
+    }
+    void operator()(const string& subcmd) override
+    {
+      ++calls;
+      last_subcmd = subcmd;
+    }
+    int calls = 0;
+    string last_subcmd;
+};
+
+
+void test_exact_dispatch_and_subcmd(void)
+{
+  cout << "test_exact_dispatch_and_subcmd" << endl;
+  CmdParser p;
+  RecCmd c12(&p, "12");
+  check(c12.addToParser(), "add command '12'");
+
+  check(p.processCmd("12"), "processCmd('12') matches");
+  check(c12.calls == 1 && c12.last_subcmd == "", "invoked once, empty subcmd");
+
+  check(p.processCmd("123"), "processCmd('123') matches '12'");
+  check(c12.calls == 2 && c12.last_subcmd == "3", "subcmd '3' extracted");
+}
+
+void test_longest_prefix_wins(void)
+{
+  cout << "test_longest_prefix_wins" << endl;
+  CmdParser p;
+  RecCmd c1(&p, "1");
+  RecCmd c12(&p, "12");
+  c1.addToParser();
+  c12.addToParser();
+
+  check(p.processCmd("123"), "processCmd('123') matches");
+  check(c12.calls == 1 && c1.calls == 0, "longest prefix '12' wins over '1'");
+  check(c12.last_subcmd == "3", "subcmd '3'");
+
+  check(p.processCmd("1"), "processCmd('1') matches");
+  check(c1.calls == 1, "'1' dispatches to the short command");
+}
+
+void test_exact_match_blocks_subcmd(void)
+{
+  cout << "test_exact_match_blocks_subcmd" << endl;
+  CmdParser p;
+  RecCmd c12(&p, "12", /*exact=*/true);
+  c12.addToParser();
+
+  check(p.processCmd("12"), "exact command matches exact string");
+  check(c12.calls == 1, "invoked for exact match");
+  check(!p.processCmd("123"), "exact command does NOT match with trailing chars");
+  check(c12.calls == 1, "not invoked for non-exact input");
+}
+
+void test_unknown_command(void)
+{
+  cout << "test_unknown_command" << endl;
+  CmdParser p;
+  RecCmd c12(&p, "12");
+  c12.addToParser();
+  check(!p.processCmd("99"), "unknown command returns false");
+  check(c12.calls == 0, "no command invoked");
+}
+
+void test_add_remove_lifecycle(void)
+{
+  cout << "test_add_remove_lifecycle" << endl;
+  CmdParser p;
+  RecCmd c12(&p, "12");
+  check(c12.addToParser(), "first add succeeds");
+  RecCmd dup(&p, "12");
+  check(!dup.addToParser(), "duplicate command string rejected");
+
+  check(c12.removeFromParser(), "remove succeeds");
+  check(!p.processCmd("12"), "removed command no longer matches");
+  check(!c12.removeFromParser(), "removing again returns false");
+}
+
+// Records handleCmd signal emissions.
+class SignalRecorder : public sigc::trackable
+{
+  public:
+    void onHandle(Command*, const string& subcmd)
+    {
+      ++calls;
+      last_subcmd = subcmd;
+    }
+    int calls = 0;
+    string last_subcmd;
+};
+
+void test_handle_cmd_signal(void)
+{
+  cout << "test_handle_cmd_signal" << endl;
+  CmdParser p;
+  // A plain Command (operator() not overridden) emits handleCmd.
+  Command c(&p, "55");
+  c.addToParser();
+  SignalRecorder rec;
+  c.handleCmd.connect(sigc::mem_fun(rec, &SignalRecorder::onHandle));
+  check(p.processCmd("557"), "processCmd('557')");
+  check(rec.calls == 1 && rec.last_subcmd == "7",
+        "handleCmd signal fired with subcmd '7'");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_exact_dispatch_and_subcmd();
+  test_longest_prefix_wins();
+  test_exact_match_blocks_subcmd();
+  test_unknown_command();
+  test_add_remove_lifecycle();
+  test_handle_cmd_signal();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All CmdParser tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " CmdParser test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/svxlink/CmdParserTest.deps.cmake
+++ b/src/svxlink/svxlink/CmdParserTest.deps.cmake
@@ -1,0 +1,2 @@
+# CmdParserTest exercises CmdParser directly, so compile the source in.
+set(CmdParserTest_EXTRA_SRCS CmdParser.cpp)

--- a/src/svxlink/svxlink/DtmfDigitHandlerTest.cpp
+++ b/src/svxlink/svxlink/DtmfDigitHandlerTest.cpp
@@ -1,0 +1,201 @@
+/**
+@file    DtmfDigitHandlerTest.cpp
+@brief   Unit tests for DtmfDigitHandler (DTMF command accumulation).
+@author  Mark Rose
+@date    2026-06-06
+
+DtmfDigitHandler accumulates received DTMF digits into a command string,
+completing on '#', with a few special digits (A enables anti-flutter, D resets
+to "D", H inserts a literal '#', B repeats the previous digit under
+anti-flutter) and a 20-digit cap. These tests drive digitReceived() directly
+and inspect command()/the commandComplete signal. The 10-second inactivity
+timeout is not exercised (it requires the event loop); a CppApplication is
+created only so the internal Async::Timer can be constructed.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <AsyncCppApplication.h>
+
+#include <iostream>
+#include <string>
+
+#include "DtmfDigitHandler.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+// Records commandComplete emissions and the command string at completion time
+// (DtmfDigitHandler resets the buffer right after emitting, so it must be read
+// from within the signal).
+class Recorder : public sigc::trackable
+{
+  public:
+    explicit Recorder(DtmfDigitHandler& dh) : m_dh(dh)
+    {
+      dh.commandComplete.connect(sigc::mem_fun(*this, &Recorder::onComplete));
+    }
+    void onComplete(void)
+    {
+      ++completions;
+      last_command = m_dh.command();
+    }
+    int completions = 0;
+    string last_command;
+  private:
+    DtmfDigitHandler& m_dh;
+};
+
+void feed(DtmfDigitHandler& dh, const string& digits)
+{
+  for (char d : digits)
+  {
+    dh.digitReceived(d);
+  }
+}
+
+
+void test_basic_accumulation(void)
+{
+  cout << "test_basic_accumulation" << endl;
+  DtmfDigitHandler dh;
+  feed(dh, "123");
+  check(dh.command() == "123", "digits accumulate to '123'");
+}
+
+void test_hash_completes_and_resets(void)
+{
+  cout << "test_hash_completes_and_resets" << endl;
+  DtmfDigitHandler dh;
+  Recorder rec(dh);
+  feed(dh, "12#");
+  check(rec.completions == 1, "commandComplete emitted once on '#'");
+  check(rec.last_command == "12", "command was '12' at completion");
+  check(dh.command() == "", "buffer cleared after completion");
+}
+
+void test_star_rules(void)
+{
+  cout << "test_star_rules" << endl;
+  DtmfDigitHandler dh;
+  feed(dh, "**");
+  check(dh.command() == "*", "leading '*' kept once, duplicate '*' ignored");
+}
+
+void test_max_length(void)
+{
+  cout << "test_max_length" << endl;
+  DtmfDigitHandler dh;
+  feed(dh, string(25, '1'));
+  check(dh.command().size() == 20, "buffer capped at 20 digits");
+}
+
+void test_d_resets_to_D(void)
+{
+  cout << "test_d_resets_to_D" << endl;
+  DtmfDigitHandler dh;
+  feed(dh, "12D");
+  check(dh.command() == "D", "'D' resets the buffer to 'D'");
+}
+
+void test_h_inserts_hash(void)
+{
+  cout << "test_h_inserts_hash" << endl;
+  DtmfDigitHandler dh;
+  feed(dh, "1H2");
+  check(dh.command() == "1#2", "'H' inserts a literal '#'");
+}
+
+void test_anti_flutter_dedup(void)
+{
+  cout << "test_anti_flutter_dedup" << endl;
+  DtmfDigitHandler dh;
+  feed(dh, "A");
+  check(dh.antiFlutterActive(), "'A' enables anti-flutter");
+  feed(dh, "1123");                 // consecutive duplicates collapsed
+  check(dh.command() == "123", "consecutive duplicate digits collapsed");
+  feed(dh, "B");                    // back-up repeats the previous digit
+  check(dh.command() == "1233", "'B' repeats the previous digit");
+}
+
+void test_anti_flutter_c_completes(void)
+{
+  cout << "test_anti_flutter_c_completes" << endl;
+  DtmfDigitHandler dh;
+  Recorder rec(dh);
+  feed(dh, "A12C");
+  check(rec.completions == 1, "'C' completes the command under anti-flutter");
+  check(rec.last_command == "12", "command was '12' at completion");
+}
+
+void test_force_command_complete(void)
+{
+  cout << "test_force_command_complete" << endl;
+  DtmfDigitHandler dh;
+  Recorder rec(dh);
+  feed(dh, "12");
+  dh.forceCommandComplete();
+  check(rec.completions == 1 && rec.last_command == "12",
+        "forceCommandComplete emits with the buffered command");
+  dh.forceCommandComplete();
+  check(rec.completions == 1, "force on empty buffer emits nothing");
+}
+
+void test_reset(void)
+{
+  cout << "test_reset" << endl;
+  DtmfDigitHandler dh;
+  feed(dh, "A12");
+  dh.reset();
+  check(dh.command() == "" && !dh.antiFlutterActive(),
+        "reset clears buffer and anti-flutter");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;   // needed so DtmfDigitHandler's Async::Timer constructs
+
+  test_basic_accumulation();
+  test_hash_completes_and_resets();
+  test_star_rules();
+  test_max_length();
+  test_d_resets_to_D();
+  test_h_inserts_hash();
+  test_anti_flutter_dedup();
+  test_anti_flutter_c_completes();
+  test_force_command_complete();
+  test_reset();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All DtmfDigitHandler tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " DtmfDigitHandler test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/svxlink/DtmfDigitHandlerTest.deps.cmake
+++ b/src/svxlink/svxlink/DtmfDigitHandlerTest.deps.cmake
@@ -1,0 +1,2 @@
+# DtmfDigitHandlerTest exercises DtmfDigitHandler directly, so compile it in.
+set(DtmfDigitHandlerTest_EXTRA_SRCS DtmfDigitHandler.cpp)

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -122,5 +122,10 @@ add_executable(SigLevDetTest SigLevDetTest.cpp)
 target_link_libraries(SigLevDetTest ${LIBNAME} asynccpp asyncaudio asynccore svxmisc)
 add_test(NAME SigLevDetTest COMMAND SigLevDetTest)
 
+# Pre-/de-emphasis filter tests (Emphasis.h is header-only)
+add_executable(EmphasisTest EmphasisTest.cpp)
+target_link_libraries(EmphasisTest asynccpp asyncaudio asynccore)
+add_test(NAME EmphasisTest COMMAND EmphasisTest)
+
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -103,5 +103,9 @@ add_test(NAME DtmfEncoderTest COMMAND DtmfEncoderTest)
 add_executable(GoertzelTest GoertzelTest.cpp)
 add_test(NAME GoertzelTest COMMAND GoertzelTest)
 
+# Modulation fromString/toString test (compile the small source directly).
+add_executable(ModulationTest ModulationTest.cpp Modulation.cpp)
+add_test(NAME ModulationTest COMMAND ModulationTest)
+
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -112,5 +112,15 @@ add_executable(TrxFactoryTest TrxFactoryTest.cpp)
 target_link_libraries(TrxFactoryTest ${LIBNAME} asynccpp asynccore asyncaudio svxmisc)
 add_test(NAME TrxFactoryTest COMMAND TrxFactoryTest)
 
+# Squelch detector tests (SquelchOpen, SquelchVox)
+add_executable(SquelchTest SquelchTest.cpp)
+target_link_libraries(SquelchTest ${LIBNAME} asynccpp asynccore asyncaudio svxmisc)
+add_test(NAME SquelchTest COMMAND SquelchTest)
+
+# Signal level detector tests (SigLevDetConst)
+add_executable(SigLevDetTest SigLevDetTest.cpp)
+target_link_libraries(SigLevDetTest ${LIBNAME} asynccpp asyncaudio asynccore svxmisc)
+add_test(NAME SigLevDetTest COMMAND SigLevDetTest)
+
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -92,6 +92,12 @@ target_link_libraries(${LIBNAME} ${LIBS})
 
 add_executable(DtmfDecoderTest DtmfDecoderTest.cpp)
 target_link_libraries(DtmfDecoderTest ${LIBNAME} asynccore asyncaudio)
+add_test(NAME DtmfDecoderTest COMMAND DtmfDecoderTest)
+
+# DtmfEncoder -> DtmfDecoder clean round-trip test
+add_executable(DtmfEncoderTest DtmfEncoderTest.cpp)
+target_link_libraries(DtmfEncoderTest ${LIBNAME} asynccore asyncaudio)
+add_test(NAME DtmfEncoderTest COMMAND DtmfEncoderTest)
 
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -127,5 +127,10 @@ add_executable(EmphasisTest EmphasisTest.cpp)
 target_link_libraries(EmphasisTest asynccpp asyncaudio asynccore)
 add_test(NAME EmphasisTest COMMAND EmphasisTest)
 
+# Resampler tests (AudioInterpolator / AudioDecimator with project coeffs)
+add_executable(ResamplerTest ResamplerTest.cpp)
+target_link_libraries(ResamplerTest asynccpp asyncaudio asynccore)
+add_test(NAME ResamplerTest COMMAND ResamplerTest)
+
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -90,47 +90,13 @@ set(LIBS ${LIBS} ${JSONCPP_LIBRARIES})
 add_library(${LIBNAME} STATIC ${LIBSRC} ${VERSION_DEPENDS})
 target_link_libraries(${LIBNAME} ${LIBS})
 
-add_executable(DtmfDecoderTest DtmfDecoderTest.cpp)
-target_link_libraries(DtmfDecoderTest ${LIBNAME} asynccore asyncaudio)
-add_test(NAME DtmfDecoderTest COMMAND DtmfDecoderTest)
-
-# DtmfEncoder -> DtmfDecoder clean round-trip test
-add_executable(DtmfEncoderTest DtmfEncoderTest.cpp)
-target_link_libraries(DtmfEncoderTest ${LIBNAME} asynccore asyncaudio)
-add_test(NAME DtmfEncoderTest COMMAND DtmfEncoderTest)
-
-# Goertzel is header-only; the test needs no libraries.
-add_executable(GoertzelTest GoertzelTest.cpp)
-add_test(NAME GoertzelTest COMMAND GoertzelTest)
-
-# Modulation fromString/toString test (compile the small source directly).
-add_executable(ModulationTest ModulationTest.cpp Modulation.cpp)
-add_test(NAME ModulationTest COMMAND ModulationTest)
-
-# Rx/Tx factory creation tests
-add_executable(TrxFactoryTest TrxFactoryTest.cpp)
-target_link_libraries(TrxFactoryTest ${LIBNAME} asynccpp asynccore asyncaudio svxmisc)
-add_test(NAME TrxFactoryTest COMMAND TrxFactoryTest)
-
-# Squelch detector tests (SquelchOpen, SquelchVox)
-add_executable(SquelchTest SquelchTest.cpp)
-target_link_libraries(SquelchTest ${LIBNAME} asynccpp asynccore asyncaudio svxmisc)
-add_test(NAME SquelchTest COMMAND SquelchTest)
-
-# Signal level detector tests (SigLevDetConst)
-add_executable(SigLevDetTest SigLevDetTest.cpp)
-target_link_libraries(SigLevDetTest ${LIBNAME} asynccpp asyncaudio asynccore svxmisc)
-add_test(NAME SigLevDetTest COMMAND SigLevDetTest)
-
-# Pre-/de-emphasis filter tests (Emphasis.h is header-only)
-add_executable(EmphasisTest EmphasisTest.cpp)
-target_link_libraries(EmphasisTest asynccpp asyncaudio asynccore)
-add_test(NAME EmphasisTest COMMAND EmphasisTest)
-
-# Resampler tests (AudioInterpolator / AudioDecimator with project coeffs)
-add_executable(ResamplerTest ResamplerTest.cpp)
-target_link_libraries(ResamplerTest asynccpp asyncaudio asynccore)
-add_test(NAME ResamplerTest COMMAND ResamplerTest)
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+# trx is a static library, so linking it into a test that does not reference
+# its objects is harmless (the linker only pulls archive members that resolve
+# an otherwise-unresolved symbol). Tests needing extra sources use a
+# <Name>.deps.cmake sidecar (e.g. ModulationTest compiles Modulation.cpp).
+svxlink_add_tests(LIBS ${LIBNAME} asynccpp asynccore asyncaudio svxmisc)
 
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -99,5 +99,9 @@ add_executable(DtmfEncoderTest DtmfEncoderTest.cpp)
 target_link_libraries(DtmfEncoderTest ${LIBNAME} asynccore asyncaudio)
 add_test(NAME DtmfEncoderTest COMMAND DtmfEncoderTest)
 
+# Goertzel is header-only; the test needs no libraries.
+add_executable(GoertzelTest GoertzelTest.cpp)
+add_test(NAME GoertzelTest COMMAND GoertzelTest)
+
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -107,5 +107,10 @@ add_test(NAME GoertzelTest COMMAND GoertzelTest)
 add_executable(ModulationTest ModulationTest.cpp Modulation.cpp)
 add_test(NAME ModulationTest COMMAND ModulationTest)
 
+# Rx/Tx factory creation tests
+add_executable(TrxFactoryTest TrxFactoryTest.cpp)
+target_link_libraries(TrxFactoryTest ${LIBNAME} asynccpp asynccore asyncaudio svxmisc)
+add_test(NAME TrxFactoryTest COMMAND TrxFactoryTest)
+
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/DtmfEncoderTest.cpp
+++ b/src/svxlink/trx/DtmfEncoderTest.cpp
@@ -1,0 +1,119 @@
+/**
+@file    DtmfEncoderTest.cpp
+@brief   Round-trip test: DtmfEncoder output decoded by DtmfDecoder.
+@author  Mark Rose
+@date    2026-06-06
+
+Generates a clean (noise-free) DTMF tone sequence for the whole digit alphabet
+with DtmfEncoder, feeds it straight into the INTERNAL DtmfDecoder, and asserts
+the decoded digits match what was sent. This validates the encoder (which has
+no test of its own) and the decoder on a clean signal. (DtmfDecoderTest covers
+the noisy/stress case.)
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include <AsyncConfig.h>
+
+#include "DtmfDecoder.h"
+#include "DtmfEncoder.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+string received;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+void on_digit(char ch, int /*duration*/)
+{
+  received += ch;
+}
+
+// Encode `digits` with a fresh encoder->decoder pipe and return the decoded
+// string.
+string round_trip(const string& digits)
+{
+  Config cfg;
+  cfg.setValue("Test", "DTMF_DEC_TYPE", string("INTERNAL"));
+
+  DtmfEncoder enc;
+  enc.setDigitDuration(80);
+  enc.setDigitSpacing(80);
+  enc.setDigitPower(-10);
+
+  DtmfDecoder* dec = DtmfDecoder::create(0, cfg, "Test");
+  if ((dec == 0) || !dec->initialize())
+  {
+    cout << "*** ERROR: could not create/initialize DTMF decoder" << endl;
+    return "";
+  }
+  dec->digitDeactivated.connect(sigc::ptr_fun(on_digit));
+  enc.registerSink(dec, true);
+
+  received.clear();
+  // A low-power leading digit settles the detector before the real sequence.
+  int p = enc.digitPower();
+  enc.setDigitPower(-100);
+  enc.send("0");
+  enc.setDigitPower(p);
+  enc.send(digits);
+  return received;
+}
+
+
+void test_full_alphabet_round_trip(void)
+{
+  cout << "test_full_alphabet_round_trip" << endl;
+  const string sent = "0123456789ABCD*#";
+  string got = round_trip(sent);
+  check(got == sent, "decoded matches sent (sent='" + sent + "' got='" + got + "')");
+}
+
+void test_repeated_digits(void)
+{
+  cout << "test_repeated_digits" << endl;
+  const string sent = "11227700";
+  string got = round_trip(sent);
+  check(got == sent, "repeated digits round-trip (sent='" + sent +
+        "' got='" + got + "')");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_full_alphabet_round_trip();
+  test_repeated_digits();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All DtmfEncoder round-trip tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " DtmfEncoder test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/trx/EmphasisTest.cpp
+++ b/src/svxlink/trx/EmphasisTest.cpp
@@ -1,0 +1,157 @@
+/**
+@file    EmphasisTest.cpp
+@brief   Unit tests for the pre-/de-emphasis audio filters.
+@author  Mark Rose
+@date    2026-06-06
+
+Pre-emphasis boosts higher frequencies; de-emphasis is its inverse. These tests
+verify that pre-emphasis applies more gain to a high tone than a low one, and
+that a pre-emphasis followed by de-emphasis approximately recovers the original
+mid-band signal level.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioSink.h>
+
+#include "Emphasis.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+const int RATE = INTERNAL_SAMPLE_RATE;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+class PushSource : public AudioSource
+{
+  public:
+    int push(const vector<float>& s) { return sinkWriteSamples(s.data(), s.size()); }
+    void resumeOutput(void) override {}
+    void allSamplesFlushed(void) override {}
+};
+
+class Capture : public AudioSink
+{
+  public:
+    int writeSamples(const float* s, int count) override
+    {
+      for (int i = 0; i < count; ++i) data.push_back(s[i]);
+      return count;
+    }
+    void flushSamples(void) override { sourceAllSamplesFlushed(); }
+    vector<float> data;
+};
+
+double rms_tail(const vector<float>& v)
+{
+  size_t start = v.size() / 2;
+  double sum = 0.0;
+  size_t n = 0;
+  for (size_t i = start; i < v.size(); ++i, ++n)
+  {
+    sum += static_cast<double>(v[i]) * v[i];
+  }
+  return n > 0 ? sqrt(sum / n) : 0.0;
+}
+
+vector<float> tone(float freq, int n, float amp = 0.2f)
+{
+  vector<float> v(n);
+  for (int i = 0; i < n; ++i)
+  {
+    v[i] = amp * sinf(2.0f * M_PI * freq * i / RATE);
+  }
+  return v;
+}
+
+
+// Pass a tone through one emphasis filter and return output RMS.
+template <typename Filter>
+double filtered_rms(float freq)
+{
+  PushSource src;
+  Filter filt;
+  Capture cap;
+  src.registerSink(&filt);
+  filt.registerSink(&cap);
+  src.push(tone(freq, 4800));
+  return rms_tail(cap.data);
+}
+
+
+void test_preemphasis_boosts_high(void)
+{
+  cout << "test_preemphasis_boosts_high" << endl;
+  double low = filtered_rms<PreemphasisFilter>(600.0f);
+  double high = filtered_rms<PreemphasisFilter>(2500.0f);
+  check(high > low * 1.5,
+        "pre-emphasis boosts 2500 Hz more than 600 Hz (low=" +
+        to_string(low) + " high=" + to_string(high) + ")");
+}
+
+void test_pre_then_de_recovers(void)
+{
+  cout << "test_pre_then_de_recovers" << endl;
+  const float freq = 1000.0f;
+  PushSource src;
+  PreemphasisFilter pre;
+  DeemphasisFilter de;
+  Capture cap;
+  src.registerSink(&pre);
+  pre.registerSink(&de);
+  de.registerSink(&cap);
+
+  vector<float> in = tone(freq, 4800);
+  src.push(in);
+  double in_rms = rms_tail(in);
+  double out_rms = rms_tail(cap.data);
+  double ratio = out_rms / in_rms;
+  check(ratio > 0.5 && ratio < 2.0,
+        "pre+de recovers mid-band level within ~6 dB (ratio " +
+        to_string(ratio) + ")");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+  test_preemphasis_boosts_high();
+  test_pre_then_de_recovers();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All Emphasis tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " Emphasis test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/trx/GoertzelTest.cpp
+++ b/src/svxlink/trx/GoertzelTest.cpp
@@ -1,0 +1,145 @@
+/**
+@file    GoertzelTest.cpp
+@brief   Unit tests for the Goertzel single-bin DFT detector.
+@author  Mark Rose
+@date    2026-06-06
+
+Goertzel computes the DFT for a single frequency bin. These tests feed known
+sine waves through it and verify the documented relationships: the amplitude of
+an on-bin tone can be recovered as A = 2*sqrt(magnitudeSquared)/block_len, an
+off-bin tone produces near-zero magnitude, and reset() clears the state.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include "Goertzel.h"
+
+using namespace std;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+const unsigned RATE = 8000;
+const unsigned N = 80;            // bin width = 100 Hz; 1000 Hz is an exact bin
+
+// Feed `n` samples of an amplitude-A sine at `freq` into a detector tuned to
+// `det_freq`, and return the recovered amplitude (A = 2*sqrt(mag^2)/n).
+float recovered_amplitude(float det_freq, float freq, float amp, unsigned n)
+{
+  Goertzel g(det_freq, RATE);
+  g.reset();
+  for (unsigned i = 0; i < n; ++i)
+  {
+    g.calc(amp * sinf(2.0f * M_PI * freq * i / RATE));
+  }
+  return 2.0f * sqrtf(g.magnitudeSquared()) / n;
+}
+
+
+void test_on_bin_amplitude_recovery(void)
+{
+  cout << "test_on_bin_amplitude_recovery" << endl;
+  float a = recovered_amplitude(1000.0f, 1000.0f, 0.5f, N);
+  check(fabs(a - 0.5f) < 0.02f,
+        "recovered amplitude ~0.5 for on-bin 1000 Hz tone (got "
+        + to_string(a) + ")");
+
+  float a2 = recovered_amplitude(1000.0f, 1000.0f, 0.25f, N);
+  check(fabs(a2 - 0.25f) < 0.02f,
+        "recovered amplitude ~0.25 (got " + to_string(a2) + ")");
+}
+
+void test_off_bin_rejected(void)
+{
+  cout << "test_off_bin_rejected" << endl;
+  // Detector at 1000 Hz, tone at 1500 Hz (another exact bin) -> near zero.
+  float a = recovered_amplitude(1000.0f, 1500.0f, 0.5f, N);
+  check(a < 0.02f, "off-bin 1500 Hz tone rejected (got " + to_string(a) + ")");
+}
+
+void test_zero_input(void)
+{
+  cout << "test_zero_input" << endl;
+  Goertzel g(1000.0f, RATE);
+  g.reset();
+  for (unsigned i = 0; i < N; ++i)
+  {
+    g.calc(0.0f);
+  }
+  check(g.magnitudeSquared() < 1e-6f, "zero input -> ~zero magnitude");
+}
+
+void test_relative_power_db(void)
+{
+  cout << "test_relative_power_db" << endl;
+  // Halving the amplitude should reduce power by ~6 dB.
+  Goertzel g1(1000.0f, RATE), g2(1000.0f, RATE);
+  g1.reset();
+  g2.reset();
+  for (unsigned i = 0; i < N; ++i)
+  {
+    float s = sinf(2.0f * M_PI * 1000.0f * i / RATE);
+    g1.calc(1.0f * s);
+    g2.calc(0.5f * s);
+  }
+  float diff_db = 10.0f * log10f(g2.magnitudeSquared() / g1.magnitudeSquared());
+  check(fabs(diff_db - (-6.02f)) < 0.5f,
+        "half amplitude -> ~-6 dB (got " + to_string(diff_db) + ")");
+}
+
+void test_reset_clears(void)
+{
+  cout << "test_reset_clears" << endl;
+  Goertzel g(1000.0f, RATE);
+  g.reset();
+  for (unsigned i = 0; i < N; ++i)
+  {
+    g.calc(sinf(2.0f * M_PI * 1000.0f * i / RATE));
+  }
+  check(g.magnitudeSquared() > 1.0f, "magnitude non-zero after a tone block");
+  g.reset();
+  check(g.magnitudeSquared() < 1e-6f, "magnitude ~zero after reset()");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_on_bin_amplitude_recovery();
+  test_off_bin_rejected();
+  test_zero_input();
+  test_relative_power_db();
+  test_reset_clears();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All Goertzel tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " Goertzel test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/trx/ModulationTest.cpp
+++ b/src/svxlink/trx/ModulationTest.cpp
@@ -1,0 +1,109 @@
+/**
+@file    ModulationTest.cpp
+@brief   Unit tests for Modulation::fromString / toString.
+@author  Mark Rose
+@date    2026-06-06
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include "Modulation.h"
+
+using namespace std;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+const Modulation::Type ALL[] = {
+  Modulation::MOD_FM, Modulation::MOD_NBFM, Modulation::MOD_WBFM,
+  Modulation::MOD_AM, Modulation::MOD_NBAM, Modulation::MOD_USB,
+  Modulation::MOD_LSB, Modulation::MOD_CW, Modulation::MOD_WBCW
+};
+
+
+void test_known_strings(void)
+{
+  cout << "test_known_strings" << endl;
+  check(Modulation::fromString("FM") == Modulation::MOD_FM, "FM");
+  check(Modulation::fromString("NBFM") == Modulation::MOD_NBFM, "NBFM");
+  check(Modulation::fromString("WBFM") == Modulation::MOD_WBFM, "WBFM");
+  check(Modulation::fromString("AM") == Modulation::MOD_AM, "AM");
+  check(Modulation::fromString("USB") == Modulation::MOD_USB, "USB");
+  check(Modulation::fromString("LSB") == Modulation::MOD_LSB, "LSB");
+  check(Modulation::fromString("CW") == Modulation::MOD_CW, "CW");
+}
+
+void test_unknown_string(void)
+{
+  cout << "test_unknown_string" << endl;
+  check(Modulation::fromString("BOGUS") == Modulation::MOD_UNKNOWN,
+        "unknown string -> MOD_UNKNOWN");
+  check(Modulation::fromString("") == Modulation::MOD_UNKNOWN,
+        "empty string -> MOD_UNKNOWN");
+  check(Modulation::fromString("fm") == Modulation::MOD_UNKNOWN,
+        "lowercase is not matched (case sensitive)");
+}
+
+void test_to_string(void)
+{
+  cout << "test_to_string" << endl;
+  check(string(Modulation::toString(Modulation::MOD_FM)) == "FM", "MOD_FM");
+  check(string(Modulation::toString(Modulation::MOD_WBCW)) == "WBCW", "MOD_WBCW");
+  check(string(Modulation::toString(Modulation::MOD_UNKNOWN)) == "UNKNOWN",
+        "MOD_UNKNOWN -> UNKNOWN");
+}
+
+void test_round_trip(void)
+{
+  cout << "test_round_trip" << endl;
+  bool all_ok = true;
+  for (Modulation::Type m : ALL)
+  {
+    if (Modulation::fromString(Modulation::toString(m)) != m)
+    {
+      all_ok = false;
+    }
+  }
+  check(all_ok, "fromString(toString(m)) == m for every modulation type");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_known_strings();
+  test_unknown_string();
+  test_to_string();
+  test_round_trip();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All Modulation tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " Modulation test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/trx/ModulationTest.deps.cmake
+++ b/src/svxlink/trx/ModulationTest.deps.cmake
@@ -1,0 +1,5 @@
+# ModulationTest compiles the small Modulation.cpp source directly (it tests
+# Modulation::fromString/toString). The trx static library also contains
+# Modulation.o, but since this object resolves the symbols directly the
+# archive member is not pulled in, so there is no duplicate-symbol conflict.
+set(ModulationTest_EXTRA_SRCS Modulation.cpp)

--- a/src/svxlink/trx/ResamplerTest.cpp
+++ b/src/svxlink/trx/ResamplerTest.cpp
@@ -1,0 +1,182 @@
+/**
+@file    ResamplerTest.cpp
+@brief   Unit tests for AudioInterpolator and AudioDecimator.
+@author  Mark Rose
+@date    2026-06-06
+
+Uses the project's 16k<->8k multirate filter coefficients to upsample (x2) and
+downsample (/2) a test tone, checking the output sample counts scale with the
+rate-change factor and that an interpolate->decimate round-trip recovers a tone
+that is comfortably below the Nyquist limit.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncAudioSource.h>
+#include <AsyncAudioSink.h>
+#include <AsyncAudioInterpolator.h>
+#include <AsyncAudioDecimator.h>
+
+#include "multirate_filter_coeff.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+class PushSource : public AudioSource
+{
+  public:
+    // Push all samples, re-offering the remainder until consumed (processors
+    // such as the resamplers accept input in limited-size chunks).
+    int push(const vector<float>& s)
+    {
+      size_t off = 0;
+      while (off < s.size())
+      {
+        int wrote = sinkWriteSamples(s.data() + off, s.size() - off);
+        if (wrote <= 0) break;
+        off += wrote;
+      }
+      return off;
+    }
+    void resumeOutput(void) override {}
+    void allSamplesFlushed(void) override {}
+};
+
+class Capture : public AudioSink
+{
+  public:
+    int writeSamples(const float* s, int count) override
+    {
+      for (int i = 0; i < count; ++i) data.push_back(s[i]);
+      return count;
+    }
+    void flushSamples(void) override { sourceAllSamplesFlushed(); }
+    vector<float> data;
+};
+
+double rms_tail(const vector<float>& v)
+{
+  if (v.size() < 4) return 0.0;
+  size_t start = v.size() / 4;       // skip filter group-delay transient
+  size_t end = v.size() - v.size() / 4;
+  double sum = 0.0;
+  size_t n = 0;
+  for (size_t i = start; i < end; ++i, ++n)
+  {
+    sum += static_cast<double>(v[i]) * v[i];
+  }
+  return n > 0 ? sqrt(sum / n) : 0.0;
+}
+
+// Tone at `freq` Hz sampled at `rate`, amplitude 0.3.
+vector<float> tone(float freq, int rate, int n)
+{
+  vector<float> v(n);
+  for (int i = 0; i < n; ++i)
+  {
+    v[i] = 0.3f * sinf(2.0f * M_PI * freq * i / rate);
+  }
+  return v;
+}
+
+
+void test_interpolator_doubles_rate(void)
+{
+  cout << "test_interpolator_doubles_rate" << endl;
+  PushSource src;
+  AudioInterpolator interp(2, coeff_16_8, coeff_16_8_taps);
+  Capture cap;
+  src.registerSink(&interp);
+  interp.registerSink(&cap);
+
+  const int n = 4800;
+  src.push(tone(1000.0f, 8000, n));
+  check(cap.data.size() == static_cast<size_t>(2 * n),
+        "interpolator x2 produces twice the samples (" +
+        to_string(cap.data.size()) + ")");
+  check(rms_tail(cap.data) > 0.05, "tone survives interpolation");
+}
+
+void test_decimator_halves_rate(void)
+{
+  cout << "test_decimator_halves_rate" << endl;
+  PushSource src;
+  AudioDecimator decim(2, coeff_16_8, coeff_16_8_taps);
+  Capture cap;
+  src.registerSink(&decim);
+  decim.registerSink(&cap);
+
+  const int n = 4800;
+  src.push(tone(1000.0f, 16000, n));   // 1000 Hz, well below 4 kHz Nyquist
+  check(cap.data.size() == static_cast<size_t>(n / 2),
+        "decimator /2 produces half the samples (" +
+        to_string(cap.data.size()) + ")");
+  check(rms_tail(cap.data) > 0.05, "tone survives decimation");
+}
+
+void test_round_trip_recovers_level(void)
+{
+  cout << "test_round_trip_recovers_level" << endl;
+  PushSource src;
+  AudioInterpolator interp(2, coeff_16_8, coeff_16_8_taps);
+  AudioDecimator decim(2, coeff_16_8, coeff_16_8_taps);
+  Capture cap;
+  src.registerSink(&interp);
+  interp.registerSink(&decim);
+  decim.registerSink(&cap);
+
+  const int n = 8000;
+  vector<float> in = tone(1000.0f, 8000, n);
+  src.push(in);
+  double ratio = rms_tail(cap.data) / rms_tail(in);
+  check(ratio > 0.5 && ratio < 2.0,
+        "interpolate->decimate recovers the level within ~6 dB (ratio " +
+        to_string(ratio) + ")");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+  test_interpolator_doubles_rate();
+  test_decimator_halves_rate();
+  test_round_trip_recovers_level();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All resampler tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " resampler test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/trx/SigLevDetTest.cpp
+++ b/src/svxlink/trx/SigLevDetTest.cpp
@@ -1,0 +1,80 @@
+/**
+@file    SigLevDetTest.cpp
+@brief   Unit tests for signal level detectors (SigLevDetConst).
+@author  Mark Rose
+@date    2026-06-06
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <AsyncConfig.h>
+
+#include "SigLevDetConst.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+
+void test_const_configured(void)
+{
+  cout << "test_const_configured" << endl;
+  Config cfg;
+  cfg.setValue("Rx", "SIGLEV_CONST", string("42"));
+  SigLevDetConst det;
+  check(det.initialize(cfg, "Rx", 16000), "initializes with SIGLEV_CONST");
+  check(fabs(det.lastSiglev() - 42.0f) < 0.001f, "lastSiglev returns 42");
+  check(fabs(det.siglevIntegrated() - 42.0f) < 0.001f,
+        "siglevIntegrated returns 42");
+}
+
+void test_const_default_zero(void)
+{
+  cout << "test_const_default_zero" << endl;
+  Config cfg;                       // SIGLEV_CONST not set
+  SigLevDetConst det;
+  check(det.initialize(cfg, "Rx", 16000), "initializes without SIGLEV_CONST");
+  check(fabs(det.lastSiglev()) < 0.001f, "default level is 0");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_const_configured();
+  test_const_default_zero();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All SigLevDet tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " SigLevDet test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/trx/SquelchTest.cpp
+++ b/src/svxlink/trx/SquelchTest.cpp
@@ -1,0 +1,162 @@
+/**
+@file    SquelchTest.cpp
+@brief   Unit tests for squelch detectors (SquelchOpen, SquelchVox).
+@author  Mark Rose
+@date    2026-06-06
+
+Feeds audio samples through squelch detectors and checks the open/close state.
+SquelchOpen should always report open; SquelchVox should open when the audio
+level rises above VOX_THRESH and close again on silence.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncConfig.h>
+
+#include "SquelchOpen.h"
+#include "SquelchVox.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+void feed_tone(Squelch& sql, float amp, int n)
+{
+  vector<float> buf(n);
+  for (int i = 0; i < n; ++i)
+  {
+    buf[i] = amp * sinf(2.0f * M_PI * 1000.0f * i / 16000.0f);
+  }
+  sql.writeSamples(buf.data(), n);
+}
+
+void feed_silence(Squelch& sql, int n)
+{
+  vector<float> buf(n, 0.0f);
+  sql.writeSamples(buf.data(), n);
+}
+
+
+void test_squelch_open_always_open(void)
+{
+  cout << "test_squelch_open_always_open" << endl;
+  Config cfg;
+  SquelchOpen sql;
+  check(sql.initialize(cfg, "Rx"), "SquelchOpen initializes");
+  feed_silence(sql, 160);
+  check(sql.isOpen(), "SquelchOpen reports open even on silence");
+}
+
+void test_vox_opens_and_closes(void)
+{
+  cout << "test_vox_opens_and_closes" << endl;
+  Config cfg;
+  cfg.setValue("Rx", "VOX_FILTER_DEPTH", string("10"));
+  cfg.setValue("Rx", "VOX_THRESH", string("300"));
+  cfg.setValue("Rx", "SQL_HANGTIME", string("0"));
+  cfg.setValue("Rx", "SQL_START_DELAY", string("0"));
+  cfg.setValue("Rx", "SQL_DELAY", string("0"));
+  SquelchVox sql;
+  check(sql.initialize(cfg, "Rx"), "SquelchVox initializes");
+  check(!sql.isOpen(), "closed before any audio");
+
+  feed_tone(sql, 0.3f, 480);              // well above threshold
+  check(sql.isOpen(), "opens on a tone above VOX_THRESH");
+
+  feed_silence(sql, 480);
+  check(!sql.isOpen(), "closes again on silence");
+}
+
+void test_vox_ignores_quiet_signal(void)
+{
+  cout << "test_vox_ignores_quiet_signal" << endl;
+  Config cfg;
+  cfg.setValue("Rx", "VOX_FILTER_DEPTH", string("10"));
+  cfg.setValue("Rx", "VOX_THRESH", string("3000"));   // high threshold
+  cfg.setValue("Rx", "SQL_HANGTIME", string("0"));
+  cfg.setValue("Rx", "SQL_START_DELAY", string("0"));
+  cfg.setValue("Rx", "SQL_DELAY", string("0"));
+  SquelchVox sql;
+  sql.initialize(cfg, "Rx");
+  feed_tone(sql, 0.05f, 480);             // weak signal, below threshold
+  check(!sql.isOpen(), "stays closed for a signal below VOX_THRESH");
+}
+
+// Records squelchOpen signal transitions.
+class SqlRecorder : public sigc::trackable
+{
+  public:
+    void onSquelchOpen(bool is_open)
+    {
+      if (is_open) ++opens; else ++closes;
+    }
+    int opens = 0;
+    int closes = 0;
+};
+
+void test_vox_emits_signal(void)
+{
+  cout << "test_vox_emits_signal" << endl;
+  Config cfg;
+  cfg.setValue("Rx", "VOX_FILTER_DEPTH", string("10"));
+  cfg.setValue("Rx", "VOX_THRESH", string("300"));
+  cfg.setValue("Rx", "SQL_HANGTIME", string("0"));
+  cfg.setValue("Rx", "SQL_START_DELAY", string("0"));
+  cfg.setValue("Rx", "SQL_DELAY", string("0"));
+  SquelchVox sql;
+  sql.initialize(cfg, "Rx");
+  SqlRecorder rec;
+  sql.squelchOpen.connect(sigc::mem_fun(rec, &SqlRecorder::onSquelchOpen));
+  feed_tone(sql, 0.3f, 480);
+  feed_silence(sql, 480);
+  check(rec.opens == 1 && rec.closes == 1,
+        "squelchOpen signal fired once open, once closed");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;   // squelch base may construct an Async::Timer
+
+  test_squelch_open_always_open();
+  test_vox_opens_and_closes();
+  test_vox_ignores_quiet_signal();
+  test_vox_emits_signal();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All Squelch tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " Squelch test check(s) FAILED" << endl;
+  return 1;
+}

--- a/src/svxlink/trx/TrxFactoryTest.cpp
+++ b/src/svxlink/trx/TrxFactoryTest.cpp
@@ -1,0 +1,107 @@
+/**
+@file    TrxFactoryTest.cpp
+@brief   Unit tests for RxFactory/TxFactory named creation.
+@author  Mark Rose
+@date    2026-06-06
+
+Checks that createNamedRx/createNamedTx honour the TYPE config variable: a
+"NONE" receiver/transmitter and an explicit Dummy type create an object, a
+missing TYPE fails, and an unknown TYPE fails.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include <AsyncConfig.h>
+
+#include "Rx.h"
+#include "Tx.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+
+void test_rx_factory(void)
+{
+  cout << "test_rx_factory" << endl;
+  Config cfg;
+
+  Rx* none = RxFactory::createNamedRx(cfg, "NONE");
+  check(none != 0, "RX 'NONE' creates a (dummy) receiver");
+  delete none;
+
+  cfg.setValue("Rx1", "TYPE", string("Dummy"));
+  Rx* dummy = RxFactory::createNamedRx(cfg, "Rx1");
+  check(dummy != 0, "RX TYPE=Dummy creates a receiver");
+  delete dummy;
+
+  Rx* no_type = RxFactory::createNamedRx(cfg, "RxNoType");
+  check(no_type == 0, "RX with no TYPE set returns null");
+
+  cfg.setValue("RxBogus", "TYPE", string("NoSuchType"));
+  Rx* bogus = RxFactory::createNamedRx(cfg, "RxBogus");
+  check(bogus == 0, "RX with unknown TYPE returns null");
+}
+
+void test_tx_factory(void)
+{
+  cout << "test_tx_factory" << endl;
+  Config cfg;
+
+  Tx* none = TxFactory::createNamedTx(cfg, "NONE");
+  check(none != 0, "TX 'NONE' creates a (dummy) transmitter");
+  delete none;
+
+  cfg.setValue("Tx1", "TYPE", string("Dummy"));
+  Tx* dummy = TxFactory::createNamedTx(cfg, "Tx1");
+  check(dummy != 0, "TX TYPE=Dummy creates a transmitter");
+  delete dummy;
+
+  Tx* no_type = TxFactory::createNamedTx(cfg, "TxNoType");
+  check(no_type == 0, "TX with no TYPE set returns null");
+
+  cfg.setValue("TxBogus", "TYPE", string("NoSuchType"));
+  Tx* bogus = TxFactory::createNamedTx(cfg, "TxBogus");
+  check(bogus == 0, "TX with unknown TYPE returns null");
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  test_rx_factory();
+  test_tx_factory();
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All Trx factory tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " Trx factory test check(s) FAILED" << endl;
+  return 1;
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,49 @@
+# SvxLink tests
+
+Unit/component tests for SvxLink and the bundled Async framework. They are
+registered with CTest and require no special hardware, network, or sound card.
+
+## Running
+
+```sh
+cmake -S src -B build
+cmake --build build -j"$(nproc)"
+ctest --test-dir build --output-on-failure
+```
+
+The TCL smoke test additionally needs `tclsh` and `python3` (both standard).
+
+## What is covered
+
+| CTest name | Area | Covers |
+| --- | --- | --- |
+| `CmdParserTest` | svxlink | command match/dispatch (prefix, exact, sub-command) |
+| `DtmfDigitHandlerTest` | svxlink | DTMF command accumulation, anti-flutter, specials |
+| `tcl_event_scripts_load` | svxlink | every TCL event script loads under tclsh |
+| `CommonTest` | misc | common.h: setValueFromString, splitStr, SepPair |
+| `ConfigTest` | async/core | Async::Config get/set, typed coercion, listSection |
+| `AsyncMsgTest` | async/core | Async::Msg pack/unpack: scalars, string, vector, map |
+| `StateMachineTest` | async/core | Async::StateMachine transitions + hierarchical dispatch |
+| `AudioPipeTest` | async/audio | AudioAmp gain, AudioValve open/close, AudioSplitter fan-out |
+| `AudioClipperTest` | async/audio | AudioClipper amplitude clamping |
+| `AudioDelayLineTest` | async/audio | AudioDelayLine delays audio by the configured time |
+| `AudioReaderTest` | async/audio | AudioReader synchronous pull reads |
+| `AudioFilterTest` | async/audio | AudioFilter lowpass/highpass/bandpass response |
+| `AudioFsfTest` | async/audio | AudioFsf frequency sampling filter passband/stopband |
+| `DtmfDecoderTest` | trx | DTMF decode (pre-existing) |
+| `DtmfEncoderTest` | trx | DtmfEncoder -> DtmfDecoder clean round-trip |
+| `GoertzelTest` | trx | single-bin DFT: amplitude recovery, off-bin rejection |
+| `ModulationTest` | trx | modulation fromString/toString round-trip |
+| `TrxFactoryTest` | trx | RxFactory/TxFactory TYPE-driven creation + error cases |
+| `SquelchTest` | trx | SquelchOpen always-open; SquelchVox thresholds |
+| `SigLevDetTest` | trx | SigLevDetConst returns the configured constant level |
+| `EmphasisTest` | trx | pre-emphasis boosts highs; pre+de recovers the signal |
+| `ResamplerTest` | trx | AudioInterpolator x2 / AudioDecimator /2 + round-trip |
+| `ReflectorMsgTest` | reflector | protocol message pack/unpack round-trip |
+
+## Conventions
+
+Each C++ test is a small standalone program that prints `ok`/`FAIL` lines and
+exits 0 on success, 1 on failure — no test framework dependency. Audio-pipe
+tests drive samples through a component and measure the captured output (RMS,
+or per-tone level via a Goertzel filter) to assert frequency/gain behaviour.

--- a/tests/test_tcl_loads.py
+++ b/tests/test_tcl_loads.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Smoke test: every TCL event script loads without error.
+
+Builds the installed events.tcl + events.d/ layout (as symlinks to the
+repository source) and sources it under plain `tclsh` with the C++-provided
+commands stubbed out, for each logic type. A TCL syntax error or undefined
+proc in any sourced script (globals.tcl, Logic.tcl, <Type>LogicType.tcl, ...)
+makes tclsh exit non-zero and fails the test.
+
+This catches breakage in the event scripts without launching svxlink.
+
+Run:  python3 tests/test_tcl_loads.py     (exit 0 = pass)
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+TCL_SRC = os.path.join(REPO, "src", "svxlink", "svxlink")
+
+# Stub the commands that svxlink's C++ side registers in the interpreter, so
+# the scripts can be sourced under a plain tclsh.
+STUBS = r"""
+foreach _c {playFile playSilence playTone playDtmf recordStart recordStop \
+            deactivateModule publishStateEvent injectDtmf setConfigValue \
+            setAnnounceOnAllLogics} {
+  proc $_c {args} {}
+}
+proc getConfigValue {section tag default} { return $default }
+"""
+
+LOGIC_TYPES = [("SimplexLogic", "Simplex"), ("RepeaterLogic", "Repeater")]
+
+failures = 0
+
+
+def check(cond, msg):
+    global failures
+    print(("  ok   " if cond else "  FAIL ") + msg)
+    if not cond:
+        failures += 1
+
+
+def _build_tree(dest):
+    share = os.path.join(dest, "share")
+    events_d = os.path.join(share, "events.d")
+    os.makedirs(events_d)
+    os.symlink(os.path.join(TCL_SRC, "events.tcl"),
+               os.path.join(share, "events.tcl"))
+    for fn in os.listdir(TCL_SRC):
+        if fn.endswith(".tcl") and fn != "events.tcl":
+            os.symlink(os.path.join(TCL_SRC, fn), os.path.join(events_d, fn))
+    os.makedirs(os.path.join(share, "sounds", "en_US"))
+    return os.path.join(share, "events.tcl")
+
+
+def load_logic(logic_name, logic_type):
+    tmp = tempfile.mkdtemp(prefix="tcltest_")
+    try:
+        events_tcl = _build_tree(tmp)
+        wrapper = os.path.join(tmp, "run.tcl")
+        with open(wrapper, "w") as f:
+            f.write(STUBS)
+            f.write(f'set logic_name "{logic_name}"\n')
+            f.write(f'set logic_type "{logic_type}"\n')
+            # Variables svxlink's C++ side normally sets in the interpreter.
+            f.write('set loaded_modules ""\n')
+            f.write('set active_module ""\n')
+            f.write('set mycall "TEST"\n')
+            f.write('set report_ctcss 0.0\n')
+            f.write(f'source "{events_tcl}"\n')
+            f.write('exit 0\n')
+        return subprocess.run(["tclsh", wrapper], capture_output=True,
+                              text=True, timeout=30)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    for logic_name, logic_type in LOGIC_TYPES:
+        r = load_logic(logic_name, logic_type)
+        ok = r.returncode == 0
+        check(ok, f"{logic_type} event scripts load cleanly")
+        if not ok:
+            print("    --- stderr/stdout ---")
+            for line in (r.stderr + r.stdout).splitlines()[-15:]:
+                print("    " + line)
+    print()
+    print("PASS" if failures == 0 else f"{failures} check(s) FAILED")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

SvxLink currently has no automated test suite — only a few standalone manual
harnesses (`DtmfDecoderTest`, `event_test.tcl`, etc.) that print output for a
human to eyeball. This PR adds **22 self-validating test programs** plus a TCL
smoke test, wires them into **CTest** (`enable_testing()`), and registers the
existing `DtmfDecoderTest` too, so the whole suite runs with one command:

```sh
cmake -S src -B build
cmake --build build -j"$(nproc)"
ctest --test-dir build --output-on-failure      # 23 tests, all pass
```

No new dependencies: the C++ tests are small standalone programs (print
`ok`/`FAIL`, exit 0/1 — no test framework), and the one Python test uses only
the standard library plus `tclsh`.

## What's covered

**Async framework** (`src/async/`)
- core: `ConfigTest`, `AsyncMsgTest` (pack/unpack), `StateMachineTest`
- audio: `AudioPipeTest` (amp/valve/splitter), `AudioFilterTest`, `AudioFsfTest`, `AudioClipperTest`, `AudioDelayLineTest`, `AudioReaderTest`

**TRX / DSP** (`src/svxlink/trx/`)
- `GoertzelTest`, `ModulationTest`, `TrxFactoryTest`, `SquelchTest`, `SigLevDetTest`, `EmphasisTest`, `ResamplerTest`, `DtmfEncoderTest` (encoder→decoder round-trip)

**SvxLink core / misc / reflector**
- `CmdParserTest`, `DtmfDigitHandlerTest`, `CommonTest`, `ReflectorMsgTest`
- `tcl_event_scripts_load` — sources every event script under `tclsh` (with the C++ commands stubbed) to catch TCL syntax / undefined-proc errors without launching svxlink

Audio-pipe tests drive samples through a component and measure the captured
output (RMS, or per-tone level via a Goertzel filter) to assert gain/frequency
behaviour deterministically.

## Notes

- **Purely additive** — no existing source files are modified; the only change
  outside new files is uncommenting `enable_testing()` plus per-directory
  `add_test()` / `add_executable()` calls.
- One commit per test or closely-related group, for reviewability.
- `tests/README.md` documents the suite and how to run it.
