### PR TITLE
ModuleEchoLink: index disconnect-by-call against the displayed QSO list

### DIFF
--- a/src/svxlink/modules/echolink/ModuleEchoLink.cpp
+++ b/src/svxlink/modules/echolink/ModuleEchoLink.cpp
@@ -109,6 +109,26 @@ using namespace EchoLink;
  ****************************************************************************/
 
 
+namespace {
+  // Return the QSOs that are selectable for "disconnect by call", in the
+  // same order as they are presented to the user. Disconnected QSOs are
+  // excluded since they are not part of the numbered selection list, so
+  // this function must be used both when rendering the list and when
+  // resolving the user's numeric selection to keep the two in sync.
+  vector<QsoImpl*> dbcSelectableQsos(const vector<QsoImpl*>& qsos)
+  {
+    vector<QsoImpl*> selectable;
+    for (vector<QsoImpl*>::const_iterator it = qsos.begin();
+         it != qsos.end(); ++it)
+    {
+      if ((*it)->currentState() != Qso::STATE_DISCONNECTED)
+      {
+        selectable.push_back(*it);
+      }
+    }
+    return selectable;
+  }
+};
 
 
 /****************************************************************************
@@ -1735,15 +1755,13 @@ void ModuleEchoLink::disconnectByCallsign(const string &cmd)
     return;
   }
 
+  vector<QsoImpl*> selectable(dbcSelectableQsos(qsos));
   stringstream ss;
   ss << "dbc_list [list";
   vector<QsoImpl*>::iterator it;
-  for (it=qsos.begin(); it!=qsos.end(); ++it)
+  for (it=selectable.begin(); it!=selectable.end(); ++it)
   {
-    if ((*it)->currentState() != Qso::STATE_DISCONNECTED)
-    {
-    	ss << " " << (*it)->remoteCallsign();
-    }
+    ss << " " << (*it)->remoteCallsign();
   }
   ss << "]";
   processEvent(ss.str());
@@ -1766,13 +1784,14 @@ void ModuleEchoLink::handleDisconnectByCall(const string& cmd)
   }
   
   unsigned idx = static_cast<unsigned>(atoi(cmd.c_str()));
+  vector<QsoImpl*> selectable(dbcSelectableQsos(qsos));
   stringstream ss;
 
   if (idx == 0)
   {
     ss << "dbc_list [list";
     vector<QsoImpl*>::const_iterator it;
-    for (it = qsos.begin(); it != qsos.end(); ++it)
+    for (it = selectable.begin(); it != selectable.end(); ++it)
     {
       ss << " " << (*it)->remoteCallsign();
     }
@@ -1782,7 +1801,7 @@ void ModuleEchoLink::handleDisconnectByCall(const string& cmd)
     return;
   }
 
-  if (idx > qsos.size())
+  if (idx > selectable.size())
   {
     ss << "dbc_index_out_of_range " << idx;
     processEvent(ss.str());
@@ -1790,7 +1809,7 @@ void ModuleEchoLink::handleDisconnectByCall(const string& cmd)
     return;
   }
 
-  qsos[idx-1]->disconnect();
+  selectable[idx-1]->disconnect();
   delete dbc_timer;
   dbc_timer = 0;
   state = STATE_NORMAL;


### PR DESCRIPTION
The "disconnect by call" flow displayed a filtered list of selectable
(non-disconnected) QSOs to the user, but resolved the operator's
numeric selection against the unfiltered qsos vector. If a disconnected
QSO object was present in qsos, the indices no longer matched, so the
wrong connection could be disconnected. Introduce a dbcSelectableQsos
helper that builds the same filtered list used for both display and
index resolution, keeping them in sync.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>