### PR TITLE
trx: reject out-of-range mute state instead of looping to it

### DIFF
--- a/src/svxlink/trx/LocalRxBase.cpp
+++ b/src/svxlink/trx/LocalRxBase.cpp
@@ -680,6 +680,14 @@ bool LocalRxBase::initialize(void)
 
 void LocalRxBase::setMuteState(MuteState new_mute_state)
 {
+  if ((new_mute_state < MUTE_NONE) || (new_mute_state > MUTE_ALL))
+  {
+    std::cerr << "*** WARNING: Ignoring out-of-range mute state "
+              << static_cast<int>(new_mute_state) << " for receiver "
+              << name() << std::endl;
+    return;
+  }
+
   auto mute_state = muteState();
 
   //std::cout << "### LocalRxBase::setMuteState[" << name()

--- a/src/svxlink/trx/NetRx.cpp
+++ b/src/svxlink/trx/NetRx.cpp
@@ -236,6 +236,14 @@ bool NetRx::initialize(void)
 
 void NetRx::setMuteState(Rx::MuteState new_mute_state)
 {
+  if ((new_mute_state < MUTE_NONE) || (new_mute_state > MUTE_ALL))
+  {
+    std::cerr << "*** WARNING: Ignoring out-of-range mute state "
+              << static_cast<int>(new_mute_state) << " for receiver "
+              << name() << std::endl;
+    return;
+  }
+
   auto mute_state = muteState();
   while (mute_state != new_mute_state)
   {


### PR DESCRIPTION
Rx::MuteState has three values (MUTE_NONE=0, MUTE_CONTENT=1, MUTE_ALL=2).
Both LocalRxBase::setMuteState and NetRx::setMuteState step one state at a time
in 'while (mute_state != new_mute_state)', guarded only by an assert that is
compiled out under NDEBUG. A remote peer's MsgSetMuteState carries a raw 4-byte
value that reaches LocalRxBase::setMuteState() via NetUplink with no validation:
a large positive value (e.g. 0x7FFFFFFF) spins the loop ~2 billion times (DoS),
and a negative value decrements past INT_MIN (signed overflow, UB).

Validate new_mute_state against the legal range up front and ignore it if out of
range, in both implementations.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
