### PR TITLE
Fix uninitialized atomic_bool in LogWriter causing spurious logfile reopen

### DIFF
--- a/src/misc/LogWriter.h
+++ b/src/misc/LogWriter.h
@@ -181,7 +181,7 @@ class LogWriter
 
     std::string       m_dest_name;
     std::string       m_tstamp_format {"%c"};
-    std::atomic_bool  m_reopen_log;
+    std::atomic_bool  m_reopen_log  {false};
     int               m_pipefd[2]     {-1, -1};
     std::thread       m_logthread;
     std::mutex        m_mutex;


### PR DESCRIPTION
- LogWriter::m_reopen_log (src/misc/LogWriter.h) was a std::atomic_bool
  with no in-class initializer and was never set in the constructor. On
  C++17 (which this project targets), a default-constructed atomic_bool
  is left with an indeterminate value rather than being value-initialized
  (that behavior only arrived in C++20). The writer thread reads this flag
  before the first call to reopenLogfile(), so on startup it could read
  an indeterminate garbage value and spuriously reopen the logfile on the
  very first log line. Fixed by giving m_reopen_log an explicit `{false}`
  initializer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

