### PR TITLE
Fix stale ssl_con_map entry after TcpConnection move-assignment

### DIFF
--- a/src/async/core/AsyncTcpConnection.cpp
+++ b/src/async/core/AsyncTcpConnection.cpp
@@ -212,6 +212,10 @@ TcpConnection& TcpConnection::operator=(TcpConnection&& other)
 
   m_ssl = other.m_ssl;
   other.m_ssl = nullptr;
+  if (m_ssl != nullptr)
+  {
+    ssl_con_map[m_ssl] = this;
+  }
 
   m_ssl_rd_bio = other.m_ssl_rd_bio;
   other.m_ssl_rd_bio = nullptr;


### PR DESCRIPTION
TcpConnection::operator=(TcpConnection&&) transferred m_ssl from the
source object and nulled it out, but never updated the static
ssl_con_map lookup table used by the OpenSSL verify callback to map an
SSL* back to its owning TcpConnection. The map still pointed the SSL*
key at the moved-from object. Since that object's m_ssl was now null,
its destructor's cleanup path skipped erasing the stale entry, leaving
ssl_con_map[ssl] referencing freed memory. A later TLS handshake
invoking the verify callback would resolve the SSL* through this stale
entry, causing a use-after-free.

- In operator=(TcpConnection&&), after taking ownership of other.m_ssl,
  re-point ssl_con_map[m_ssl] at `this` so the map always reflects the
  live owner of the SSL* key.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

