### PR TITLE
Fix use-after-free from SampleBuffer self-deletion in its own FdWatch callback

### DIFF
--- a/src/svxlink/trx/RtlUsb.cpp
+++ b/src/svxlink/trx/RtlUsb.cpp
@@ -52,6 +52,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ****************************************************************************/
 
 #include <AsyncFdWatch.h>
+#include <AsyncApplication.h>
 
 
 /****************************************************************************
@@ -242,8 +243,13 @@ class RtlUsb::SampleBuffer : public sigc::trackable
       int r = read(signal_pipe[0], read_buf, sizeof(read_buf));
       if (r == 0)
       {
-        closeReadPipe();
-        writePipeClosed();
+          // Closing the read pipe (which deletes the FdWatch) and emitting
+          // writePipeClosed (which may end up deleting this SampleBuffer)
+          // must not be done here since we are currently executing inside
+          // the FdWatch activity callback for this very object. Defer the
+          // cleanup to run after we have returned from the callback.
+        Application::app().runTask(
+            mem_fun(*this, &SampleBuffer::handleWritePipeClosed));
         return;
       }
       else if (r <= 0)
@@ -264,6 +270,16 @@ class RtlUsb::SampleBuffer : public sigc::trackable
         lockMutex();
       }
       unlockMutex();
+    }
+
+      // Deferred cleanup, run outside of the FdWatch activity callback since
+      // it may end up destroying this SampleBuffer object (through the
+      // writePipeClosed signal) as well as the FdWatch that invoked
+      // removeSamples in the first place.
+    void handleWritePipeClosed(void)
+    {
+      closeReadPipe();
+      writePipeClosed();
     }
 };
 


### PR DESCRIPTION
RtlUsb::SampleBuffer::removeSamples() is invoked as the activity callback
of the FdWatch that monitors the read end of its internal signal pipe.
When the RTL reader thread exits and closes the write end of that pipe,
read() returns 0 (EOF) and removeSamples() responded by synchronously
calling closeReadPipe() (which deletes the FdWatch currently dispatching
this very callback) and then emitting writePipeClosed(), which is
connected to RtlUsb::verboseClose() and ends up deleting the SampleBuffer
object itself — all while still executing a member function on that
same object's call stack. This is a self-delete-during-callback bug that
can lead to use-after-free.

- Add SampleBuffer::handleWritePipeClosed(), a small helper that performs
  the closeReadPipe()/writePipeClosed() cleanup, and defer its invocation
  via Async::Application::runTask() from removeSamples() instead of
  calling it inline. This ensures the FdWatch and the owning SampleBuffer
  are only destroyed after control has returned to the top-level event
  loop, not from within the FdWatch's own activity dispatch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

