### PR TITLE
LinkManager: don't leak a duplicate self-connector when adding a logic

### DIFF
--- a/src/svxlink/svxlink/LinkManager.cpp
+++ b/src/svxlink/svxlink/LinkManager.cpp
@@ -305,6 +305,15 @@ void LinkManager::addLogic(LogicBase *logic)
     // Now create a connection from the new logic source to each sink.
   for (SinkMap::iterator it=sinks.begin(); it != sinks.end(); ++it)
   {
+      // Skip the connection from the new logic's source to its own sink: it is
+      // created by the loop below (over sources), which writes the same
+      // sinks[name].connectors[name] entry. Creating it here as well left the
+      // first AudioPassthrough orphaned (leaked, and still wired into the
+      // splitter/selector) when the second loop overwrote the map entry.
+    if ((*it).first == logic->name())
+    {
+      continue;
+    }
     AudioPassthrough *connector = new AudioPassthrough;
     splitter->addSink(connector, true);
     AudioSelector *other_selector = (*it).second.selector;


### PR DESCRIPTION
addLogic() iterates both the sink map and the source map after inserting the
new logic into each, so both loops created an AudioPassthrough connecting the
new logic's source to its own sink and wrote the same
sinks[name].connectors[name] entry. The second write overwrote the first,
orphaning one AudioPassthrough (a leak) that was still wired into the
splitter and selector.

Skip the self entry in the first loop so the self-connection is created
exactly once by the second loop. The self-connector is still created (and is
relied upon by deleteLogic, which asserts every sink has a connector from the
logic being removed); only the duplicate is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)