### PR TITLE
Fix out-of-bounds read parsing SERIAL_SET_PINS with a truncated token

### DIFF
--- a/src/svxlink/trx/PttSerialPin.cpp
+++ b/src/svxlink/trx/PttSerialPin.cpp
@@ -252,6 +252,13 @@ bool PttSerialPin::setPins(const Async::Config &cfg, const std::string &name)
       do_set = false;
       ++it;
     }
+    if (pins.end() - it < 3)
+    {
+      cerr << "*** ERROR: Illegal (incomplete) pin name for the "
+           << name << "/SERIAL_SET_PINS configuration variable. "
+           << "Accepted values are \"[!]RTS\" and/or \"[!]DTR\".\n";
+      return false;
+    }
     std::string pin_name(it, it+3);
     it += 3;
     if (pin_name == "RTS")

--- a/src/svxlink/trx/SquelchSerial.h
+++ b/src/svxlink/trx/SquelchSerial.h
@@ -281,6 +281,13 @@ class SquelchSerial : public Squelch
           do_set = false;
           ++it;
         }
+        if (pins.end() - it < 3)
+        {
+          std::cerr << "*** ERROR: Illegal (incomplete) pin name for the "
+                    << rx_name << "/SERIAL_SET_PINS configuration variable. "
+                    << "Accepted values are \"[!]RTS\" and/or \"[!]DTR\".\n";
+          return false;
+        }
         std::string pin_name(it, it+3);
         it += 3;
         if (pin_name == "RTS")


### PR DESCRIPTION
Both the serial PTT driver and the serial squelch driver parse the
SERIAL_SET_PINS config value by walking a std::string with an iterator
and unconditionally reading a 3-character pin name via
`std::string pin_name(it, it+3)` in a loop that continues until the
iterator hits end(). If the value ends with a token shorter than 3
characters (e.g. "RTS!" followed by nothing, or a bare "RT"), the
iterator can be advanced past end() before this construction runs,
turning `it+3` into a past-the-end iterator and making the range
constructor read out of bounds. Because the loop condition only checks
`it != pins.end()`, an overshoot also prevents the loop from ever
terminating normally, extending the invalid reads.

- PttSerialPin::setPins() (src/svxlink/trx/PttSerialPin.cpp): validate
  that at least 3 characters remain before constructing pin_name, and
  report a config error and bail out otherwise.
- SquelchSerial::setPins() (src/svxlink/trx/SquelchSerial.h): apply the
  same bounds check, since it contains an independent copy of the same
  parsing logic.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

