### PR TITLE
Fix stale PTT pin used when PttHidraw reopens the HID device

### DIFF
--- a/src/svxlink/trx/PttHidraw.cpp
+++ b/src/svxlink/trx/PttHidraw.cpp
@@ -266,6 +266,11 @@ bool PttHidraw::setTxOn(bool tx_on)
 {
   //cerr << "### PttHidraw::setTxOn(" << (tx_on ? "true" : "false") << ")\n";
 
+  if ((m_fd < 0) && !openDevice())
+  {
+    return false;
+  }
+
   const char a[5] = {
     '\000',
     '\000',
@@ -273,11 +278,6 @@ bool PttHidraw::setTxOn(bool tx_on)
     m_pin,
     '\000'
   };
-
-  if ((m_fd < 0) && !openDevice())
-  {
-    return false;
-  }
 
   if (::write(m_fd, a, sizeof(a)) == -1)
   {


### PR DESCRIPTION
- PttHidraw::setTxOn() built its 5-byte HID GPIO report from m_pin
  before checking whether the device needed to be reopened. When a
  prior write() failure had closed the device, closeDevice() resets
  m_pin to 0, so the very next setTxOn(true) call assembled a no-op
  report (all zero GPIO bits) using the stale m_pin, and only
  afterwards reopened the device and restored the real pin mask. The
  no-op report was written successfully and setTxOn() returned true,
  so the caller believed PTT had been keyed while the GPIO line never
  actually changed. Fixed by reopening the device (and thus
  refreshing m_pin/m_active_low) before building the report, so the
  report always reflects the currently configured pin.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

