### PR TITLE
async: unpack string fields into a heap buffer, not a stack VLA

### DIFF
--- a/src/async/core/AsyncMsg.h
+++ b/src/async/core/AsyncMsg.h
@@ -428,14 +428,17 @@ class MsgPacker<std::string>
       uint16_t str_len;
       if (MsgPacker<uint16_t>::unpack(is, str_len))
       {
-        if (str_len > std::numeric_limits<uint16_t>::max())
+        if (str_len == 0)
         {
-          return false;
+          val.clear();
+          return true;
         }
-        char buf[str_len];
-        if (is.read(buf, str_len))
+          // Heap buffer sized from the (bounded) wire length -- never a
+          // variable-length array on the stack
+        std::vector<char> buf(str_len);
+        if (is.read(buf.data(), str_len))
         {
-          val.assign(buf, str_len);
+          val.assign(buf.data(), str_len);
           //std::cout << "unpack<string>(" << val << ")" << std::endl;
           return true;
         }


### PR DESCRIPTION
MsgPacker<std::string>::unpack read a uint16_t length off the wire and then
declared char buf[str_len] -- a variable-length array on the stack whose size
is chosen entirely by the peer (up to 65535), so any string field (callsign,
PEM, JSON, error text), even in a small pre-auth frame, could force a ~64 KB
stack allocation per field. The accompanying guard
'str_len > numeric_limits<uint16_t>::max()' is always false (a uint16_t cannot
exceed its own max), so it never bounded anything.

Read into a heap-allocated std::vector<char> instead (str_len is already bounded
to 16 bits), and drop the dead guard. Short reads still fail via the stream
failbit as before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
