### PR TITLE
ModuleEchoLink: free active QSO objects on module cleanup

### DIFF
--- a/src/svxlink/modules/echolink/ModuleEchoLink.cpp
+++ b/src/svxlink/modules/echolink/ModuleEchoLink.cpp
@@ -537,8 +537,25 @@ void ModuleEchoLink::onCommandPtyInput(const void *buf, size_t count)
 
 void ModuleEchoLink::moduleCleanup(void)
 {
-  //FIXME: Delete qso objects
-  
+    // Tear down any still-active QSO objects before the audio pipeline they
+    // are attached to (splitter/selector) is deleted further down. The
+    // QsoImpl destructor only releases its own resources and does not touch
+    // the qsos list, so iterating here is safe.
+  talker = 0;
+  for (QsoImpl *qso : qsos)
+  {
+    if (splitter != 0)
+    {
+      splitter->removeSink(qso);
+    }
+    if (selector != 0)
+    {
+      selector->removeSource(qso);
+    }
+    delete qso;
+  }
+  qsos.clear();
+
   delete num_con_update_timer;
   num_con_update_timer = 0;
 


### PR DESCRIPTION
moduleCleanup() had a "//FIXME: Delete qso objects" placeholder and never
deleted the QsoImpl objects still in the qsos list, then went on to delete
the splitter/selector those QSOs were attached to. Any QSO still active at
module unload was leaked (along with its EventHandler, MsgHandler, timers,
etc.) and the audio pipeline was torn down with sinks/sources still attached.

Remove each QSO from the splitter/selector and delete it (and clear the
talker pointer) before the pipeline objects are destroyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #726.
