### PR TITLE
ModuleEchoLink: don't leak destroy_timer on repeated DISCONNECTED

### DIFF
--- a/src/svxlink/modules/echolink/QsoImpl.cpp
+++ b/src/svxlink/modules/echolink/QsoImpl.cpp
@@ -514,8 +514,14 @@ void QsoImpl::onStateChange(Qso::State state)
 	ss << "disconnected " << remoteCallsign();
       	module->processEvent(ss.str());
       }
-      destroy_timer = new Timer(5000);
-      destroy_timer->expired.connect(mem_fun(*this, &QsoImpl::destroyMeNow));
+        // Guard against re-entering DISCONNECTED (e.g. a reject followed by a
+        // BYE) which would otherwise leak the previous timer and schedule a
+        // second destroyMeNow. connect() clears destroy_timer when reused.
+      if (destroy_timer == 0)
+      {
+        destroy_timer = new Timer(5000);
+        destroy_timer->expired.connect(mem_fun(*this, &QsoImpl::destroyMeNow));
+      }
       break;
     case Qso::STATE_CONNECTING:
       cout << "CONNECTING\n";


### PR DESCRIPTION
onStateChange() unconditionally allocated a new 5s destroy_timer each time
the QSO entered STATE_DISCONNECTED. A QSO that reaches DISCONNECTED more than
once (e.g. a rejected connection that is then BYE'd) overwrote the live timer
pointer, leaking the previous Timer and queueing a second destroyMeNow.

Only allocate the timer when one is not already pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)