### PR TITLE
Fix out-of-bounds read parsing IPv4 SAN entries in TLS certs

### DIFF
--- a/src/async/core/AsyncSslX509ExtSubjectAltName.h
+++ b/src/async/core/AsyncSslX509ExtSubjectAltName.h
@@ -39,6 +39,8 @@ An example of how to use the SslX509ExtSubjectAltName class
  ****************************************************************************/
 
 #include <functional>
+#include <cstdint>
+#include <cstring>
 
 
 /****************************************************************************
@@ -272,7 +274,9 @@ class SslX509ExtSubjectAltName
               const unsigned char* data =
                 ASN1_STRING_get0_data(entry->d.iPAddress);
               struct in_addr in_addr = {0};
-              in_addr.s_addr = *reinterpret_cast<const unsigned long*>(data);
+              uint32_t addr_val;
+              std::memcpy(&addr_val, data, sizeof(addr_val));
+              in_addr.s_addr = addr_val;
               Async::IpAddress addr(in_addr);
               name = addr.toString();
             }


### PR DESCRIPTION
- In SslX509ExtSubjectAltName's GEN_IPADD handling, an IPv4 iPAddress
  SAN is a 4-byte ASN.1 octet string, but the code dereferenced it as
  `*reinterpret_cast<const unsigned long*>(data)`, reading a full
  `unsigned long` (8 bytes on LP64/64-bit Linux) and thus 4 bytes past
  the end of the 4-byte buffer. Fixed by copying exactly 4 bytes into
  a uint32_t via memcpy before assigning to in_addr.s_addr.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

