### PR TITLE
Bugfix: Fix memory handling problem in RemoteTrx

### DIFF
--- a/src/svxlink/ChangeLog
+++ b/src/svxlink/ChangeLog
@@ -40,6 +40,8 @@
   connection object → unbounded resource exhaustion (network DoS)
   Credit: Mark Rose <markrose@markrose.ca>
 
+* Bugfix: Fix memory handling problem in RemoteTrx
+
 
 
  1.10.0 -- 23 May 2026

--- a/src/svxlink/remotetrx/NetUplink.cpp
+++ b/src/svxlink/remotetrx/NetUplink.cpp
@@ -297,22 +297,20 @@ void NetUplink::handleIncomingConnection(TcpConnection *incoming_con)
   
   setState(STATE_CON_SETUP);
 
-  MsgProtoVer *ver_msg = new MsgProtoVer;
-  sendMsg(ver_msg);
+  sendMsg(MsgProtoVer());
 
   if (auth_key.empty())
   {
     std::cerr << "*** WARNING: Using an empty AUTH_KEY will allow anyone to "
                  "connect"
               << std::endl;
-    MsgAuthOk *auth_msg = new MsgAuthOk;
-    sendMsg(auth_msg);
+    sendMsg(MsgAuthOk());
     setState(STATE_READY);
   }
   else
   {
-    MsgAuthChallenge *auth_msg = new MsgAuthChallenge;
-    memcpy(auth_challenge, auth_msg->challenge(),
+    MsgAuthChallenge auth_msg;
+    memcpy(auth_challenge, auth_msg.challenge(),
            MsgAuthChallenge::CHALLENGE_LEN);
     sendMsg(auth_msg);
   }
@@ -488,8 +486,7 @@ void NetUplink::handleMsg(Msg *msg)
         }
         else
         {
-          MsgAuthOk *ok_msg = new MsgAuthOk;
-          sendMsg(ok_msg);
+          sendMsg(MsgAuthOk());
         }
         setState(STATE_READY);
       }
@@ -725,27 +722,24 @@ void NetUplink::handleMsg(Msg *msg)
 } /* NetUplink::handleMsg */
 
 
-void NetUplink::sendMsg(Msg *msg)
+void NetUplink::sendMsg(const Msg& msg)
 {
   if ((state == STATE_CON_SETUP) || (state == STATE_READY))
   {
-    int written = con->write(msg, msg->size());
+    int written = con->write(&msg, msg.size());
     if (written == -1)
     {
       std::cerr << "*** ERROR: TCP transmit error in NetUplink \"" << name
                 << "\": " << strerror(errno) << "." << std::endl;
       forceDisconnect();
     }
-    else if (written != static_cast<int>(msg->size()))
+    else if (written != static_cast<int>(msg.size()))
     {
       std::cerr << "*** ERROR: TCP transmit buffer overflow in NetUplink "
                 << name << "." << std::endl;
       forceDisconnect();
     }
   }
-  
-  delete msg;
-  
 } /* NetUplink::sendMsg */
 
 
@@ -764,9 +758,8 @@ void NetUplink::squelchOpen(bool is_open)
     }
   }
 
-  MsgSquelch *msg = new MsgSquelch(is_open, rx->signalStrength(),
-                                   rx->sqlRxId(), rx->squelchActivityInfo());
-  sendMsg(msg);
+  sendMsg(MsgSquelch(is_open, rx->signalStrength(), rx->sqlRxId(),
+                     rx->squelchActivityInfo()));
 } /* NetUplink::squelchOpen */
 
 
@@ -774,24 +767,21 @@ void NetUplink::dtmfDigitDetected(char digit, int duration)
 {
   cout << name << ": DTMF digit detected: " << digit << " with duration " << duration
        << " milliseconds" << endl;
-  MsgDtmf *msg = new MsgDtmf(digit, duration);
-  sendMsg(msg);
+  sendMsg(MsgDtmf(digit, duration));
 } /* NetUplink::dtmfDigitDetected */
 
 
 void NetUplink::toneDetected(float tone_fq)
 {
   cout << name << ": Tone detected: " << tone_fq << endl;
-  MsgTone *msg = new MsgTone(tone_fq);
-  sendMsg(msg);
+  sendMsg(MsgTone(tone_fq));
 } /* NetUplink::toneDetected */
 
 
 void NetUplink::selcallSequenceDetected(std::string sequence)
 {
   // cout "Sel5 sequence detected: " << sequence << endl;
-  MsgSel5 *msg = new MsgSel5(sequence);
-  sendMsg(msg);
+  sendMsg(MsgSel5(sequence));
 } /* NetUplink::selcallSequenceDetected */
 
 
