### PR TITLE
Async: avoid undefined behavior in Config::trimSpaces on non-ASCII input

### DIFF
--- a/src/async/core/AsyncConfig.cpp
+++ b/src/async/core/AsyncConfig.cpp
@@ -404,13 +404,14 @@ bool Config::parseCfgFile(FILE *file)
 char *Config::trimSpaces(char *line)
 {
   char *begin = line;
-  while ((*begin != 0) && isspace(*begin))
+  while ((*begin != 0) && isspace(static_cast<unsigned char>(*begin)))
   {
     ++begin;
   }
-  
+
   char *end = begin + strlen(begin);
-  while ((end != begin) && (isspace(*end) || (*end == 0)))
+  while ((end != begin) &&
+         (isspace(static_cast<unsigned char>(*end)) || (*end == 0)))
   {
     *end-- = 0;
   }


### PR DESCRIPTION
trimSpaces() passed a plain (possibly signed) char to isspace(). For bytes
with the high bit set (UTF-8 or Latin-1 content in a config file) that
yields a negative value, and passing any negative value other than EOF to
isspace() is undefined behavior.

Cast to unsigned char at both call sites, which is the correct way to feed a
char to the <cctype> functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)