### PR TITLE
Fix file descriptor leaks and unsafe exec in Async::Exec

### DIFF
--- a/src/async/core/AsyncExec.cpp
+++ b/src/async/core/AsyncExec.cpp
@@ -91,6 +91,27 @@ using namespace Async;
  *
  ****************************************************************************/
 
+namespace {
+
+/**
+ * @brief   Close a set of file descriptors, ignoring invalid ones
+ * @param   fds The file descriptors to close
+ *
+ * Helper used to release pipe file descriptors that were already
+ * successfully opened when a later step of Exec::run fails.
+ */
+void closeFds(std::initializer_list<int> fds)
+{
+  for (int fd : fds)
+  {
+    if (fd >= 0)
+    {
+      close(fd);
+    }
+  }
+} /* closeFds */
+
+}; // anonymous namespace
 
 
 /****************************************************************************
@@ -263,6 +284,13 @@ void Exec::setTimeout(int time_s)
 
 bool Exec::run(void)
 {
+  if (args.empty())
+  {
+    cerr << "*** ERROR: Cannot execute subprocess with an empty "
+            "command line\n";
+    return false;
+  }
+
     // Create pipe file descriptor pair for handling stdin to subprocess
   int in_filedes[2];
   int ret = pipe(in_filedes);
@@ -280,6 +308,7 @@ bool Exec::run(void)
   {
     cerr << "*** ERROR: Could not set up stdout pipe for subprocess "
          << args[0] << ": " << strerror(errno) << endl;
+    closeFds({in_filedes[0], in_filedes[1]});
     return false;
   }
 
@@ -290,6 +319,7 @@ bool Exec::run(void)
   {
     cerr << "*** ERROR: Could not set up stderr pipe for subprocess "
          << args[0] << ": " << strerror(errno) << endl;
+    closeFds({in_filedes[0], in_filedes[1], out_filedes[0], out_filedes[1]});
     return false;
   }
 
@@ -298,6 +328,8 @@ bool Exec::run(void)
   {
     cerr << "*** ERROR: The fork system call failed for subprocess "
          << args[0] << ": " << strerror(errno) << endl;
+    closeFds({in_filedes[0], in_filedes[1], out_filedes[0], out_filedes[1],
+              err_filedes[0], err_filedes[1]});
     return false;
   }
 
@@ -420,7 +452,13 @@ bool Exec::kill(int sig)
 
 bool Exec::closeStdin(void)
 {
-  return (close(stdin_fd) == 0);
+  if (stdin_fd == -1)
+  {
+    return true;
+  }
+  bool success = (close(stdin_fd) == 0);
+  stdin_fd = -1;
+  return success;
 } /* Exec::closeStdin */
 
 

