### PR TITLE
trx: fix remote OOB read in NetTrx message string accessors

### DIFF
--- a/src/svxlink/trx/NetTrxMsg.h
+++ b/src/svxlink/trx/NetTrxMsg.h
@@ -374,8 +374,17 @@ class MsgAudioCodecSelect : public Msg
       }
     }
     
-    const char *name(void) const { return m_codec_name; }
-  
+    std::string name(void) const
+    {
+      const char *end = reinterpret_cast<const char*>(
+          std::memchr(m_codec_name, 0, sizeof(m_codec_name)));
+      if (end == NULL)
+      {
+        end = m_codec_name+sizeof(m_codec_name);
+      }
+      return std::string(m_codec_name, end);
+    }
+
   private:
     char    m_codec_name[32];
     uint8_t m_option_cnt;
@@ -585,7 +594,16 @@ class MsgSel5 : public Msg
       m_digits[MAX_DIGITS] = 0;
       setSize(size() - MAX_DIGITS + strlen(m_digits));
     }
-    std::string digits(void) const { return m_digits; }
+    std::string digits(void) const
+    {
+      const char *end = reinterpret_cast<const char*>(
+          std::memchr(m_digits, 0, MAX_DIGITS));
+      if (end == NULL)
+      {
+        end = m_digits+MAX_DIGITS;
+      }
+      return std::string(m_digits, end);
+    }
 
   private:
     char m_digits[MAX_DIGITS + 1];
@@ -652,7 +670,16 @@ class MsgSendDtmf : public Msg
       m_digits[MAX_DIGITS] = 0;
       setSize(size() - MAX_DIGITS + strlen(m_digits));
     }
-    std::string digits(void) const { return m_digits; }
+    std::string digits(void) const
+    {
+      const char *end = reinterpret_cast<const char*>(
+          std::memchr(m_digits, 0, MAX_DIGITS));
+      if (end == NULL)
+      {
+        end = m_digits+MAX_DIGITS;
+      }
+      return std::string(m_digits, end);
+    }
     unsigned duration(void) const { return m_duration; }
   
   private:


### PR DESCRIPTION
The NetTrx message structs are reinterpret_cast directly from the
network recv buffer on the receive side, so their constructors (which
NUL-terminate the fixed char arrays) never run. Several accessors built
a std::string / returned a const char* from a fixed char array without
bounding the read to the array size, relying on the sender to have
NUL-terminated the buffer. A malicious or corrupt peer can fill the
entire array with non-NUL bytes, causing the const char* -> std::string
conversion (or downstream C-string use) to read PAST the array into
adjacent recv-buffer memory until a NUL is found -- an out-of-bounds
read (stale-buffer info disclosure, or a crash if no NUL precedes the
end of the buffer).

Fix MsgSel5::digits(), MsgSendDtmf::digits() and
MsgAudioCodecSelect::name() to use the same bounded std::memchr pattern
already used safely by MsgSquelch::sqlActivityInfo(), so the read can
never exceed the array bound. MsgAudioCodecSelect::name() now returns a
std::string (was const char*); all callers already use it as a string
(passed to AudioEncoder/Decoder::create(const std::string&) and streamed
to cout), so the change is source-compatible and builds clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>