### PR TITLE
reflector: guard against empty received TCP frame

### DIFF
--- a/src/svxlink/svxlink/ReflectorLogic.cpp
+++ b/src/svxlink/svxlink/ReflectorLogic.cpp
@@ -1114,6 +1114,13 @@ void ReflectorLogic::onFrameReceived(FramedTcpConnection*,
 {
   //std::cout << "### ReflectorLogic::onFrameReceived: data.size()="
   //          << data.size() << std::endl;
+  if (data.empty())
+  {
+    std::cerr << "*** ERROR[" << name()
+              << "]: Received an empty TCP frame" << std::endl;
+    disconnect();
+    return;
+  }
   char *buf = reinterpret_cast<char*>(&data.front());
   int len = data.size();
 

--- a/src/svxlink/svxlink/ReflectorV2Logic.cpp
+++ b/src/svxlink/svxlink/ReflectorV2Logic.cpp
@@ -834,6 +834,13 @@ void ReflectorLogic::onDisconnected(TcpConnection *con,
 void ReflectorLogic::onFrameReceived(FramedTcpConnection *con,
                                      std::vector<uint8_t>& data)
 {
+  if (data.empty())
+  {
+    std::cerr << "*** ERROR[" << name()
+              << "]: Received an empty TCP frame" << std::endl;
+    disconnect();
+    return;
+  }
   char *buf = reinterpret_cast<char*>(&data.front());
   int len = data.size();
 


### PR DESCRIPTION
Fixes #827.

ReflectorLogic::onFrameReceived() (both the v1 and v2 reflector client logic) dereferenced &data.front() on the received frame vector without first checking it was non-empty. The framing layer accepts a zero-length framed payload (only the maximum size is bounded), so an empty frame makes &data.front() undefined behavior. Add a data.empty() guard that logs an error and disconnects.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>