### PR TITLE
Async: clear UDP send-buffer-full state after a hard send error

### DIFF
--- a/src/async/core/AsyncUdpSocket.cpp
+++ b/src/async/core/AsyncUdpSocket.cpp
@@ -380,17 +380,19 @@ void UdpSocket::sendRest(FdWatch *watch)
     {
       return;
     }
-    else
-    {
-      perror("sendto in UdpSocket::sendRest");
-    }
+    perror("sendto in UdpSocket::sendRest");
   }
   else
   {
     assert(ret == send_buf->len);
-    sendBufferFull(false);
   }
-  
+
+    // The deferred send is now finished, whether the datagram was sent or
+    // dropped due to a hard error. Clear the buffer-full condition that was
+    // signalled in write() in both cases. Previously it was only cleared on
+    // success, so a non-EAGAIN send error left the sender stalled.
+  sendBufferFull(false);
+
   delete send_buf;
   send_buf = 0;
   wr_watch->setEnabled(false);


### PR DESCRIPTION
UdpSocket::sendRest() only emitted sendBufferFull(false) on a successful
deferred send. If the retried sendto() failed with a non-EAGAIN error, the
packet was dropped and the write watch disabled without ever clearing the
buffer-full condition that write() had signalled, so the upper layer could
believe the buffer was still full and stop sending.

Emit sendBufferFull(false) whenever the deferred send completes (success or
hard error); only the EAGAIN retry path returns early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)