### PR TITLE
svxlink: fix NULL dereference in MsgHandler::playFile for extensionless paths

### DIFF
--- a/src/svxlink/svxlink/MsgHandler.cpp
+++ b/src/svxlink/svxlink/MsgHandler.cpp
@@ -293,11 +293,11 @@ void MsgHandler::playFile(const string& path, bool idle_marked)
 {
   QueueItem *item = 0;
   const char *ext = strrchr(path.c_str(), '.');
-  if (strcmp(ext, ".gsm") == 0)
+  if (ext != 0 && strcmp(ext, ".gsm") == 0)
   {
     item = new GsmFileQueueItem(path, idle_marked);
   }
-  else if (strcmp(ext, ".wav") == 0)
+  else if (ext != 0 && strcmp(ext, ".wav") == 0)
   {
     item = new WavFileQueueItem(path, idle_marked);
   }

--- a/src/svxlink/svxlink/MsgHandlerTest.cpp
+++ b/src/svxlink/svxlink/MsgHandlerTest.cpp
@@ -1,0 +1,79 @@
+/**
+@file    MsgHandlerTest.cpp
+@brief   Unit test for MsgHandler extensionless-path handling
+@author  Mark Rose
+@date    2026-07-10
+
+MsgHandler::playFile() classifies a clip by its file extension. For a path with
+no '.', strrchr() returns NULL, which was passed straight into strcmp(),
+dereferencing NULL and crashing. This test drives playFile() with an
+extensionless path and verifies it no longer crashes (it falls through to the
+raw-file handler).
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include <AsyncAudioSink.h>
+
+#include "MsgHandler.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+  // Minimal sink so MsgHandler has somewhere to flush to (playback of a
+  // non-existent file ends in a flush).
+class NullSink : public AudioSink
+{
+  public:
+    virtual int writeSamples(const float*, int count) { return count; }
+    virtual void flushSamples(void) { sourceAllSamplesFlushed(); }
+};
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  MsgHandler h(16000);
+  NullSink sink;
+  h.registerSink(&sink);
+
+    // Extensionless path: strrchr(path, '.') == NULL. Before the fix this
+    // dereferenced NULL in strcmp(); now it falls through to the raw handler.
+  h.playFile("/tmp/svxlink_msghandler_test_no_extension", false);
+  check(true, "playFile on an extensionless path did not crash");
+
+    // Extensioned paths still classify without issue.
+  h.playFile("/tmp/svxlink_msghandler_test.wav", false);
+  h.playFile("/tmp/svxlink_msghandler_test.gsm", false);
+  check(true, "playFile on .wav / .gsm paths did not crash");
+
+  h.clear();
+
+  cout << (failures == 0 ? "ALL TESTS PASSED" : "TESTS FAILED") << endl;
+  return failures != 0;
+} /* main */

--- a/src/svxlink/svxlink/MsgHandlerTest.deps.cmake
+++ b/src/svxlink/svxlink/MsgHandlerTest.deps.cmake
@@ -1,0 +1,4 @@
+# MsgHandlerTest exercises MsgHandler directly, so compile it in. MsgHandler is
+# an Async::AudioSource (asyncaudio) and uses the GSM codec for .gsm clips.
+set(MsgHandlerTest_EXTRA_SRCS MsgHandler.cpp)
+set(MsgHandlerTest_EXTRA_LIBS asyncaudio ${GSM_LIBRARY})


### PR DESCRIPTION
## Problem

`MsgHandler::playFile()` classifies a clip by file extension:

```cpp
const char *ext = strrchr(path.c_str(), '.');
if (strcmp(ext, ".gsm") == 0) ...
else if (strcmp(ext, ".wav") == 0) ...
```

`strrchr()` returns `NULL` when the file name contains no `.`, and that `NULL`
is passed straight into `strcmp()`, dereferencing it and crashing. A path
without an extension is legitimate (it simply isn't GSM or WAV).

## Fix

Guard the extension comparisons against a `NULL` result and fall through to the
raw-file handler when there is no extension.

## Testing

Builds and links clean in a `Release` (`-DNDEBUG`) configuration.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
This PR also adds a unit test (`MsgHandlerTest.cpp`). It is auto-discovered and executed by the CTest suite proposed in #762 once that is merged; without that suite present the test file is inert and does not affect the build.