@@ -803,8 +793,7 @@ void NetUplink::writeEncodedSamples(const void *buf, int size)
   {
     const int bufsize = MsgAudio::BUFSIZE;
     int len = min(size, bufsize);
-    MsgAudio *msg = new MsgAudio(ptr, len);
-    sendMsg(msg);
+    sendMsg(MsgAudio(ptr, len));
     size -= len;
     ptr += len;
   }
@@ -813,31 +802,26 @@ void NetUplink::writeEncodedSamples(const void *buf, int size)
 
 void NetUplink::txTimeout(void)
 {
-  MsgTxTimeout *msg = new MsgTxTimeout;
-  sendMsg(msg);
+  sendMsg(MsgTxTimeout());
 } /* NetUplink::txTimeout */
 
 
 void NetUplink::transmitterStateChange(bool is_transmitting)
 {
-  MsgTransmitterStateChange *msg =
-      new MsgTransmitterStateChange(is_transmitting);
-  sendMsg(msg);
+  sendMsg(MsgTransmitterStateChange(is_transmitting));
 } /* NetUplink::transmitterStateChange */
 
 
 void NetUplink::allEncodedSamplesFlushed(void)
 {
-  MsgAllSamplesFlushed *msg = new MsgAllSamplesFlushed;
-  sendMsg(msg);
+  sendMsg(MsgAllSamplesFlushed());
 } /* NetUplink::allEncodedSamplesFlushed */
 
 
 void NetUplink::heartbeat(Timer *t)
 {
-  MsgHeartbeat *msg = new MsgHeartbeat;
-  sendMsg(msg);
-  
+  sendMsg(MsgHeartbeat());
+
   struct timeval diff_tv;
   struct timeval now;
   gettimeofday(&now, NULL);
@@ -893,9 +877,7 @@ void NetUplink::setFallbackActive(bool activate)
 
 void NetUplink::signalLevelUpdated(float siglev)
 {
-  MsgSiglevUpdate *msg = new MsgSiglevUpdate(rx->signalStrength(),
-					     rx->sqlRxId());
-  sendMsg(msg);  
+  sendMsg(MsgSiglevUpdate(rx->signalStrength(), rx->sqlRxId()));
 } /* NetUplink::signalLevelUpdated */
 
 

--- a/src/svxlink/remotetrx/NetUplink.h
+++ b/src/svxlink/remotetrx/NetUplink.h
@@ -200,7 +200,7 @@ class NetUplink : public Uplink
       	      	      	    Async::TcpConnection::DisconnectReason reason);
     int tcpDataReceived(Async::TcpConnection *con, void *data, int size);
     void handleMsg(NetTrxMsg::Msg *msg);
-    void sendMsg(NetTrxMsg::Msg *msg);
+    void sendMsg(const NetTrxMsg::Msg& msg);
 
     /**
      * @brief 	Set squelch state to open/closed

--- a/src/svxlink/trx/NetTrxMsg.h
+++ b/src/svxlink/trx/NetTrxMsg.h
@@ -119,6 +119,11 @@ namespace NetTrxMsg
 @brief	Base class for remote transceiver network messages
 @author Tobias Blomberg / SM0SVX
 @date   2006-04-14
+
+NOTE: This class must not be made virtual since that would add a vptr to a
+vtable (virtual function table) thus increasing the size of the class which
+will cause the vptr to be transmitted with the message over the network. One
+limitation of that is that message classes cannot be used with polymorphism.
 */
 class Msg
 {
@@ -129,12 +134,7 @@ class Msg
      * @param 	size The message size
      */
     Msg(unsigned type, unsigned size) : m_type(type), m_size(size) {}
-  
-    /**
-     * @brief 	Destructor
-     */
-    ~Msg(void) {}
-  
+
     /**
      * @brief 	Get the message type
      * @return	Returns the message type

--- a/src/versions
+++ b/src/versions
@@ -1,5 +1,5 @@
 # Project release version
-PROJECT=26.05.0.99.11
+PROJECT=26.05.0.99.12
 
 # Version for the Qtel application
 QTEL=1.3.0
@@ -25,7 +25,7 @@ MODULE_FRN=1.1.1
 MODULE_TRX=1.0.1.99.0
 
 # Version for the RemoteTrx application
-REMOTE_TRX=1.6.0.99.2
+REMOTE_TRX=1.6.0.99.3
 
 # Version for the signal level calibration utility
 SIGLEV_DET_CAL=1.0.11.99.0


### PR DESCRIPTION
The Msg class was used in a polymorphic delete which was not correct since the Msg class is not a virtual class.