### PR TITLE
trx: free RtlUsb sample blocks with delete[] in setBlockSize

### DIFF
--- a/src/svxlink/trx/RtlUsb.cpp
+++ b/src/svxlink/trx/RtlUsb.cpp
@@ -154,7 +154,7 @@ class RtlUsb::SampleBuffer : public sigc::trackable
       block_size = new_block_size;
       while (!block_queue.empty())
       {
-        delete block_queue.front();
+        delete [] block_queue.front();
         block_queue.pop();
       }
       delete [] buf;


### PR DESCRIPTION
SampleBuffer::block_queue holds blocks allocated with new uint8_t[block_size].
The dtor, clear() and removeSamples() drain them with delete[], but
setBlockSize() used scalar delete on each queued block. Freeing new[] memory
with scalar delete is undefined behavior (size-cookie/allocator mismatch) and
can corrupt the heap. setBlockSize() runs on a runtime sample-rate change, which
can race the RTL reader thread while blocks are still queued.

Use delete[] to match the array allocation, consistent with the sibling loops.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
