### PR TITLE
trx: fix one-past-the-end iterator dereference in WbRxRtlSdr

### DIFF
--- a/src/svxlink/trx/WbRxRtlSdr.cpp
+++ b/src/svxlink/trx/WbRxRtlSdr.cpp
@@ -351,8 +351,8 @@ void WbRxRtlSdr::findBestCenterFq(void)
   {
     deque<uint32_t>::iterator next = it+1;
     int32_t dist = *it - center_fq;
-    int32_t next_dist = *next - center_fq;
-    if ((next == fqs.end()) || (abs(dist) < abs(next_dist)))
+    if ((next == fqs.end()) ||
+        (abs(dist) < abs(static_cast<int32_t>(*next - center_fq))))
     {
       if (abs(dist) < 12500)
       {


### PR DESCRIPTION
## Problem

The channel-centering loop in `WbRxRtlSdr` dereferences the `next` iterator
before checking whether it is `end()`:

```cpp
deque<uint32_t>::iterator next = it + 1;
int32_t dist = *it - center_fq;
int32_t next_dist = *next - center_fq;                 // UB when next == end()
if ((next == fqs.end()) || (abs(dist) < abs(next_dist)))
```

On the final iteration `next == fqs.end()`, so `*next` reads one past the end of
the deque — undefined behavior. The value is only used inside a condition that
is already guarded by `next == fqs.end() || ...`.

## Fix

Fold the dereference into the short-circuited term so `*next` is read only when
`next` refers to a valid element.

## Testing

Builds and links clean in a `Release` (`-DNDEBUG`) configuration.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
