### PR TITLE
Async: reject out-of-range TCP server port instead of truncating

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@
 ##############################################################################
 cmake_minimum_required(VERSION 3.7...3.30)
 project(svxlink C CXX)
-#enable_testing()
+enable_testing()
 
 # The path to the project global include directory
 set(PROJECT_INCLUDE_DIR ${PROJECT_BINARY_DIR}/include)
@@ -41,6 +41,9 @@ set(RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 # Add project local CMake module directory
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
+# Conflict-free unit-test auto-discovery helper (svxlink_add_tests)
+include(SvxLinkAddTests)
 
 # Optional parts
 option(USE_QT "Build Qt applications and libs" ON)

--- a/src/async/core/AsyncTcpServerBase.cpp
+++ b/src/async/core/AsyncTcpServerBase.cpp
@@ -43,6 +43,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>
+#include <cerrno>
 
 
 /****************************************************************************
@@ -121,6 +123,27 @@ using namespace Async;
  *
  ****************************************************************************/
 
+int TcpServerBase::parsePort(const std::string& port_str)
+{
+  if (port_str.empty())
+  {
+    return -1;
+  }
+  char *endptr = 0;
+  errno = 0;
+  long val = strtol(port_str.c_str(), &endptr, 10);
+  if ((*endptr != '\0') || (errno != 0))
+  {
+    return -1;  // Not a pure number -- caller falls back to service lookup
+  }
+  if ((val < 1) || (val > 65535))
+  {
+    return -1;  // Out of range -- reject instead of truncating to 16 bits
+  }
+  return static_cast<int>(val);
+} /* TcpServerBase::parsePort */
+
+
 TcpServerBase::TcpServerBase(const string& port_str,
                              const Async::IpAddress &bind_ip)
   : m_sock(-1), m_rd_watch(0), m_con_throt_timer(-1, Timer::TYPE_PERIODIC)
@@ -157,21 +180,22 @@ TcpServerBase::TcpServerBase(const string& port_str,
     return;
   }
 
-  char *endptr = 0;
   struct servent *se;
-  uint16_t port = strtol(port_str.c_str(), &endptr, 10);
-  if (*endptr != '\0')
+  uint16_t port;
+  int parsed_port = parsePort(port_str);
+  if (parsed_port > 0)
   {
-    if ((se = getservbyname(port_str.c_str(), "tcp")) != NULL)
-    {
-      port = ntohs(se->s_port);
-    }
-    else
-    {
-      cerr << "Could not find service " << port_str << endl;
-      cleanup();
-      return;
-    }
+    port = static_cast<uint16_t>(parsed_port);
+  }
+  else if ((se = getservbyname(port_str.c_str(), "tcp")) != NULL)
+  {
+    port = ntohs(se->s_port);
+  }
+  else
+  {
+    cerr << "Could not find service " << port_str << endl;
+    cleanup();
+    return;
   }
 
   struct sockaddr_in addr = { 0 };

--- a/src/async/core/AsyncTcpServerBase.h
+++ b/src/async/core/AsyncTcpServerBase.h
@@ -116,6 +116,18 @@ class TcpServerBase : public sigc::trackable
 {
   public:
     /**
+     * @brief   Parse a numeric TCP port string with range validation
+     * @param   port_str The string to parse
+     * @return  The port number (1-65535) if port_str is a valid numeric
+     *          port, or -1 if it is not a purely-numeric, in-range port
+     *
+     * This rejects out-of-range values (e.g. "70000") instead of silently
+     * truncating them to a 16-bit port. A return value of -1 means the
+     * caller should fall back to a service-name lookup.
+     */
+    static int parsePort(const std::string& port_str);
+
+    /**
      * @brief 	Default constuctor
      * @param 	port_str A port number or service name to listen to
      * @param 	bind_ip The IP to bind the server to

--- a/src/async/core/CMakeLists.txt
+++ b/src/async/core/CMakeLists.txt
@@ -58,6 +58,10 @@ if (BUILD_STATIC_LIBS)
   target_link_libraries(${LIBNAME}_static ${LIBS})
 endif(BUILD_STATIC_LIBS)
 
+# Unit tests: every *Test.cpp here is auto-registered (see SvxLinkAddTests).
+# Adding a new test = drop in a new *Test.cpp file; no edits needed here.
+svxlink_add_tests(LIBS ${LIBNAME})
+
 # Install files
 install(TARGETS ${LIBNAME} DESTINATION ${LIB_INSTALL_DIR})
 if (BUILD_STATIC_LIBS)

--- a/src/async/core/TcpServerPortTest.cpp
+++ b/src/async/core/TcpServerPortTest.cpp
@@ -1,0 +1,75 @@
+/**
+@file    TcpServerPortTest.cpp
+@brief   Unit tests for Async::TcpServerBase::parsePort range validation.
+@author  Mark Rose
+@date    2026-06-10
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include "AsyncTcpServerBase.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  cout << "test_parse_port" << endl;
+
+  // Valid in-range numeric ports are accepted as-is.
+  check(TcpServerBase::parsePort("5300") == 5300, "valid port 5300");
+  check(TcpServerBase::parsePort("1") == 1, "minimum port 1");
+  check(TcpServerBase::parsePort("65535") == 65535, "maximum port 65535");
+
+  // The bug: out-of-range values must be rejected, not truncated mod 65536.
+  // Pre-fix, strtol("70000") narrowed to uint16_t == 4464 and silently bound
+  // the wrong port. parsePort must return -1 instead.
+  check(TcpServerBase::parsePort("70000") == -1, "70000 rejected (no 16-bit wrap)");
+  check(TcpServerBase::parsePort("65536") == -1, "65536 rejected (one past max)");
+  check(TcpServerBase::parsePort("4294967296") == -1, "huge value rejected");
+
+  // Out-of-range low / invalid values.
+  check(TcpServerBase::parsePort("0") == -1, "port 0 rejected");
+  check(TcpServerBase::parsePort("-1") == -1, "negative rejected");
+
+  // Non-numeric strings return -1 so the caller falls back to a service
+  // name lookup (e.g. getservbyname).
+  check(TcpServerBase::parsePort("http") == -1, "service name -> -1 (fallback)");
+  check(TcpServerBase::parsePort("53x") == -1, "trailing junk -> -1");
+  check(TcpServerBase::parsePort("") == -1, "empty -> -1");
+
+  if (failures == 0)
+  {
+    cout << "All TcpServerBase::parsePort tests passed" << endl;
+    return 0;
+  }
+  cout << failures << " parsePort test check(s) FAILED" << endl;
+  return 1;
+} /* main */

--- a/src/cmake/Modules/SvxLinkAddTests.cmake
+++ b/src/cmake/Modules/SvxLinkAddTests.cmake
@@ -1,0 +1,45 @@
+# SvxLinkAddTests.cmake
+#
+# Conflict-free unit-test registration for SvxLink.
+#
+# svxlink_add_tests() auto-discovers every *Test.cpp file in the calling
+# directory and registers each as a CTest test named after the file (without
+# extension). Adding a new unit test then only requires dropping a new
+# <Name>Test.cpp file into the directory -- no edits to this file or to any
+# shared CMakeLists.txt are needed, so independent branches/PRs that each add
+# a test never conflict with one another.
+#
+# Common link libraries for the directory are passed via LIBS:
+#   svxlink_add_tests(LIBS asynccore asynccpp)
+#
+# A test that needs extra sources or libraries beyond the directory default
+# can declare them in an optional sidecar file <Name>Test.deps.cmake placed
+# next to the test source. The sidecar is include()d before the target is
+# created and may set:
+#   <Name>Test_EXTRA_SRCS  - extra source files to compile into the test
+#   <Name>Test_EXTRA_LIBS  - extra libraries to link
+# Because the sidecar is a separate per-test file, it is also conflict-free.
+
+function(svxlink_add_tests)
+  cmake_parse_arguments(SAT "" "" "LIBS" ${ARGN})
+
+  file(GLOB _svxlink_test_srcs CONFIGURE_DEPENDS
+       "${CMAKE_CURRENT_SOURCE_DIR}/*Test.cpp")
+
+  foreach(_src ${_svxlink_test_srcs})
+    get_filename_component(_name "${_src}" NAME_WE)
+
+    set(${_name}_EXTRA_SRCS "")
+    set(${_name}_EXTRA_LIBS "")
+    set(_sidecar "${CMAKE_CURRENT_SOURCE_DIR}/${_name}.deps.cmake")
+    if(EXISTS "${_sidecar}")
+      include("${_sidecar}")
+    endif()
+
+    add_executable(${_name} "${_src}" ${${_name}_EXTRA_SRCS})
+    if(SAT_LIBS OR ${_name}_EXTRA_LIBS)
+      target_link_libraries(${_name} ${SAT_LIBS} ${${_name}_EXTRA_LIBS})
+    endif()
+    add_test(NAME ${_name} COMMAND ${_name})
+  endforeach()
+endfunction()


### PR DESCRIPTION
TcpServerBase parsed the listen port with strtol() and assigned the long
result straight into a uint16_t, so an out-of-range value such as "70000"
was silently truncated mod 65536 (to 4464) and the server bound the wrong
port with no error.

Extract the numeric parsing into a static, range-validating helper
TcpServerBase::parsePort() that returns the port for a valid 1-65535 number
and -1 otherwise (non-numeric or out of range), in which case the caller
falls back to a service-name lookup.

Add TcpServerPortTest plus the minimal CTest wiring to build and run it:
enable_testing() and a small svxlink_add_tests() helper that auto-discovers
every *Test.cpp in a directory (so future tests need no CMakeLists edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)