### PR TITLE
Trx: fix GPIOD v2 PTT init keying and dead line-name error check

### DIFF
--- a/src/svxlink/trx/PttGpiod.cpp
+++ b/src/svxlink/trx/PttGpiod.cpp
@@ -195,14 +195,15 @@ bool PttGpiod::initialize(Async::Config &cfg, const std::string name)
   else
   {
 #if GPIOD_VERSION_MAJOR >= 2
-    m_line_offset = gpiod_chip_get_line_offset_from_name(m_chip, line.c_str());
-    if (m_line_offset < 0)
+    int line_offset = gpiod_chip_get_line_offset_from_name(m_chip, line.c_str());
+    if (line_offset < 0)
     {
       std::cerr << "*** ERROR: Get GPIOD line \"" << line
                 << "\" failed for TX " << name << ": "
                 << std::strerror(errno) << std::endl;
       return false;
     }
+    m_line_offset = line_offset;
 #else
     m_line = gpiod_chip_find_line(m_chip, line.c_str());
     if (!m_line)
@@ -225,8 +226,13 @@ bool PttGpiod::initialize(Async::Config &cfg, const std::string name)
   }
 
   gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_OUTPUT);
-  gpiod_line_settings_set_output_value(settings,
-      active_low ? GPIOD_LINE_VALUE_ACTIVE : GPIOD_LINE_VALUE_INACTIVE);
+    // Initialise the line to the unkeyed (INACTIVE) state. setTxOn() drives
+    // the line ACTIVE to key the transmitter, and the active-low inversion is
+    // handled by set_active_low() below, so the initial output value must be
+    // INACTIVE in both the active-high and active-low cases. Previously an
+    // active-low PTT was initialised to ACTIVE, which keyed the transmitter
+    // the moment the line was requested (e.g. at startup).
+  gpiod_line_settings_set_output_value(settings, GPIOD_LINE_VALUE_INACTIVE);
 
   if (active_low)
   {

--- a/src/svxlink/trx/SquelchGpiod.cpp
+++ b/src/svxlink/trx/SquelchGpiod.cpp
@@ -204,14 +204,15 @@ bool SquelchGpiod::initialize(Async::Config& cfg, const std::string& rx_name)
   else
   {
 #if GPIOD_VERSION_MAJOR >= 2
-    m_line_offset = gpiod_chip_get_line_offset_from_name(m_chip, line.c_str());
-    if (m_line_offset < 0)
+    int line_offset = gpiod_chip_get_line_offset_from_name(m_chip, line.c_str());
+    if (line_offset < 0)
     {
       std::cerr << "*** ERROR: Get GPIOD line \"" << line
                 << "\" failed for RX \"" << rx_name << "\": "
                 << std::strerror(errno) << std::endl;
       return false;
     }
+    m_line_offset = line_offset;
 #else
     m_line = gpiod_chip_find_line(m_chip, line.c_str());
     if (!m_line)


### PR DESCRIPTION
Two libgpiod v2 (GPIOD_VERSION_MAJOR >= 2) defects:

* PttGpiod initialised the line's output value to ACTIVE when the PTT was
  active-low. Because setTxOn() drives the line ACTIVE to key and the
  active-low inversion is applied via set_active_low(), the initial value
  must be INACTIVE in both cases. As written, an active-low PTT keyed the
  transmitter the instant the line was requested (e.g. at startup/reload).
  Always initialise to INACTIVE.

* PttGpiod and SquelchGpiod assigned gpiod_chip_get_line_offset_from_name()
  (which returns -1 on error) into an unsigned m_line_offset and then tested
  "m_line_offset < 0", a comparison that is always false. A misconfigured
  line *name* therefore went undetected and a bogus offset (0xFFFFFFFF) was
  used. Capture the result in a signed int and check it before assigning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)