### PR TITLE
Logic: mute logic linking while a logic core is offline

### DIFF
--- a/src/svxlink/svxlink/Logic.cpp
+++ b/src/svxlink/svxlink/Logic.cpp
@@ -1017,11 +1017,13 @@ void Logic::setOnline(bool online)
   if (online)
   {
     tx().setTxCtrlMode(currently_set_tx_ctrl_mode);
+    setMuteLinking(false);
   }
   else
   {
     tx().setTxCtrlMode(Tx::TX_OFF);
     deactivateModule(0);
+    setMuteLinking(true);
   }
   stringstream ss;
   ss << "logic_online ";


### PR DESCRIPTION
Taking a logic core offline (`setOnline(false)`, e.g. via the `ONLINE_CMD`
DTMF command) set the transmitter to `TX_OFF` and deactivated the active
module, but left the logic connected in the logic-linking layer. Audio
received by the offline logic therefore kept flowing to every linked logic
core -- most visibly, a deactivated node continued transmitting its RX audio
onto a connected SvxReflector talk group.

Mute the logic in the linking layer while it is offline and unmute it when it
is brought back online, so a deactivated logic no longer passes audio to or
from other logic cores. This reuses the same `setMuteLinking()` mechanism a
module already uses via `MUTE_LOGIC_LINKING`.

Fixes #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)