### PR TITLE
Fix CmdParser::removeCmd erasing the wrong command on duplicate IDs

### DIFF
--- a/src/svxlink/svxlink/CmdParser.cpp
+++ b/src/svxlink/svxlink/CmdParser.cpp
@@ -135,7 +135,7 @@ bool CmdParser::addCmd(Command *cmd)
 bool CmdParser::removeCmd(Command *cmd)
 {
   CmdMap::iterator cmd_it = cmds.find(cmd->cmdStr());
-  bool cmd_exist = (cmd_it != cmds.end());
+  bool cmd_exist = (cmd_it != cmds.end()) && (cmd_it->second == cmd);
   if (cmd_exist)
   {
     cmds.erase(cmd_it);


### PR DESCRIPTION
- CmdParser::removeCmd() looked up the map entry to erase by command
  string only, without checking that the stored pointer matched the
  Command being removed. addCmd() refuses to overwrite an existing
  entry when two commands share the same command string, so the
  duplicate is never stored in the map. However, when that rejected
  duplicate is later deleted, its destructor calls removeCmd(this),
  which found the map entry by string, matched the *original*
  still-in-use command, and erased it. This silently unregistered a
  live command from the parser, leaving processCmd() unable to reach
  it anymore. Fixed by also comparing the mapped pointer against the
  Command instance being removed before erasing, so removeCmd() only
  ever removes its own entry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

