### PR TITLE
Reflector: guard UDP/TCP heartbeat tx counters against unsigned underflow (v1 and v2)

### DIFF
--- a/src/svxlink/svxlink/ReflectorLogic.cpp
+++ b/src/svxlink/svxlink/ReflectorLogic.cpp
@@ -2347,7 +2347,11 @@ void ReflectorLogic::handleTimerTick(Async::Timer *t)
     }
   }
 
-  if (--m_udp_heartbeat_tx_cnt == 0)
+  if (m_udp_heartbeat_tx_cnt > 0)
+  {
+    --m_udp_heartbeat_tx_cnt;
+  }
+  if (m_udp_heartbeat_tx_cnt == 0)
   {
     if (m_con_state == STATE_EXPECT_UDP_HEARTBEAT)
     {
@@ -2359,7 +2363,11 @@ void ReflectorLogic::handleTimerTick(Async::Timer *t)
     }
   }
 
-  if (--m_tcp_heartbeat_tx_cnt == 0)
+  if (m_tcp_heartbeat_tx_cnt > 0)
+  {
+    --m_tcp_heartbeat_tx_cnt;
+  }
+  if (m_tcp_heartbeat_tx_cnt == 0)
   {
     sendMsg(MsgHeartbeat());
   }

--- a/src/svxlink/svxlink/ReflectorV2Logic.cpp
+++ b/src/svxlink/svxlink/ReflectorV2Logic.cpp
@@ -1552,7 +1552,11 @@ void ReflectorLogic::handleTimerTick(Async::Timer *t)
     }
   }
 
-  if (--m_udp_heartbeat_tx_cnt == 0)
+  if (m_udp_heartbeat_tx_cnt > 0)
+  {
+    --m_udp_heartbeat_tx_cnt;
+  }
+  if (m_udp_heartbeat_tx_cnt == 0)
   {
     sendUdpMsg(MsgUdpHeartbeat());
   }

--- a/src/svxlink/svxlink/ReflectorV2Logic.cpp
+++ b/src/svxlink/svxlink/ReflectorV2Logic.cpp
@@ -1554,12 +1554,20 @@ void ReflectorLogic::handleTimerTick(Async::Timer *t)
     }
   }
 
-  if (--m_udp_heartbeat_tx_cnt == 0)
+  if (m_udp_heartbeat_tx_cnt > 0)
+  {
+    --m_udp_heartbeat_tx_cnt;
+  }
+  if (m_udp_heartbeat_tx_cnt == 0)
   {
     sendUdpMsg(MsgUdpHeartbeat());
   }
 
-  if (--m_tcp_heartbeat_tx_cnt == 0)
+  if (m_tcp_heartbeat_tx_cnt > 0)
+  {
+    --m_tcp_heartbeat_tx_cnt;
+  }
+  if (m_tcp_heartbeat_tx_cnt == 0)
   {
     sendMsg(MsgHeartbeat());
   }


### PR DESCRIPTION
Fixes #829.

The heartbeat transmit counters were decremented unconditionally with `if (--cnt == 0)`. Each counter is only reset inside its send path (`sendUdpMsg()` / `sendMsg()`), which can return early or take a send-nothing branch without resetting the counter. If a counter reaches 0 while sends are suppressed (e.g. the UDP counter reaching 0 while neither `STATE_EXPECT_UDP_HEARTBEAT` nor logged in, and `sendUdpMsg()` returning early when not logged in), the next tick decrements 0 and the unsigned counter wraps to a huge value, stalling heartbeats far longer than intended.

This guards each decrement (only decrement while the counter is still positive) at **all four** transmit-counter sites:

- `ReflectorLogic.cpp` (v1) — UDP and TCP tx counters
- `ReflectorV2Logic.cpp` (v2) — UDP and TCP tx counters

_(Expanded from the original single-site v2-UDP fix to cover all four sites, per the discussion in #829.)_
