### PR TITLE
trx: prevent RtlSdr zero block size causing infinite loop / OOM

### DIFF
--- a/src/svxlink/trx/RtlSdr.cpp
+++ b/src/svxlink/trx/RtlSdr.cpp
@@ -150,6 +150,13 @@ void RtlSdr::setCenterFq(uint32_t fq)
 void RtlSdr::setSampleRate(uint32_t rate)
 {
   block_size = 10 * 2 * rate / 1000; // 10ms block size
+  if (block_size == 0)
+  {
+    cerr << "*** WARNING: RtlSdr sample rate " << rate << " Hz is too low to "
+            "form a 10ms block; clamping the internal block size to 1 sample. "
+            "Use a valid RTL-SDR sample rate.\n";
+    block_size = 1;
+  }
   samp_rate = rate;
   samp_rate_set = true;
   handleSetSampleRate(rate);

--- a/src/svxlink/trx/RtlSdrTest.cpp
+++ b/src/svxlink/trx/RtlSdrTest.cpp
@@ -1,0 +1,86 @@
+/**
+@file    RtlSdrTest.cpp
+@brief   Unit test for RtlSdr block-size computation
+@author  Mark Rose
+@date    2026-07-10
+
+RtlSdr::setSampleRate() derives block_size = 10*2*rate/1000. A sample rate below
+50 Hz made that integer expression zero, and a zero block size spins the RtlUsb
+sample-buffer loop forever. This test verifies block_size is clamped to a
+non-zero value for a degenerate rate while a normal rate is unaffected.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+#include "RtlSdr.h"
+
+using namespace std;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+  // Concrete RtlSdr with all hardware hooks stubbed out.
+class TestRtlSdr : public RtlSdr
+{
+  public:
+    virtual bool isReady(void) const { return true; }
+    virtual const std::string displayName(void) const { return "test"; }
+
+      // blockSize() is protected; expose it for the test.
+    size_t testBlockSize(void) const { return blockSize(); }
+
+  protected:
+    virtual void handleSetTunerIfGain(uint16_t, int16_t) {}
+    virtual void handleSetCenterFq(uint32_t) {}
+    virtual void handleSetSampleRate(uint32_t) {}
+    virtual void handleSetGainMode(uint32_t) {}
+    virtual void handleSetGain(int32_t) {}
+    virtual void handleSetFqCorr(int) {}
+    virtual void handleEnableTestMode(bool) {}
+    virtual void handleEnableDigitalAgc(bool) {}
+};
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  TestRtlSdr rtl;
+
+    // A sample rate under 50 Hz makes 10*2*rate/1000 evaluate to 0. A zero
+    // block size makes the RtlUsb SampleBuffer copy loop never terminate.
+  rtl.setSampleRate(40);
+  check(rtl.testBlockSize() >= 1,
+        "degenerate sample rate does not yield a zero block size");
+
+    // A normal sample rate still produces the expected 10 ms block.
+  rtl.setSampleRate(960000);
+  check(rtl.testBlockSize() == 10u * 2u * 960000u / 1000u,
+        "normal sample rate block size unchanged");
+  check(rtl.testBlockSize() > 0, "normal sample rate block size positive");
+
+  cout << (failures == 0 ? "ALL TESTS PASSED" : "TESTS FAILED") << endl;
+  return failures != 0;
+} /* main */

--- a/src/svxlink/trx/RtlUsb.cpp
+++ b/src/svxlink/trx/RtlUsb.cpp
@@ -177,6 +177,13 @@ class RtlUsb::SampleBuffer : public sigc::trackable
 
     bool addSamples(const unsigned char *samples, uint32_t len)
     {
+      if (block_size == 0)
+      {
+          // Guard against a degenerate block size: with block_size == 0 the
+          // copy count below is always 0 while len stays > 0, so the loop
+          // never terminates and pushes empty blocks forever (OOM).
+        return false;
+      }
       lockMutex();
       while (len > 0)
       {


### PR DESCRIPTION
## Problem

`RtlSdr::setSampleRate()` derives the block size as
`block_size = 10 * 2 * rate / 1000`. Any sample rate below 50 Hz makes this
integer expression evaluate to **0**. That `block_size` is handed to the
`RtlUsb` `SampleBuffer`, whose `addSamples()` loop does:

```cpp
while (len > 0) {
  uint32_t cpy_cnt = min(block_size - buf_cnt, len);  // == 0 when block_size == 0
  ...
}
```

With `block_size == 0` the copy count is always 0 while `len` stays > 0, so the
loop never terminates and keeps pushing empty blocks — an unbounded busy-loop
and memory-growth DoS driven by a configuration value.

## Fix

* Clamp `block_size` to a non-zero minimum in `setSampleRate()` (with a warning).
* Add a defensive guard in `SampleBuffer::addSamples()` so a zero block size can
  never spin the loop regardless of how it was set.

## Testing

Builds and links clean in a `Release` (`-DNDEBUG`) configuration.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
This PR also adds a unit test (`RtlSdrTest.cpp`). It is auto-discovered and executed by the CTest suite proposed in #762 once that is merged; without that suite present the test file is inert and does not affect the build.
