### PR TITLE
Fix X.509/CSR parsing bugs: OOB read, inverted sign check, stack VLA, leaks

### DIFF
--- a/src/async/core/AsyncSslCertSigningReq.h
+++ b/src/async/core/AsyncSslCertSigningReq.h
@@ -200,6 +200,14 @@ class SslCertSigningReq
      */
     SslCertSigningReq& operator=(SslCertSigningReq& other)
     {
+      if (this == &other)
+      {
+        return *this;
+      }
+      if (m_req != nullptr)
+      {
+        X509_REQ_free(m_req);
+      }
 #if OPENSSL_VERSION_MAJOR >= 3
       m_req = X509_REQ_dup(other);
 #else
@@ -356,27 +364,7 @@ class SslCertSigningReq
      */
     std::string subjectNameString(void) const
     {
-      std::string str;
-      const X509_NAME* nm = subjectName();
-      if (nm != nullptr)
-      {
-        BIO *mem = BIO_new(BIO_s_mem());
-        assert(mem != nullptr);
-          // Print all subject names on one line. Don't escape multibyte chars.
-        int len = X509_NAME_print_ex(mem, nm, 0,
-            XN_FLAG_ONELINE & ~ASN1_STRFLGS_ESC_MSB);
-        if (len > 0)
-        {
-          char buf[len+1];
-          len = BIO_read(mem, buf, sizeof(buf));
-          if (len > 0)
-          {
-            str = std::string(buf, len);
-          }
-        }
-        BIO_free(mem);
-      }
-      return str;
+      return x509NameOnelineString(subjectName());
     }
 
     /**
@@ -406,7 +394,7 @@ class SslCertSigningReq
       {
         X509_NAME_ENTRY *e = X509_NAME_get_entry(subj, lastpos);
         ASN1_STRING *d = X509_NAME_ENTRY_get_data(e);
-        cn = reinterpret_cast<const char*>(ASN1_STRING_get0_data(d));
+        cn = asn1StringToStdString(d);
       }
       return cn;
     }
@@ -467,9 +455,7 @@ class SslCertSigningReq
     {
       assert(m_req != nullptr);
       auto md = EVP_sha256();
-      //auto md_size = EVP_MD_get_size(md);
-      auto md_size = EVP_MD_size(md);
-      return (X509_REQ_sign(m_req, privkey, md) == md_size);
+      return (X509_REQ_sign(m_req, privkey, md) > 0);
     }
 
     /**

--- a/src/async/core/AsyncSslKeypair.h
+++ b/src/async/core/AsyncSslKeypair.h
@@ -44,9 +44,11 @@ An example of how to use the Async::SslKeypair class
 #include <openssl/rsa.h>
 #include <openssl/bn.h>
 #include <openssl/pem.h>
+#include <openssl/x509.h>
 
 #include <cassert>
 #include <string>
+#include <vector>
 
 
 /****************************************************************************
@@ -114,6 +116,56 @@ namespace Async
  ****************************************************************************/
 
 /**
+ * @brief   Convert an ASN1_STRING to a std::string
+ * @param   str The ASN1_STRING to convert
+ * @return  Returns the string data as a std::string
+ *
+ * The data in an ASN1_STRING is not guaranteed to be NUL terminated and may
+ * also contain embedded NUL bytes, both of which would be mishandled by the
+ * std::string(const char*) constructor. This helper instead builds the
+ * string from the data pointer and the explicit length.
+ */
+inline std::string asn1StringToStdString(const ASN1_STRING* str)
+{
+  if (str == nullptr)
+  {
+    return std::string();
+  }
+  const auto* data = ASN1_STRING_get0_data(str);
+  return std::string(reinterpret_cast<const char*>(data),
+                      ASN1_STRING_length(str));
+}
+
+/**
+ * @brief   Get an X509_NAME as a one line, human readable, string
+ * @param   nm The X509_NAME to convert
+ * @return  Returns the name as a string
+ */
+inline std::string x509NameOnelineString(const X509_NAME* nm)
+{
+  std::string str;
+  if (nm != nullptr)
+  {
+    BIO *mem = BIO_new(BIO_s_mem());
+    assert(mem != nullptr);
+      // Print all subject names on one line. Don't escape multibyte chars.
+    int len = X509_NAME_print_ex(mem, nm, 0,
+        XN_FLAG_ONELINE & ~ASN1_STRFLGS_ESC_MSB);
+    if (len > 0)
+    {
+      std::vector<char> buf(len+1);
+      len = BIO_read(mem, buf.data(), buf.size());
+      if (len > 0)
+      {
+        str = std::string(buf.data(), len);
+      }
+    }
+    BIO_free(mem);
+  }
+  return str;
+}
+
+/**
 @brief  A class representing private and public keys
 @author Tobias Blomberg / SM0SVX
 @date   2024-07-11
@@ -165,6 +217,7 @@ class SslKeypair
     SslKeypair& operator=(SslKeypair& other)
     {
       EVP_PKEY_up_ref(other.m_pkey);
+      EVP_PKEY_free(m_pkey);
       m_pkey = other.m_pkey;
       return *this;
     }

--- a/src/async/core/AsyncSslX509.h
+++ b/src/async/core/AsyncSslX509.h
@@ -356,7 +356,7 @@ class SslX509
       {
         X509_NAME_ENTRY *e = X509_NAME_get_entry(subj, lastpos);
         ASN1_STRING *d = X509_NAME_ENTRY_get_data(e);
-        cn = reinterpret_cast<const char*>(ASN1_STRING_get0_data(d));
+        cn = asn1StringToStdString(d);
       }
       return cn;
     }
@@ -755,27 +755,7 @@ class SslX509
      */
     std::string issuerNameString(void) const
     {
-      std::string str;
-      const X509_NAME* nm = issuerName();
-      if (nm != nullptr)
-      {
-        BIO *mem = BIO_new(BIO_s_mem());
-        assert(mem != nullptr);
-          // Print all subject names on one line. Don't escape multibyte chars.
-        int len = X509_NAME_print_ex(mem, nm, 0,
-            XN_FLAG_ONELINE & ~ASN1_STRFLGS_ESC_MSB);
-        if (len > 0)
-        {
-          char buf[len+1];
-          len = BIO_read(mem, buf, sizeof(buf));
-          if (len > 0)
-          {
-            str = std::string(buf, len);
-          }
-        }
-        BIO_free(mem);
-      }
-      return str;
+      return x509NameOnelineString(issuerName());
     }
 
     /**
@@ -784,27 +764,7 @@ class SslX509
      */
     std::string subjectNameString(void) const
     {
-      std::string str;
-      const X509_NAME* nm = subjectName();
-      if (nm != nullptr)
-      {
-        BIO *mem = BIO_new(BIO_s_mem());
-        assert(mem != nullptr);
-          // Print all subject names on one line. Don't escape multibyte chars.
-        int len = X509_NAME_print_ex(mem, nm, 0,
-            XN_FLAG_ONELINE & ~ASN1_STRFLGS_ESC_MSB);
-        if (len > 0)
-        {
-          char buf[len+1];
-          len = BIO_read(mem, buf, sizeof(buf));
-          if (len > 0)
-          {
-            str = std::string(buf, len);
-          }
-        }
-        BIO_free(mem);
-      }
-      return str;
+      return x509NameOnelineString(subjectName());
     }
 
     /**
@@ -848,8 +808,7 @@ class SslX509
     bool sign(SslKeypair& pkey)
     {
       auto md = EVP_sha256();
-      auto md_size = EVP_MD_size(md);
-      return (X509_sign(m_cert, pkey, md) != md_size);
+      return (X509_sign(m_cert, pkey, md) > 0);
     }
 
     /**


### PR DESCRIPTION
- SslX509::commonName() and SslCertSigningReq::commonName() built the CN
  from ASN1_STRING_get0_data() via the std::string(const char*)
  constructor, which relies on strlen() and ignores the ASN1_STRING's
  explicit length. A parsed DN field is not guaranteed to be NUL
  terminated and may contain an embedded NUL, letting a crafted cert/CSR
  truncate or overrun the resulting common name. Added a shared
  asn1StringToStdString() helper that builds the string from the data
  pointer and ASN1_STRING_length(), and used it in both places.

- SslX509::sign() compared the return value of X509_sign() against the
  digest size (X509_sign(...) != md_size), but X509_sign() returns the
  signature length (e.g. 256 for RSA-2048) on success and 0 on failure -
  it never equals the digest size. This inverted the success/failure
  result, so a failed signing operation was reported as success.
  SslCertSigningReq::sign() had the same bug for X509_REQ_sign(). Both
  now check for a positive return value.

- SslX509::issuerNameString()/subjectNameString() and
  SslCertSigningReq::subjectNameString() sized a stack buffer with
  `char buf[len+1]` where len comes from X509_NAME_print_ex() on
  attacker-controlled DN content, allowing a certificate/CSR with a very
  long subject or issuer name to trigger an unbounded stack allocation.
  Factored the duplicated printing logic into a shared
  x509NameOnelineString() helper that uses a heap-backed std::vector<char>
  instead of a variable-length array.

- SslCertSigningReq::operator=(SslCertSigningReq&) and
  SslKeypair::operator=(SslKeypair&) reassigned their underlying OpenSSL
  handle (m_req / m_pkey) without freeing the previous one, leaking the
  X509_REQ/EVP_PKEY held by the left-hand side whenever it was assigned
  over. Both now free the prior handle before taking the new one.
  SslCertSigningReq's assignment also guards against self-assignment
  (`csr = csr`), since freeing m_req before X509_REQ_dup(other) would
  otherwise dup from freed memory when other aliases *this.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>