--- a/src/async/core/AsyncExecTest.cpp
+++ b/src/async/core/AsyncExecTest.cpp
@@ -1,0 +1,140 @@
+/**
+@file    AsyncExecTest.cpp
+@brief   Unit test for Async::Exec fd-leak and exec-safety fixes
+@author  Mark Rose
+@date    2026-07-11
+
+Exercises three defects fixed together in Async::Exec:
+
+ 1. run() used to proceed with an empty command line, leading the child
+    process to execv() a NULL path and the parent to read args[0] on an
+    empty vector. run() must now reject an empty command line and return
+    false without forking.
+
+ 2. closeStdin() used to close(stdin_fd) without resetting stdin_fd to -1,
+    so a second call (or the destructor) would close the same fd number
+    again. Once a subsequent open/pipe/dup recycles that fd number, this
+    second close() silently closes an unrelated file descriptor. This test
+    calls closeStdin() twice and requires the second call to be a no-op
+    that still reports success, proving stdin_fd was reset.
+
+ 3. run() used to leak the stdin (and stdout) pipe file descriptors it had
+    already opened whenever a later pipe() call failed. This test lowers
+    RLIMIT_NOFILE so that the stdin pipe succeeds but the stdout pipe fails,
+    then verifies the fd budget freed up by the failed run() is available
+    again -- i.e. the stdin pipe's fds were closed rather than leaked.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/resource.h>
+
+#include <iostream>
+#include <string>
+
+#include <AsyncCppApplication.h>
+#include <AsyncExec.h>
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+  // Return the fd number that the next open() call would hand out. Per
+  // POSIX, open() always returns the lowest-numbered fd not currently open
+  // for the process, so this is deterministic.
+int nextFreeFd(void)
+{
+  int fd = open("/dev/null", O_RDONLY);
+  if (fd >= 0)
+  {
+    close(fd);
+  }
+  return fd;
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  CppApplication app;
+
+    // --- Defect 1: empty command line must be rejected, not forked ---
+  {
+    Exec e("");
+    check(!e.run(), "run() rejects an empty command line");
+  }
+
+    // --- Defect 2: closeStdin() must be idempotent ---
+  {
+    Exec e("/no/such/command-for-async-exec-test");
+    check(e.run(), "run() succeeds (fork only, exec failure is async)");
+    check(e.closeStdin(), "first closeStdin() closes the pipe");
+    check(e.closeStdin(),
+          "second closeStdin() is a no-op that still reports success "
+          "(stdin_fd was reset to -1)");
+    e.kill(SIGKILL);
+  }
+
+    // --- Defect 3: a failed run() must not leak the fds it already
+    //     opened before the failure ---
+  {
+    struct rlimit orig_rl;
+    check(getrlimit(RLIMIT_NOFILE, &orig_rl) == 0, "getrlimit succeeds");
+
+    int free_fd = nextFreeFd();
+    check(free_fd >= 0, "could determine next free fd");
+
+      // Allow exactly two more fds to be opened (one pipe's worth). The
+      // stdin pipe in run() will consume them; the following stdout pipe
+      // will then fail with EMFILE.
+    struct rlimit limited_rl = orig_rl;
+    limited_rl.rlim_cur = free_fd + 2;
+    check(setrlimit(RLIMIT_NOFILE, &limited_rl) == 0,
+          "setrlimit lowers the fd budget");
+
+    Exec e("/no/such/command-for-async-exec-test-2");
+    bool run_result = e.run();
+
+      // Restore the fd budget before making any more assertions so the
+      // test process itself doesn't get wedged if something goes wrong.
+    setrlimit(RLIMIT_NOFILE, &orig_rl);
+
+    check(!run_result,
+          "run() fails when the second pipe() call hits the fd limit");
+
+      // If the stdin pipe's fds were leaked, "free_fd" and "free_fd+1" are
+      // still in use, so the next allocation would be free_fd+2 or higher.
+      // With the fix, run() closed them on the failure path, so the next
+      // free fd is back to what it was before run() was called.
+    int free_fd_after = nextFreeFd();
+    check(free_fd_after == free_fd,
+          "failed run() releases the pipe fds it had already opened "
+          "(no fd leak)");
+  }
+
+  cout << (failures == 0 ? "ALL TESTS PASSED" : "TESTS FAILED") << endl;
+  return failures != 0;
+} /* main */

--- a/src/async/core/AsyncExecTest.deps.cmake
+++ b/src/async/core/AsyncExecTest.deps.cmake
@@ -1,0 +1,4 @@
+# Exec's constructor sets up an Async::FdWatch (for the SIGCHLD pipe),
+# which requires an Async::Application instance to exist. Link asynccpp
+# for Async::CppApplication.
+set(AsyncExecTest_EXTRA_LIBS asynccpp)


### PR DESCRIPTION
- Exec::closeStdin() closed stdin_fd but never reset it to -1, so the
  destructor would close it a second time, potentially closing an
  unrelated fd that had since been recycled by the OS. closeStdin() now
  sets stdin_fd to -1 after closing (and is a no-op if already closed).
- Exec::run() leaked the stdin/stdout/stderr pipe file descriptors it
  had already opened whenever a later pipe() or fork() call failed
  (2, 4, or 6 leaked fds depending on which call failed). Added a small
  helper that closes a set of fds and call it on each failure path so
  already-opened pipes are released before returning.
- Exec::run() did not validate the command line before use. With an
  empty command line, the child process would call execv() with a NULL
  path and later code would read args[0] on an empty vector (undefined
  behavior). run() now rejects an empty command line up front and
  returns false instead of proceeding.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---
This PR also adds a unit test (`AsyncExecTest.cpp`). It is auto-discovered and executed by the CTest suite proposed in #762 once that is merged; without that suite present the test file is inert and does not affect the build.
