### PR TITLE
reflector: move required calls out of assert() (broken under NDEBUG)

### DIFF
--- a/src/svxlink/reflector/Reflector.cpp
+++ b/src/svxlink/reflector/Reflector.cpp
@@ -414,7 +414,12 @@ bool Reflector::sendUdpDatagram(ReflectorClient *client,
   {
     ReflectorUdpMsg header(msg.type());
     ostringstream ss;
-    assert(header.pack(ss) && msg.pack(ss));
+    if (!header.pack(ss) || !msg.pack(ss))
+    {
+      std::cout << "*** WARNING: Packing UDP datagram failed for "
+                << udp_addr << ":" << udp_port << std::endl;
+      return false;
+    }
 
     m_udp_sock->setCipherIV(client->udpCipherIV());
     m_udp_sock->setCipherKey(client->udpCipherKey());
@@ -435,7 +440,12 @@ bool Reflector::sendUdpDatagram(ReflectorClient *client,
     ReflectorUdpMsgV2 header(msg.type(), client->clientId(),
         client->udpCipherIVCntrNext() & 0xffff);
     ostringstream ss;
-    assert(header.pack(ss) && msg.pack(ss));
+    if (!header.pack(ss) || !msg.pack(ss))
+    {
+      std::cout << "*** WARNING: Packing UDP datagram failed for "
+                << udp_addr << ":" << udp_port << std::endl;
+      return false;
+    }
     return m_udp_sock->UdpSocket::write(
         udp_addr, udp_port,
         ss.str().data(), ss.str().size());
@@ -911,7 +921,12 @@ bool Reflector::udpCipherDataReceived(const IpAddress& addr, uint16_t port,
 
   stringstream ss;
   ss.write(reinterpret_cast<const char *>(buf), UdpCipher::AADLEN);
-  assert(m_aad.unpack(ss));
+  if (!m_aad.unpack(ss))
+  {
+    std::cout << "### Reflector::udpCipherDataReceived: "
+                 "Could not unpack AAD; ignoring datagram" << std::endl;
+    return true;
+  }
 
   ReflectorClient* client = nullptr;
   if (m_aad.iv_cntr == 0)
@@ -1017,14 +1032,19 @@ void Reflector::udpDatagramReceived(const IpAddress& addr, uint16_t port,
     if (aad.iv_cntr == 0) // Client UDP registration
     {
       UdpCipher::InitialAAD iaad;
-      assert(aadss.seekg(0));
+      aadss.seekg(0);
       if (!iaad.unpack(aadss))
       {
         std::cout << "### Reflector::udpDatagramReceived: "
                      "Could not unpack iaad" << std::endl;
         return;
       }
-      assert(iaad.iv_cntr == 0);
+      if (iaad.iv_cntr != 0)
+      {
+        std::cout << "### Reflector::udpDatagramReceived: "
+                     "Unexpected non-zero iv_cntr in initial AAD" << std::endl;
+        return;
+      }
       //std::cout << "### Reflector::udpDatagramReceived: iaad.client_id="
       //          << iaad.client_id << std::endl;
       client = ReflectorClient::lookup(iaad.client_id);

--- a/src/svxlink/reflector/Reflector.cpp
+++ b/src/svxlink/reflector/Reflector.cpp
@@ -412,7 +412,12 @@ bool Reflector::sendUdpDatagram(ReflectorClient *client,
   {
     ReflectorUdpMsg header(msg.type());
     ostringstream ss;
-    assert(header.pack(ss) && msg.pack(ss));
+    if (!header.pack(ss) || !msg.pack(ss))
+    {
+      std::cout << "*** WARNING: Packing UDP datagram failed for "
+                << udp_addr << ":" << udp_port << std::endl;
+      return false;
+    }
 
     m_udp_sock->setCipherIV(client->udpCipherIV());
     m_udp_sock->setCipherKey(client->udpCipherKey());
@@ -433,7 +438,12 @@ bool Reflector::sendUdpDatagram(ReflectorClient *client,
     ReflectorUdpMsgV2 header(msg.type(), client->clientId(),
         client->udpCipherIVCntrNext() & 0xffff);
     ostringstream ss;
-    assert(header.pack(ss) && msg.pack(ss));
+    if (!header.pack(ss) || !msg.pack(ss))
+    {
+      std::cout << "*** WARNING: Packing UDP datagram failed for "
+                << udp_addr << ":" << udp_port << std::endl;
+      return false;
+    }
     return m_udp_sock->UdpSocket::write(
         udp_addr, udp_port,
         ss.str().data(), ss.str().size());
@@ -908,7 +918,12 @@ bool Reflector::udpCipherDataReceived(const IpAddress& addr, uint16_t port,
 
   stringstream ss;
   ss.write(reinterpret_cast<const char *>(buf), UdpCipher::AADLEN);
-  assert(m_aad.unpack(ss));
+  if (!m_aad.unpack(ss))
+  {
+    std::cout << "### Reflector::udpCipherDataReceived: "
+                 "Could not unpack AAD; ignoring datagram" << std::endl;
+    return true;
+  }
 
   ReflectorClient* client = nullptr;
   if (m_aad.iv_cntr == 0)
@@ -1014,14 +1029,19 @@ void Reflector::udpDatagramReceived(const IpAddress& addr, uint16_t port,
     if (aad.iv_cntr == 0) // Client UDP registration
     {
       UdpCipher::InitialAAD iaad;
-      assert(aadss.seekg(0));
+      aadss.seekg(0);
       if (!iaad.unpack(aadss))
       {
         std::cout << "### Reflector::udpDatagramReceived: "
                      "Could not unpack iaad" << std::endl;
         return;
       }
-      assert(iaad.iv_cntr == 0);
+      if (iaad.iv_cntr != 0)
+      {
+        std::cout << "### Reflector::udpDatagramReceived: "
+                     "Unexpected non-zero iv_cntr in initial AAD" << std::endl;
+        return;
+      }
       //std::cout << "### Reflector::udpDatagramReceived: iaad.client_id="
       //          << iaad.client_id << std::endl;
       client = ReflectorClient::lookup(iaad.client_id);


### PR DESCRIPTION
Fixes #828.

## Problem

Several **side-effecting** calls in `Reflector.cpp` are wrapped in `assert()`, so
a release build (`-DNDEBUG`) compiles them out entirely:

* `sendUdpDatagram()` — `assert(header.pack(ss) && msg.pack(ss))` at both the
  proto ≥ 3.0 and the V2 branches. Under `NDEBUG` the messages are never
  serialized, so the reflector transmits **empty UDP datagrams** in release
  builds.
* `udpCipherDataReceived()` — `assert(m_aad.unpack(ss))`: the AAD is never
  unpacked under `NDEBUG`, breaking UDP cipher handling.
* `udpDatagramReceived()` — `assert(aadss.seekg(0))`: the stream is never
  rewound under `NDEBUG`, so the following `InitialAAD` unpack reads from the
  wrong offset.

## Fix

Replace each with an explicit call whose result is checked and handled (warn and
bail). Also convert the adjacent `assert(iaad.iv_cntr == 0)` — which asserts on
attacker-controlled datagram content and would abort a debug build on malformed
input — into a normal validation that rejects the datagram.

## Testing

Builds and links clean in a `Release` (`-DNDEBUG`) configuration.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)