### PR TITLE
Fix crash and per-event recompile of ACTIVATE_ON_TG regex in LinkManager

### DIFF
--- a/src/svxlink/svxlink/LinkManager.cpp
+++ b/src/svxlink/svxlink/LinkManager.cpp
@@ -118,6 +118,53 @@ namespace
  ****************************************************************************/
 
 
+
+/****************************************************************************
+ *
+ * Local functions
+ *
+ ****************************************************************************/
+
+/**
+ * @brief   Compile and cache an ACTIVATE_ON_TG regex pattern
+ * @param   link_name The name of the link that the pattern belongs to
+ * @param   logic_name The name of the logic that the pattern belongs to
+ * @param   pattern The regex pattern, as read from the configuration
+ * @return  Return a pointer to the compiled regex or 0 if the pattern is
+ *          invalid
+ *
+ * The regex patterns configured through ACTIVATE_ON_TG are compiled once
+ * and cached here, keyed on link and logic name, instead of being rebuilt
+ * on every received TG update event. This also means that an invalid
+ * pattern is only ever reported and handled once instead of throwing
+ * std::regex_error out of the receivedTgUpdated signal handler.
+ */
+const std::regex *cachedTgRegex(const std::string &link_name,
+                                 const std::string &logic_name,
+                                 const std::string &pattern)
+{
+  static std::map<std::pair<std::string, std::string>, std::regex> cache;
+  auto key = std::make_pair(link_name, logic_name);
+  auto it = cache.find(key);
+  if (it != cache.end())
+  {
+    return &it->second;
+  }
+  try
+  {
+    auto res = cache.emplace(key, std::regex(pattern));
+    return &res.first->second;
+  }
+  catch (const std::regex_error &e)
+  {
+    cerr << "*** ERROR: Invalid ACTIVATE_ON_TG pattern \"" << pattern
+         << "\" for logic \"" << logic_name << "\" in link \"" << link_name
+         << "\": " << e.what() << endl;
+    return 0;
+  }
+} /* cachedTgRegex */
+
+
 } // End of anonymous namespace
 
 /****************************************************************************
@@ -250,6 +297,17 @@ bool LinkManager::initialize(Async::Config &cfg,
         std::cerr << "*** WARNING: Missing configuration " << link.name
                   << "/TIMEOUT=??, setting to default (30 sec)" << std::endl;
         timeout = 30;
+      }
+
+        // Validate and precompile the ACTIVATE_ON_TG regex patterns here so
+        // that an invalid pattern is caught at configuration time instead of
+        // crashing the application when the first TG update event arrives.
+      for (const auto &item : link.auto_activate_on_tg)
+      {
+        if (cachedTgRegex(link.name, item.first, item.second) == 0)
+        {
+          init_ok = false;
+        }
       }
     }
 
@@ -965,10 +1023,12 @@ void LinkManager::onReceivedTgUpdated(LogicBase *src_logic, uint32_t tg)
     std::ostringstream tgss;
     tgss << tg;
     auto aait = link.auto_activate_on_tg.find(src_logic->name());
-    if (!link.is_activated &&
+    const std::regex *tg_regex =
+        (!link.is_activated && aait != link.auto_activate_on_tg.end())
+        ? cachedTgRegex(link.name, aait->first, aait->second) : 0;
+    if (tg_regex != 0 &&
         //(link.logic_props.find( != link.logic_props.end()) &&
-        aait != link.auto_activate_on_tg.end() &&
-        std::regex_match(tgss.str(), std::regex(aait->second)))
+        std::regex_match(tgss.str(), *tg_regex))
     {
       std::ostringstream ss;
       ss << "ACTIVATE_ON_TG from logic '"


### PR DESCRIPTION
- LinkManager::onReceivedTgUpdated built a new std::regex from the
  ACTIVATE_ON_TG configuration string on every received TG update event.
  An invalid regex pattern therefore threw std::regex_error from inside
  the receivedTgUpdated signal handler, which is never caught, causing
  svxlink to terminate. It was also wastefully recompiled on every event
  even when the pattern was valid.

  Patterns are now compiled once and cached (keyed by link and logic
  name) the first time they are needed. LinkManager::initialize() now
  eagerly compiles and validates every ACTIVATE_ON_TG pattern while
  reading the configuration, reporting an error and failing
  initialization for any invalid pattern instead of letting it surface
  later as a runtime crash. onReceivedTgUpdated reuses the cached,
  already-validated regex instead of rebuilding it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

