### PR TITLE
Fix AudioRecorder leak and SEL5_MACRO_RANGE misparse in Logic

### DIFF
--- a/src/svxlink/svxlink/Logic.cpp
+++ b/src/svxlink/svxlink/Logic.cpp
@@ -353,9 +353,18 @@ bool Logic::initialize(Async::Config& cfgobj, const std::string& logic_name)
   if (cfg().getValue(name(), "SEL5_MACRO_RANGE", sel5_macros))
   {
     size_t comma = sel5_macros.find(",");
-    sel5_from = sel5_macros.substr(0, int(comma));
-    sel5_to = sel5_macros.substr(int(comma) + 1, sel5_macros.length());
-    cout << "Sel5 macro range from " << sel5_from << " to " << sel5_to << endl;
+    if (comma == string::npos)
+    {
+      cerr << "*** ERROR: Bad format for config variable SEL5_MACRO_RANGE. "
+           << "Valid format for value is from,to.\n";
+    }
+    else
+    {
+      sel5_from = sel5_macros.substr(0, comma);
+      sel5_to = sel5_macros.substr(comma + 1, sel5_macros.length());
+      cout << "Sel5 macro range from " << sel5_from << " to " << sel5_to
+           << endl;
+    }
   }
 
   if (cfg().getValue(name(), "TX_CTCSS", value))
@@ -849,7 +858,8 @@ void Logic::recordStart(const string& filename, unsigned max_time)
     cerr << "*** ERROR: Could not open file " << filename
          << " for recording in logic " << name() << ": "
          << recorder->errorMsg() << endl;
-    recordStop();
+    delete recorder;
+    recorder = 0;
     return;
   }
   recorder->setMaxRecordingTime(max_time);


### PR DESCRIPTION
- Logic::recordStart leaked the AudioRecorder when initialize() failed
  (e.g. file could not be opened due to a bad path or permissions).
  On the failure path it called recordStop(), which removes the
  recorder from rx_splitter, but the recorder was never registered as
  a splitter sink at that point (addSink() runs later, only on
  success), so the removal was a no-op and the sole pointer to the
  object was dropped. Now the recorder is deleted directly on the
  failure path instead of relying on recordStop().

- Logic::initialize mishandled a SEL5_MACRO_RANGE config value that is
  missing the required comma separator. string::find(",") returns
  npos, which was cast to int and used as a substr() length/position,
  silently producing sel5_from == sel5_to == the entire (malformed)
  string instead of reporting the bad config. Now the missing-comma
  case is detected explicitly and an error is logged instead of
  silently deriving a degenerate range.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

