### PR TITLE
echolib: bound-check EchoLink non-audio packets before reading

### DIFF
--- a/src/echolib/EchoLinkQso.cpp
+++ b/src/echolib/EchoLinkQso.cpp
@@ -692,6 +692,11 @@ void Qso::handleAudioInput(unsigned char *buf, int len)
     return;
   }
   
+  if (len <= 0)
+  {
+    return;
+  }
+
   if(buf[0] != 0xc0) /* Not an audio packet */
   {
     handleNonAudioPacket(buf, len);
@@ -707,13 +712,20 @@ inline void Qso::handleNonAudioPacket(unsigned char *buf, int len)
 {
   //printData(buf, len);
 
+  if (len < 7)
+  {
+    cerr << "Ignoring short non-audio packet received:\n";
+    printData(buf, len);
+    return;
+  }
+
   if(memcmp(buf+1, "NDATA", 5) == 0)
   {
     if (buf[6] == 0x0d) // Remote station info / conference status
     {
       char *info_buf = reinterpret_cast<char *>(buf);
       char *null = (char *)memchr(info_buf, 0, len);
-      if (null == 0)
+      if (null == 0 || null < info_buf + 7)
       {
       	cerr << "Malformed info packet received:\n";
 	printData(buf, len);
@@ -736,7 +748,7 @@ inline void Qso::handleNonAudioPacket(unsigned char *buf, int len)
     {
       char *chat_buf = reinterpret_cast<char *>(buf);
       char *null = (char *)memchr(buf, 0, len);
-      if (null == 0)
+      if (null == 0 || null < chat_buf + 6)
       {
       	cerr << "Malformed chat packet received:\n";
 	printData(buf, len);


### PR DESCRIPTION
Qso::handleAudioInput() / handleNonAudioPacket() read prefix bytes of a received
datagram before validating its length:
  - buf[0] (audio/non-audio discriminator) with no check that len > 0
  - memcmp(buf+1, "NDATA", 5) reads buf[1..5]
  - buf[6] (info vs chat discriminator)
A peer (or spoofed UDP source matching an active QSO) sending a datagram shorter
than 7 bytes causes an out-of-bounds read.

Additionally, the info/chat string constructors use the first NUL found from
index 0 as the range end: string(info_buf+7, null) / string(chat_buf+6, null).
A NUL at or before the prefix makes first > last, an invalid iterator range
(std::string computes a huge size_type -> crash / huge OOB copy).

Reject datagrams shorter than the 7-byte prefix, and require the NUL terminator
to sit at or after the payload start before constructing the string.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
