### PR TITLE
Trx: keep CTCSS squelch open when handing off between simultaneous tones

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@
 ##############################################################################
 cmake_minimum_required(VERSION 3.7...3.30)
 project(svxlink C CXX)
-#enable_testing()
+enable_testing()
 
 # The path to the project global include directory
 set(PROJECT_INCLUDE_DIR ${PROJECT_BINARY_DIR}/include)
@@ -41,6 +41,9 @@ set(RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 # Add project local CMake module directory
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
+# Conflict-free unit-test auto-discovery helper (svxlink_add_tests)
+include(SvxLinkAddTests)
 
 # Optional parts
 option(USE_QT "Build Qt applications and libs" ON)

--- a/src/cmake/Modules/SvxLinkAddTests.cmake
+++ b/src/cmake/Modules/SvxLinkAddTests.cmake
@@ -1,0 +1,45 @@
+# SvxLinkAddTests.cmake
+#
+# Conflict-free unit-test registration for SvxLink.
+#
+# svxlink_add_tests() auto-discovers every *Test.cpp file in the calling
+# directory and registers each as a CTest test named after the file (without
+# extension). Adding a new unit test then only requires dropping a new
+# <Name>Test.cpp file into the directory -- no edits to this file or to any
+# shared CMakeLists.txt are needed, so independent branches/PRs that each add
+# a test never conflict with one another.
+#
+# Common link libraries for the directory are passed via LIBS:
+#   svxlink_add_tests(LIBS asynccore asynccpp)
+#
+# A test that needs extra sources or libraries beyond the directory default
+# can declare them in an optional sidecar file <Name>Test.deps.cmake placed
+# next to the test source. The sidecar is include()d before the target is
+# created and may set:
+#   <Name>Test_EXTRA_SRCS  - extra source files to compile into the test
+#   <Name>Test_EXTRA_LIBS  - extra libraries to link
+# Because the sidecar is a separate per-test file, it is also conflict-free.
+
+function(svxlink_add_tests)
+  cmake_parse_arguments(SAT "" "" "LIBS" ${ARGN})
+
+  file(GLOB _svxlink_test_srcs CONFIGURE_DEPENDS
+       "${CMAKE_CURRENT_SOURCE_DIR}/*Test.cpp")
+
+  foreach(_src ${_svxlink_test_srcs})
+    get_filename_component(_name "${_src}" NAME_WE)
+
+    set(${_name}_EXTRA_SRCS "")
+    set(${_name}_EXTRA_LIBS "")
+    set(_sidecar "${CMAKE_CURRENT_SOURCE_DIR}/${_name}.deps.cmake")
+    if(EXISTS "${_sidecar}")
+      include("${_sidecar}")
+    endif()
+
+    add_executable(${_name} "${_src}" ${${_name}_EXTRA_SRCS})
+    if(SAT_LIBS OR ${_name}_EXTRA_LIBS)
+      target_link_libraries(${_name} ${SAT_LIBS} ${${_name}_EXTRA_LIBS})
+    endif()
+    add_test(NAME ${_name} COMMAND ${_name})
+  endforeach()
+endfunction()

--- a/src/svxlink/trx/CMakeLists.txt
+++ b/src/svxlink/trx/CMakeLists.txt
@@ -90,8 +90,13 @@ set(LIBS ${LIBS} ${JSONCPP_LIBRARIES})
 add_library(${LIBNAME} STATIC ${LIBSRC} ${VERSION_DEPENDS})
 target_link_libraries(${LIBNAME} ${LIBS})
 
-add_executable(DtmfDecoderTest DtmfDecoderTest.cpp)
-target_link_libraries(DtmfDecoderTest ${LIBNAME} asynccore asyncaudio)
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+# trx is a static library, so linking it into a test that does not reference
+# its objects is harmless (the linker only pulls archive members that resolve
+# an otherwise-unresolved symbol). Tests needing extra sources use a
+# <Name>.deps.cmake sidecar (e.g. ModulationTest compiles Modulation.cpp).
+svxlink_add_tests(LIBS ${LIBNAME} asynccpp asynccore asyncaudio svxmisc)
 
 # Install targets
 #install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})

--- a/src/svxlink/trx/SquelchCtcss.h
+++ b/src/svxlink/trx/SquelchCtcss.h
@@ -470,20 +470,24 @@ class SquelchCtcss : public Squelch
         if (m_active_det == det)
         {
           m_active_det = 0;
-          //for (const auto& d : m_dets)
-          //{
-          //  if (d->isActivated())
-          //  {
-          //    //std::cout << "### ANOTHER TONE ALREADY ACTIVE" << std::endl;
-          //    m_active_det = d;
-          //    //setSignalDetected(false, ss.str());
-          //    ss.str(std::string());
-          //    ss << std::setprecision(1) << std::fixed << d->toneFq()
-          //       << ":" << static_cast<int>(std::roundf(d->lastSnr()));
-          //    setSignalDetected(true, ss.str());
-          //    return;
-          //  }
-          //}
+            // If another configured CTCSS tone is still present, hand the
+            // "signal detected" state over to it instead of closing the
+            // squelch. Only one active detector was tracked, so when it
+            // dropped the squelch closed even though a second valid tone was
+            // still active. (det itself just deactivated, so it is skipped.)
+          for (const auto& d : m_dets)
+          {
+            if (d->isActivated())
+            {
+              m_active_det = d;
+              ss.str(std::string());
+              ss << std::setprecision(1) << std::fixed << d->toneFq()
+                 << ":" << static_cast<int>(std::roundf(
+                       d->lastSnr() - m_ctcss_snr_offsets[d->toneFq()]));
+              setSignalDetected(true, ss.str());
+              return;
+            }
+          }
           setSignalDetected(false, ss.str());
         }
       }

