### PR TITLE
Fix subnet mask computation in IpAddress::isWithinSubet

### DIFF
--- a/src/async/core/AsyncIpAddress.cpp
+++ b/src/async/core/AsyncIpAddress.cpp
@@ -41,7 +41,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#include <cmath>
+#include <cstdlib>
 #include <algorithm>
 
 
@@ -88,6 +88,40 @@ using namespace Async;
  *
  ****************************************************************************/
 
+namespace {
+
+
+/****************************************************************************
+ *
+ * Local functions
+ *
+ ****************************************************************************/
+
+  /**
+   * @brief   Parse a netmask prefix length (0-32) into a 32 bit mask
+   * @param   prefix_str The prefix length as a string, e.g. "24"
+   * @param   mask       Set to the resulting network byte order mask
+   * @return  Return \em true if the prefix was valid, otherwise \em false
+   *
+   * The mask is computed using integer shifts only, avoiding the undefined
+   * behaviour that comes from converting an out of range double, produced
+   * by a bad or out of range prefix, to an integer type.
+   */
+  bool parseNetmaskPrefix(const std::string& prefix_str, uint32_t& mask)
+  {
+    char *endptr = 0;
+    long prefix = strtol(prefix_str.c_str(), &endptr, 10);
+    if ((endptr == prefix_str.c_str()) || (*endptr != '\0') ||
+        (prefix < 0) || (prefix > 32))
+    {
+      return false;
+    }
+    mask = (prefix == 0) ? 0 : (0xffffffffU << (32 - prefix));
+    return true;
+  } /* parseNetmaskPrefix */
+
+
+}; /* End of anonymous namespace */
 
 
 /****************************************************************************
@@ -186,7 +220,11 @@ bool IpAddress::isWithinSubet(const std::string& subnet) const
     return false;
   }
   string mask_str(slash, subnet.end());
-  uint32_t mask = 0xffffffff ^ ((uint32_t)pow(2.0, 32-atoi(mask_str.c_str())) - 1);
+  uint32_t mask;
+  if (!parseNetmaskPrefix(mask_str, mask))
+  {
+    return false;
+  }
 
   return (ntohl(m_addr.s_addr) & mask) == (ntohl(ip.s_addr) & mask);
  

--- a/src/async/core/IpAddressTest.cpp
+++ b/src/async/core/IpAddressTest.cpp
@@ -1,0 +1,87 @@
+/**
+@file    IpAddressTest.cpp
+@brief   Unit test for IpAddress::isWithinSubet() netmask prefix validation
+@author  Mark Rose
+@date    2026-07-11
+
+IpAddress::isWithinSubet() parses a "<ip>/<prefix>" subnet specification. The
+prefix used to be turned into a mask via atoi() and pow(2.0, 32-prefix) with
+no validation. A non-numeric or out-of-range prefix (e.g. "/x", "/33", "/-1")
+made that computation collapse to a mask of 0, which matches every address --
+silently turning an ALLOW_IP/subnet check into an "allow all" rule. This test
+verifies that a malformed prefix is now rejected (isWithinSubet() returns
+false) instead of failing open, while valid prefixes still behave correctly.
+
+\verbatim
+SvxLink - A Multi Purpose Voice Services System for Ham Radio Use
+Copyright (C) 2026 Tobias Blomberg / SM0SVX
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#include <iostream>
+#include <string>
+
+#include "AsyncIpAddress.h"
+
+using namespace std;
+using namespace Async;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const string& msg)
+{
+  cout << (cond ? "  ok   " : "  FAIL ") << msg << endl;
+  if (!cond)
+  {
+    ++failures;
+  }
+}
+
+} /* anonymous namespace */
+
+
+int main(void)
+{
+  IpAddress addr("192.168.1.50");
+
+    // A malformed (non-numeric) prefix must not fail open and match
+    // every address.
+  check(!addr.isWithinSubet("10.0.0.0/x"),
+        "non-numeric prefix does not match (fails closed)");
+
+    // Out of range prefixes must likewise be rejected.
+  check(!addr.isWithinSubet("192.168.1.0/33"),
+        "prefix > 32 does not match (fails closed)");
+  check(!addr.isWithinSubet("192.168.1.0/-1"),
+        "negative prefix does not match (fails closed)");
+
+    // Trailing garbage after a numeric prefix must be rejected too.
+  check(!addr.isWithinSubet("192.168.1.0/24abc"),
+        "prefix with trailing garbage does not match (fails closed)");
+
+    // A completely unrelated network with a malformed prefix must not
+    // match either -- this is the "allow all" failure mode of the bug.
+  check(!addr.isWithinSubet("8.8.8.8/x"),
+        "unrelated network with bad prefix does not match");
+
+    // Sanity: valid prefixes still work correctly, both inside and
+    // outside the subnet.
+  check(addr.isWithinSubet("192.168.1.0/24"),
+        "address within valid /24 subnet matches");
+  check(!addr.isWithinSubet("192.168.2.0/24"),
+        "address outside valid /24 subnet does not match");
+  check(addr.isWithinSubet("192.168.1.48/30"),
+        "address within valid /30 subnet matches");
+  check(addr.isWithinSubet("0.0.0.0/0"),
+        "prefix /0 matches everything as expected");
+
+  cout << (failures == 0 ? "ALL TESTS PASSED" : "TESTS FAILED") << endl;
+  return failures != 0;
+} /* main */


### PR DESCRIPTION
IpAddress::isWithinSubet() computed the netmask from the CIDR prefix
length using `atoi()` and `pow(2.0, 32 - prefix)`, with no validation
that the prefix was a valid number in the 0-32 range:

- A non-numeric prefix (e.g. "10.0.0.0/x") makes atoi() return 0,
  so pow(2.0, 32) overflows a uint32_t and the resulting mask
  collapses to 0.
- An out-of-range prefix such as /33 or a negative value produces a
  negative exponent, which similarly yields a mask of 0 once cast to
  uint32_t (undefined behaviour on the out-of-range double-to-integer
  conversion).

A mask of 0 makes isWithinSubet() match every address, silently
turning an ALLOW_IP/subnet check into an "allow all" rule when the
configured prefix is malformed.

Replaced the computation with a small helper, parseNetmaskPrefix(),
that parses the prefix with strtol(), rejects anything outside 0-32
or with trailing garbage, and builds the mask with a plain integer
shift instead of floating point exponentiation. isWithinSubet() now
returns false (no match) for an invalid prefix instead of failing
open.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---
This PR also adds a unit test (`IpAddressTest.cpp`). It is auto-discovered and executed by the CTest suite proposed in #762 once that is merged; without that suite present the test file is inert and does not affect the build.
