### PR TITLE
ModuleEchoLink: reset stale reject_qso flag when reusing a QSO object

### DIFF
--- a/src/svxlink/modules/echolink/ModuleEchoLink.cpp
+++ b/src/svxlink/modules/echolink/ModuleEchoLink.cpp
@@ -1423,6 +1423,14 @@ void ModuleEchoLink::createOutgoingConnection(const StationData &station)
 	processEvent(ss.str());
 	return;
       }
+      if ((*it)->connectionRejected())
+      {
+        // Do not reuse a QSO object that carries a stale reject_qso flag
+        // from a previous rejection. Fall through and create a fresh
+        // object instead so that the new outgoing connection is not
+        // silently suppressed.
+        break;
+      }
       qso = *it;
       qsos.erase(it);
       qsos.push_back(qso);


### PR DESCRIPTION
When a previously disconnected QSO object for a callsign is reused for
a new outgoing connection, its reject_qso flag could still be set from
an earlier rejection. This caused the new connection attempt to be
silently suppressed. Detect a stale reject_qso flag and fall through
to creating a fresh QSO object instead of reusing the stale one.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>