--- a/src/svxlink/trx/SquelchCtcssTest.cpp
+++ b/src/svxlink/trx/SquelchCtcssTest.cpp
@@ -1,0 +1,119 @@
+/**
+@file    SquelchCtcssTest.cpp
+@brief   Functional test for SquelchCtcss multi-tone handoff.
+@author  Mark Rose
+@date    2026-06-10
+
+Feeds synthesized CTCSS tones through a SquelchCtcss configured with two
+tones and verifies that, when the first (active) tone drops while a second
+valid tone is still present, the squelch stays open instead of closing.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <AsyncCppApplication.h>
+#include <AsyncConfig.h>
+
+#include "SquelchCtcss.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+// Feed n samples that are the sum of the given tone frequencies (an empty
+// list feeds silence). Phase is derived from an absolute sample counter so
+// successive calls produce a continuous waveform.
+long sample_pos = 0;
+void feed(Squelch& sql, const vector<float>& fqs, float amp, int n)
+{
+  const float sr = INTERNAL_SAMPLE_RATE;
+  vector<float> buf(n);
+  for (int i = 0; i < n; ++i)
+  {
+    float s = 0.0f;
+    for (float f : fqs)
+    {
+      s += amp * sinf(2.0f * M_PI * f * (sample_pos + i) / sr);
+    }
+    buf[i] = s;
+  }
+  sample_pos += n;
+  sql.writeSamples(buf.data(), n);
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;   // Squelch base may construct Async::Timer objects
+
+  cout << "test_ctcss_multitone_handoff" << endl;
+
+  Config cfg;
+  cfg.setValue("Rx", "CTCSS_FQ", string("100.0,151.4"));
+  cfg.setValue("Rx", "CTCSS_OPEN_THRESH", string("1.0"));
+  cfg.setValue("Rx", "CTCSS_CLOSE_THRESH", string("0.5"));
+  cfg.setValue("Rx", "SQL_HANGTIME", string("0"));
+  cfg.setValue("Rx", "SQL_START_DELAY", string("0"));
+  cfg.setValue("Rx", "SQL_DELAY", string("0"));
+
+  SquelchCtcss sql;
+  check(sql.initialize(cfg, "Rx"), "SquelchCtcss initializes");
+  check(!sql.isOpen(), "closed before any audio");
+
+  // ~1s per phase, well beyond the 100ms detect/undetect delays.
+  const int N = INTERNAL_SAMPLE_RATE;
+
+  // Phase 1: first tone only -> squelch opens.
+  feed(sql, {100.0f}, 0.5f, N);
+  check(sql.isOpen(), "opens on CTCSS tone A (100.0 Hz)");
+
+  // Phase 2: both tones present -> both detectors active.
+  feed(sql, {100.0f, 151.4f}, 0.5f, N);
+  check(sql.isOpen(), "stays open with both tones present");
+
+  // Phase 3: drop the first tone, keep the second. This is the bug: the
+  // active detector deactivates, and pre-fix the squelch closed even though
+  // the second tone is still valid. It must hand off and stay open.
+  feed(sql, {151.4f}, 0.5f, N);
+  check(sql.isOpen(), "stays open when first tone drops but second remains");
+
+  // Phase 4: silence -> squelch closes.
+  feed(sql, {}, 0.0f, N);
+  check(!sql.isOpen(), "closes when all tones are gone");
+
+  cout << endl;
+  if (failures == 0)
+  {
+    cout << "All SquelchCtcss tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " SquelchCtcss test check(s) FAILED" << endl;
+  return 1;
+} /* main */


### PR DESCRIPTION
SquelchCtcss tracked only a single active tone detector. With more than one
CTCSS_FQ configured, if a second tone activated while the first was still
present and the first then dropped, the squelch closed even though the
second, still-valid tone was active. When the active detector deactivates,
hand the "signal detected" state over to another still-activated detector
instead of closing.

Add SquelchCtcssTest (a functional test that feeds tone A, then A+B, then B
alone and checks the squelch stays open across the hand-off) plus the minimal
CTest wiring to build/run it: enable_testing() and a small svxlink_add_tests()
auto-discovery helper. The trx test registration is converted to the helper,
which also brings the existing DtmfDecoderTest under CTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)