### PR TITLE
reflector/async: validate UDP cipher key length before decrypt

### DIFF
--- a/src/async/core/AsyncEncryptedUdpSocket.cpp
+++ b/src/async/core/AsyncEncryptedUdpSocket.cpp
@@ -363,8 +363,13 @@ void EncryptedUdpSocket::onDataReceived(const IpAddress& ip, uint16_t port,
   //std::cout << "### iv_length=" << iv_length << std::endl;
   if (key_length > 0)
   {
-    //OPENSSL_assert(key_length == m_cipher_key.size());
-    //OPENSSL_assert(iv_length == m_cipher_iv.size());
+    if (m_cipher_key.size() != static_cast<size_t>(key_length))
+    {
+      std::cout << "*** WARNING: EncryptedUdpSocket: cipher key length "
+                << m_cipher_key.size() << " does not match the required "
+                << key_length << " bytes; dropping datagram" << std::endl;
+      return;
+    }
 
       // Set key and IV in the cipher context
     EVP_DecryptInit_ex(m_cipher_ctx, NULL, NULL, m_cipher_key.data(),

--- a/src/svxlink/reflector/Reflector.cpp
+++ b/src/svxlink/reflector/Reflector.cpp
@@ -963,7 +963,13 @@ bool Reflector::udpCipherDataReceived(const IpAddress& addr, uint16_t port,
     //          << m_aad.iv_cntr << std::endl;
     m_udp_sock->setCipherIV(UdpCipher::IV{client->udpCipherIVRand(),
                                           client->clientId(), m_aad.iv_cntr});
-    m_udp_sock->setCipherKey(client->udpCipherKey());
+    if (!m_udp_sock->setCipherKey(client->udpCipherKey()))
+    {
+      std::cout << "*** WARNING: Reflector: client " << addr << ":" << port
+                << " supplied a UDP cipher key of invalid length; "
+                   "ignoring datagram" << std::endl;
+      return true;
+    }
     m_udp_sock->setCipherAADLength(UdpCipher::AADLEN);
   }
   else


### PR DESCRIPTION
A reflector client supplies its UDP cipher key over the wire in MsgNodeInfo as a
std::vector<uint8_t> of arbitrary length. EncryptedUdpSocket::setCipherKey stores
it unconditionally and returns whether the size matches the cipher's key length,
but Reflector::udpCipherDataReceived discarded that return value. On the next
datagram, EncryptedUdpSocket::onDataReceived called EVP_DecryptInit_ex(),
which reads the full (16-byte, AES-128-GCM) key length from m_cipher_key.data()
regardless of the vector's actual size -- an out-of-bounds heap read when the
client sent a short (empty/1-byte) key. The guarding OPENSSL_assert had been
commented out.

- onDataReceived(): bail out (drop the datagram) unless m_cipher_key.size()
  matches the cipher key length, instead of decrypting past the buffer.
- udpCipherDataReceived(): check setCipherKey()'s return and ignore the datagram
  for a wrong-length key.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
