### PR TITLE
Fix stack buffer overflow from unbounded sprintf on pidfile path

### DIFF
--- a/src/svxlink/svxlink/svxlink.cpp
+++ b/src/svxlink/svxlink/svxlink.cpp
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
     if (pidfile == 0)
     {
       char err[256];
-      sprintf(err, "fopen(\"%s\")", pidfile_name);
+      snprintf(err, sizeof(err), "fopen(\"%s\")", pidfile_name);
       perror(err);
       fflush(stderr);
       exit(1);


### PR DESCRIPTION
- svxlink.cpp: when fopen() on the pidfile fails, the error message was
  built with sprintf() into a fixed 256-byte stack buffer using the
  user-supplied --pidfile path directly. An oversized --pidfile argument
  (path length that also causes fopen() to fail, e.g. via ENAMETOOLONG)
  overflows this buffer. Switched to snprintf() with sizeof(err) so the
  path is always safely truncated to fit the buffer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

