### PR TITLE
Fix undefined behavior and memory leak in AfskModulator

### DIFF
--- a/src/svxlink/digital/AfskModulator.cpp
+++ b/src/svxlink/digital/AfskModulator.cpp
@@ -284,6 +284,8 @@ AfskModulator::~AfskModulator(void)
 {
   AudioSource::clearHandler();
   delete sigc_src;
+  delete [] sin_lookup;
+  delete [] exp_lookup;
 } /* AfskModulator::~AfskModulator */
 
 
@@ -379,6 +381,7 @@ void AfskModulator::writeToSink(void)
         if (bitclock >= sample_rate)
         {
           bitclock -= sample_rate;
+          bool last_bit = bitbuf.front();
           bitbuf.pop_front();
           if (bitbuf.empty())
           {
@@ -387,7 +390,7 @@ void AfskModulator::writeToSink(void)
               fade_dir = -1;
               for (unsigned sym=0; sym<FADE_SYMBOLS; ++sym)
               {
-                bitbuf.push_back(bitbuf.back());
+                bitbuf.push_back(last_bit);
               }
             }
             else


### PR DESCRIPTION
- Fix undefined-behavior read of back() on an empty deque during
  end-of-frame fade-out. When the last symbol is popped from bitbuf
  in writeToSink(), the deque becomes empty; the fade-out code then
  refilled it with bitbuf.push_back(bitbuf.back()), reading from an
  empty container on the first iteration. This fired at the end of
  every AFSK burst. Capture the last transmitted bit before popping
  it and use that saved value to refill the deque instead.

- Free the sin_lookup and exp_lookup heap-allocated lookup tables in
  ~AfskModulator(); they were allocated with new[] in the constructor
  but never released, leaking on every destruction of the modulator.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

