### PR TITLE
trx/remotetrx: clear reused receive buffer past each message

### DIFF
--- a/src/svxlink/remotetrx/NetUplink.cpp
+++ b/src/svxlink/remotetrx/NetUplink.cpp
@@ -430,6 +430,12 @@ int NetUplink::tcpDataReceived(TcpConnection *con, void *data, int size)
     
     if (recv_cnt == recv_exp)
     {
+        // Clear any bytes past the just-received message so a handler that
+        // casts to a message struct larger than was actually sent reads
+        // zeroes instead of stale bytes left in the reused receive buffer by
+        // a previous (e.g. audio) message.
+      memset(recv_buf + recv_cnt, 0, sizeof(recv_buf) - recv_cnt);
+
       if (recv_exp == sizeof(Msg))
       {
       	Msg *msg = reinterpret_cast<Msg*>(recv_buf);

--- a/src/svxlink/trx/NetTrxTcpClient.cpp
+++ b/src/svxlink/trx/NetTrxTcpClient.cpp
@@ -299,6 +299,12 @@ int NetTrxTcpClient::tcpDataReceived(TcpConnection *con, void *data, int size)
     
     if (recv_cnt == recv_exp)
     {
+        // Clear any bytes past the just-received message so a handler that
+        // casts to a message struct larger than was actually sent reads
+        // zeroes instead of stale bytes left in the reused receive buffer by
+        // a previous (e.g. audio) message.
+      memset(recv_buf + recv_cnt, 0, sizeof(recv_buf) - recv_cnt);
+
       if (recv_exp == sizeof(Msg))
       {
       	Msg *msg = reinterpret_cast<Msg*>(recv_buf);


### PR DESCRIPTION
The NetUplink and NetTrxTcpClient framing loops accumulate messages into a
single 4096-byte recv_buf that is never cleared between messages. A message
whose header declares size() == sizeof(Msg) (or any size smaller than the struct
its type maps to) is dispatched with only those bytes valid; the handler then
reinterpret_casts to the larger message type and reads fixed-offset fields from
whatever the previous (e.g. ~2 KB MsgAudio) message left in the buffer. With an
empty AUTH_KEY this is reachable unauthenticated, yielding attacker-controlled
'stale' reads: bogus signal levels, injected MsgSquelch activity-info strings,
and arbitrary codec options.

Zero the bytes beyond the received message before dispatch, so any read past the
declared length returns deterministic zeroes rather than attacker-controlled
leftovers. (In-bounds of recv_buf throughout; this removes the controllability,
not an OOB access.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
