### PR TITLE
reflector: add native federation support

### DIFF
--- a/src/svxlink/reflector/CMakeLists.txt
+++ b/src/svxlink/reflector/CMakeLists.txt
@@ -60,7 +60,9 @@ install_if_not_exists(${CMAKE_CURRENT_BINARY_DIR}/Federation.conf
   ${SVX_SYSCONF_INSTALL_DIR}/svxreflector.d
   )
 install_if_not_exists(ca-hook.yaml ${SVX_SYSCONF_INSTALL_DIR})
-install(PROGRAMS svxreflector-status
+install(PROGRAMS
+  svxreflector-status
+  svx_federation_builder.py
   DESTINATION ${BIN_INSTALL_DIR}
   )
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/ca-hook.py

--- a/src/svxlink/reflector/CMakeLists.txt
+++ b/src/svxlink/reflector/CMakeLists.txt
@@ -24,7 +24,13 @@ set(LIBS asynccpp asyncaudio asynccore svxmisc ${LIBS})
 
 # Build the executable
 add_executable(svxreflector
-  svxreflector.cpp Reflector.cpp ReflectorClient.cpp TGHandler.cpp
+  svxreflector.cpp
+  FederationLibrary.cpp
+  FederationPeerConnection.cpp
+  Reflector.cpp
+  ReflectorClient.cpp
+  ReflectorFederation.cpp
+  TGHandler.cpp
 )
 target_link_libraries(svxreflector ${LIBS})
 set_target_properties(svxreflector PROPERTIES
@@ -36,6 +42,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/svxreflector.conf.in
   ${CMAKE_CURRENT_BINARY_DIR}/svxreflector.conf
   @ONLY
   )
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Federation.conf.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Federation.conf
+  @ONLY
+  )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ca-hook.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/ca-hook.py
   @ONLY
@@ -45,6 +55,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ca-hook.py.in
 install(TARGETS svxreflector DESTINATION ${BIN_INSTALL_DIR})
 install_if_not_exists(${CMAKE_CURRENT_BINARY_DIR}/svxreflector.conf
   ${SVX_SYSCONF_INSTALL_DIR}
+  )
+install_if_not_exists(${CMAKE_CURRENT_BINARY_DIR}/Federation.conf
+  ${SVX_SYSCONF_INSTALL_DIR}/svxreflector.d
   )
 install_if_not_exists(ca-hook.yaml ${SVX_SYSCONF_INSTALL_DIR})
 install(PROGRAMS svxreflector-status

--- a/src/svxlink/reflector/Federation.conf.in
+++ b/src/svxlink/reflector/Federation.conf.in
@@ -1,0 +1,98 @@
+###################################################################
+#
+# Optional SVXReflector federation
+#
+# Load this file by including its directory through GLOBAL/CFG_DIR
+# in svxreflector.conf. Federation is disabled unless ENABLE=1.
+#
+###################################################################
+
+
+[FEDERATION]
+
+# Set to 1 to enable federation.
+ENABLE=0
+
+# Administrative federation domain containing this reflector.
+#DOMAIN=UK-WIDE
+
+# Globally unique, stable identity for this reflector.
+# This identity is carried in federation stream messages and must
+# match REFLECTOR_ID in each remote peer's configuration.
+#REFLECTOR_ID=uk-wide.example.org
+
+# Federation access identity used by this reflector when connecting
+# to its configured peers.
+#
+# CALLSIGN is the established SVXReflector configuration name. The
+# value identifies a federated reflector and is not the callsign of
+# a user originating audio.
+#
+# Before use, this identity must be registered and accepted through
+# the normal callsign and X.509 certificate administration of every
+# receiving reflector. Each receiving reflector must then map it to
+# the appropriate peer in [FEDERATION_TRUST].
+#CALLSIGN=REFLECTOR-FUK
+
+# JSON routing and peer-policy library.
+#LIBRARY=@SVX_SYSCONF_INSTALL_DIR@/federation.json
+
+# Comma-separated peer names. Each name requires a matching
+# [FEDERATION_PEER_<name>] section below.
+#PEERS=NORTH-AMERICA
+
+
+###################################################################
+#
+# Federation peers
+#
+# CONNECT controls only the locally originated outgoing connection.
+# CONNECT=1 makes this reflector connect and reconnect to the peer.
+# CONNECT=0 permits a trusted incoming session without starting a
+# local outgoing connector.
+#
+# For bidirectional traffic, configure the peer on both reflectors
+# and normally set CONNECT=1 at both ends. This creates one
+# independently authenticated session in each direction.
+#
+###################################################################
+
+
+#[FEDERATION_PEER_NORTH-AMERICA]
+
+# Remote reflector hostname or address.
+#HOST=reflector.example.org
+
+# Expected identity announced by the remote reflector.
+# Defaults to HOST when omitted.
+#REFLECTOR_ID=north-america.example.org
+
+# Remote SVXReflector TCP/UDP service port.
+#PORT=35300
+
+# Federation connections currently negotiate SVXReflector client
+# protocol version 2.0.
+#PROTOCOL=2
+
+# Authentication key for the local CALLSIGN access identity on the
+# remote reflector.
+#AUTH_KEY=change-this-key
+
+# Start and maintain an outgoing connection to this peer.
+#CONNECT=1
+
+
+# Each configured peer requires exactly one trusted incoming
+# federation access identity.
+#
+# The identity must first be registered and accepted through the
+# receiving reflector's normal callsign and X.509 certificate
+# administration. [FEDERATION_TRUST] then grants that accepted
+# identity the federation privileges of the named peer.
+
+# Example trusted identities for a UK-WIDE reflector:
+#
+#[FEDERATION_TRUST]
+#REFLECTOR-FNA=NORTH-AMERICA
+#REFLECTOR-FAU=AUSTRALIA
+#REFLECTOR-FYN=YORKSHIRENET

--- a/src/svxlink/reflector/FederationLibrary.cpp
+++ b/src/svxlink/reflector/FederationLibrary.cpp
@@ -1,0 +1,635 @@
+/**
+@file   FederationLibrary.cpp
+@brief  Hot-reloadable talkgroup library for reflector federation
+@author Chris Jackson / G4NAB
+@date   2026-08-14
+
+\verbatim
+Copyright (C) 2026 Chris Jackson / G4NAB
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <cerrno>
+#include <cstdlib>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <json/json.h>
+
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "FederationLibrary.h"
+
+/****************************************************************************
+ *
+ * Local functions
+ *
+ ****************************************************************************/
+
+namespace {
+  bool parsePositiveUint32(const std::string& text, std::uint32_t& value)
+  {
+    if (text.empty())
+    {
+      return false;
+    }
+
+    for (std::string::const_iterator it=text.begin(); it!=text.end(); ++it)
+    {
+      if ((*it < '0') || (*it > '9'))
+      {
+        return false;
+      }
+    }
+
+    errno = 0;
+    char *end = 0;
+    const unsigned long long parsed = std::strtoull(text.c_str(), &end, 10);
+
+    if ((errno != 0) || (end == 0) || (*end != '\0') ||
+        (parsed == 0) ||
+        (parsed > std::numeric_limits<std::uint32_t>::max()))
+    {
+      return false;
+    }
+
+    value = static_cast<std::uint32_t>(parsed);
+    return true;
+  }
+
+
+  bool validateRoute(const Json::Value& route,
+                     Json::Value::ArrayIndex index,
+                     FederationLibrary::Route& parsed_route,
+                     std::string& error)
+  {
+    std::ostringstream prefix;
+    prefix << "Federation route " << index << ": ";
+
+    if (!route.isObject())
+    {
+      error = prefix.str() + "entry must be a JSON object";
+      return false;
+    }
+
+    if (!route["type"].isString())
+    {
+      error = prefix.str() + "type is missing or invalid";
+      return false;
+    }
+
+    const std::string type(route["type"].asString());
+
+    if (type == "exact")
+    {
+      if (!route["value"].isUInt() || (route["value"].asUInt() == 0))
+      {
+        error = prefix.str() +
+                "exact value must be a positive talkgroup number";
+        return false;
+      }
+
+      parsed_route.type = FederationLibrary::Route::TYPE_EXACT;
+      parsed_route.first = route["value"].asUInt();
+      parsed_route.last = parsed_route.first;
+    }
+    else if (type == "prefix")
+    {
+      std::uint32_t value = 0;
+      if (!route["value"].isString() ||
+          !parsePositiveUint32(route["value"].asString(), value))
+      {
+        error = prefix.str() +
+                "prefix value must be a string containing digits";
+        return false;
+      }
+
+      parsed_route.type = FederationLibrary::Route::TYPE_PREFIX;
+      parsed_route.prefix = route["value"].asString();
+    }
+    else if (type == "range")
+    {
+      if (!route["value"].isString())
+      {
+        error = prefix.str() +
+                "range value must use the form \"first-last\"";
+        return false;
+      }
+
+      const std::string range(route["value"].asString());
+      const std::string::size_type separator = range.find('-');
+
+      if ((separator == std::string::npos) ||
+          (range.find('-', separator + 1) != std::string::npos))
+      {
+        error = prefix.str() +
+                "range value must use the form \"first-last\"";
+        return false;
+      }
+
+      std::uint32_t first = 0;
+      std::uint32_t last = 0;
+
+      if (!parsePositiveUint32(range.substr(0, separator), first) ||
+          !parsePositiveUint32(range.substr(separator + 1), last) ||
+          (first > last))
+      {
+        error = prefix.str() + "range value is invalid";
+        return false;
+      }
+
+      parsed_route.type = FederationLibrary::Route::TYPE_RANGE;
+      parsed_route.first = first;
+      parsed_route.last = last;
+    }
+    else
+    {
+      error = prefix.str() + "unknown route type \"" + type + "\"";
+      return false;
+    }
+
+    if (!route["home"].isString() || route["home"].asString().empty())
+    {
+      error = prefix.str() + "home is missing or empty";
+      return false;
+    }
+    parsed_route.home = route["home"].asString();
+
+    if (!route["scope"].isString() || route["scope"].asString().empty())
+    {
+      error = prefix.str() + "scope is missing or empty";
+      return false;
+    }
+    parsed_route.scope = route["scope"].asString();
+
+    if (route.isMember("service_anchor"))
+    {
+      if (!route["service_anchor"].isString() ||
+          route["service_anchor"].asString().empty())
+      {
+        error = prefix.str() + "service_anchor must be a non-empty string";
+        return false;
+      }
+      parsed_route.service_anchor = route["service_anchor"].asString();
+    }
+
+    if (route.isMember("description"))
+    {
+      if (!route["description"].isString())
+      {
+        error = prefix.str() + "description must be a string";
+        return false;
+      }
+      parsed_route.description = route["description"].asString();
+    }
+
+    return true;
+  }
+
+  bool parseTalkgroupPattern(
+      const Json::Value& value,
+      FederationLibrary::TalkgroupPattern& pattern,
+      std::string& error)
+  {
+    if (!value.isString())
+    {
+      error = "talkgroup pattern must be a string";
+      return false;
+    }
+
+    const std::string text(value.asString());
+    if (text.empty())
+    {
+      error = "talkgroup pattern must not be empty";
+      return false;
+    }
+
+    const std::string::size_type wildcard = text.find('*');
+
+    if (wildcard == std::string::npos)
+    {
+      std::uint32_t exact = 0;
+      if (!parsePositiveUint32(text, exact))
+      {
+        error = "exact talkgroup pattern must contain only digits";
+        return false;
+      }
+
+      pattern.type =
+          FederationLibrary::TalkgroupPattern::TYPE_EXACT;
+      pattern.exact = exact;
+      return true;
+    }
+
+    if ((wildcard != (text.size() - 1)) ||
+        (text.find('*', wildcard + 1) != std::string::npos))
+    {
+      error = "talkgroup wildcard must appear once at the end";
+      return false;
+    }
+
+    const std::string prefix(text.substr(0, wildcard));
+    std::uint32_t unused = 0;
+    if (!parsePositiveUint32(prefix, unused))
+    {
+      error = "talkgroup prefix must contain digits before the wildcard";
+      return false;
+    }
+
+    pattern.type =
+        FederationLibrary::TalkgroupPattern::TYPE_PREFIX;
+    pattern.prefix = prefix;
+    return true;
+  }
+  bool matchesTalkgroupPattern(
+      const FederationLibrary::TalkgroupPattern& pattern,
+      std::uint32_t tg)
+  {
+    if (pattern.type ==
+        FederationLibrary::TalkgroupPattern::TYPE_EXACT)
+    {
+      return pattern.exact == tg;
+    }
+
+    std::ostringstream tg_stream;
+    tg_stream << tg;
+    const std::string tg_text(tg_stream.str());
+
+    return (pattern.prefix.size() <= tg_text.size()) &&
+           (tg_text.compare(0,
+                            pattern.prefix.size(),
+                            pattern.prefix) == 0);
+  }
+
+  bool matchesAnyPattern(
+      const std::vector<FederationLibrary::TalkgroupPattern>& patterns,
+      std::uint32_t tg)
+  {
+    for (std::vector<FederationLibrary::TalkgroupPattern>::
+             const_iterator it=patterns.begin();
+         it!=patterns.end(); ++it)
+    {
+      if (matchesTalkgroupPattern(*it, tg))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool parsePatternList(
+      const Json::Value& values,
+      const std::string& peer,
+      const std::string& direction,
+      std::vector<FederationLibrary::TalkgroupPattern>& patterns,
+      std::string& error)
+  {
+    if (!values.isArray())
+    {
+      error = "Peer policy " + peer + "/" + direction +
+              " must be an array";
+      return false;
+    }
+
+    for (Json::Value::ArrayIndex index=0;
+         index<values.size(); ++index)
+    {
+      FederationLibrary::TalkgroupPattern pattern;
+      std::string pattern_error;
+
+      if (!parseTalkgroupPattern(values[index],
+                                 pattern,
+                                 pattern_error))
+      {
+        std::ostringstream message;
+        message << "Peer policy " << peer << "/"
+                << direction << " entry " << index
+                << ": " << pattern_error;
+        error = message.str();
+        return false;
+      }
+
+      patterns.push_back(pattern);
+    }
+
+    return true;
+  }
+
+
+  bool validatePeerPolicies(
+      const Json::Value& root,
+      std::vector<FederationLibrary::PeerPolicy>& policies,
+      std::string& error)
+  {
+    if (!root.isMember("peer_policy"))
+    {
+      return true;
+    }
+
+    const Json::Value& policy_root(root["peer_policy"]);
+    if (!policy_root.isObject())
+    {
+      error = "Federation library peer_policy must be an object";
+      return false;
+    }
+
+    const Json::Value::Members peers(policy_root.getMemberNames());
+
+    for (Json::Value::Members::const_iterator it=peers.begin();
+         it!=peers.end(); ++it)
+    {
+      if (it->empty())
+      {
+        error = "Federation peer policy name must not be empty";
+        return false;
+      }
+
+      const Json::Value& value(policy_root[*it]);
+      if (!value.isObject())
+      {
+        error = "Federation peer policy " + *it +
+                " must be an object";
+        return false;
+      }
+
+      FederationLibrary::PeerPolicy policy;
+      policy.peer = *it;
+
+      if (!parsePatternList(value["import"],
+                            policy.peer,
+                            "import",
+                            policy.import_patterns,
+                            error))
+      {
+        return false;
+      }
+
+      if (!parsePatternList(value["export"],
+                            policy.peer,
+                            "export",
+                            policy.export_patterns,
+                            error))
+      {
+        return false;
+      }
+
+      policies.push_back(policy);
+    }
+
+    return true;
+  }
+} /* namespace */
+
+
+/****************************************************************************
+ *
+ * Public member functions
+ *
+ ****************************************************************************/
+
+FederationLibrary::FederationLibrary(void)
+  : m_schema(0), m_generation(0)
+{
+} /* FederationLibrary::FederationLibrary */
+
+
+FederationLibrary::~FederationLibrary(void)
+{
+} /* FederationLibrary::~FederationLibrary */
+
+const FederationLibrary::Route*
+FederationLibrary::findRoute(std::uint32_t tg) const
+{
+  // An exact talkgroup always has the highest precedence.
+  for (std::vector<Route>::const_iterator it=m_routes.begin();
+       it!=m_routes.end(); ++it)
+  {
+    if ((it->type == Route::TYPE_EXACT) && (it->first == tg))
+    {
+      return &(*it);
+    }
+  }
+
+  // Of all matching ranges, select the narrowest.
+  const Route* best_route = 0;
+  std::uint32_t best_span =
+      std::numeric_limits<std::uint32_t>::max();
+
+  for (std::vector<Route>::const_iterator it=m_routes.begin();
+       it!=m_routes.end(); ++it)
+  {
+    if ((it->type == Route::TYPE_RANGE) &&
+        (tg >= it->first) && (tg <= it->last))
+    {
+      const std::uint32_t span = it->last - it->first;
+      if ((best_route == 0) || (span < best_span))
+      {
+        best_route = &(*it);
+        best_span = span;
+      }
+    }
+  }
+
+  if (best_route != 0)
+  {
+    return best_route;
+  }
+
+  // Of all matching prefixes, select the longest.
+  std::ostringstream tg_stream;
+  tg_stream << tg;
+  const std::string tg_text(tg_stream.str());
+  std::size_t best_prefix_length = 0;
+
+  for (std::vector<Route>::const_iterator it=m_routes.begin();
+       it!=m_routes.end(); ++it)
+  {
+    if ((it->type == Route::TYPE_PREFIX) &&
+        (it->prefix.size() <= tg_text.size()) &&
+        (tg_text.compare(0, it->prefix.size(), it->prefix) == 0) &&
+        ((best_route == 0) ||
+         (it->prefix.size() > best_prefix_length)))
+    {
+      best_route = &(*it);
+      best_prefix_length = it->prefix.size();
+    }
+  }
+
+  return best_route;
+} /* FederationLibrary::findRoute */
+
+
+bool FederationLibrary::hasPeerPolicy(const std::string& peer) const
+{
+  for (std::vector<PeerPolicy>::const_iterator
+           it=m_peer_policies.begin();
+       it!=m_peer_policies.end(); ++it)
+  {
+    if (it->peer == peer)
+    {
+      return true;
+    }
+  }
+
+  return false;
+} /* FederationLibrary::hasPeerPolicy */
+
+
+bool FederationLibrary::mayImport(const std::string& peer,
+                                  std::uint32_t tg) const
+{
+  for (std::vector<PeerPolicy>::const_iterator
+           it=m_peer_policies.begin();
+       it!=m_peer_policies.end(); ++it)
+  {
+    if (it->peer == peer)
+    {
+      return matchesAnyPattern(it->import_patterns, tg);
+    }
+  }
+
+  return false;
+} /* FederationLibrary::mayImport */
+
+
+bool FederationLibrary::mayExport(const std::string& peer,
+                                  std::uint32_t tg) const
+{
+  for (std::vector<PeerPolicy>::const_iterator
+           it=m_peer_policies.begin();
+       it!=m_peer_policies.end(); ++it)
+  {
+    if (it->peer == peer)
+    {
+      return matchesAnyPattern(it->export_patterns, tg);
+    }
+  }
+
+  return false;
+} /* FederationLibrary::mayExport */
+
+
+
+bool FederationLibrary::load(const std::string& path,
+                             const std::string& expected_domain,
+                             std::string& error)
+{
+  std::ifstream stream(path.c_str());
+  if (!stream.is_open())
+  {
+    error = "Could not open federation library: " + path;
+    return false;
+  }
+
+  Json::CharReaderBuilder builder;
+  builder["collectComments"] = false;
+
+  Json::Value root;
+  std::string parse_errors;
+  if (!Json::parseFromStream(builder, stream, &root, &parse_errors))
+  {
+    error = "Could not parse federation library: " + parse_errors;
+    return false;
+  }
+
+  if (!root.isObject())
+  {
+    error = "Federation library root must be a JSON object";
+    return false;
+  }
+
+  if (!root["schema"].isUInt() || (root["schema"].asUInt() != 1))
+  {
+    error = "Federation library schema must be 1";
+    return false;
+  }
+
+  if (!root["generation"].isUInt64() ||
+      (root["generation"].asUInt64() == 0))
+  {
+    error = "Federation library generation must be a positive integer";
+    return false;
+  }
+
+  const std::uint64_t candidate_generation =
+      root["generation"].asUInt64();
+
+  if ((m_generation != 0) && (candidate_generation <= m_generation))
+  {
+    std::ostringstream message;
+    message << "Federation library generation "
+            << candidate_generation
+            << " is not newer than active generation "
+            << m_generation;
+    error = message.str();
+    return false;
+  }
+
+  if (!root["domain"].isString() || root["domain"].asString().empty())
+  {
+    error = "Federation library domain is missing or empty";
+    return false;
+  }
+
+  const std::string candidate_domain(root["domain"].asString());
+  if (!expected_domain.empty() && (candidate_domain != expected_domain))
+  {
+    error = "Federation library domain does not match FEDERATION/DOMAIN";
+    return false;
+  }
+
+  if (!root["routes"].isArray())
+  {
+    error = "Federation library routes must be an array";
+    return false;
+  }
+
+  const Json::Value& routes(root["routes"]);
+  std::vector<Route> candidate_routes;
+  candidate_routes.reserve(routes.size());
+
+  for (Json::Value::ArrayIndex index=0; index<routes.size(); ++index)
+  {
+    Route parsed_route;
+    if (!validateRoute(routes[index], index, parsed_route, error))
+    {
+      return false;
+    }
+
+    candidate_routes.push_back(parsed_route);
+  }
+
+  std::vector<PeerPolicy> candidate_peer_policies;
+  if (!validatePeerPolicies(root, candidate_peer_policies, error))
+
+  {
+    return false;
+  }
+  // Commit metadata only after the complete candidate has passed validation.
+  m_schema = root["schema"].asUInt();
+  m_generation = candidate_generation;
+  m_domain = candidate_domain;
+  m_routes.swap(candidate_routes);
+  m_peer_policies.swap(candidate_peer_policies);
+
+  error.clear();
+  return true;
+} /* FederationLibrary::load */

--- a/src/svxlink/reflector/FederationLibrary.h
+++ b/src/svxlink/reflector/FederationLibrary.h
@@ -1,0 +1,138 @@
+/**
+@file   FederationLibrary.h
+@brief  Hot-reloadable talkgroup library for reflector federation
+@author Chris Jackson / G4NAB
+@date   2026-08-14
+
+\verbatim
+Copyright (C) 2026 Chris Jackson / G4NAB
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#ifndef FEDERATION_LIBRARY_INCLUDED
+#define FEDERATION_LIBRARY_INCLUDED
+
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief  Load and validate a federation talkgroup library
+
+A failed load leaves the previously accepted library metadata unchanged.
+*/
+class FederationLibrary
+{
+  public:
+    struct Route
+    {
+      enum Type
+      {
+        TYPE_EXACT,
+        TYPE_RANGE,
+        TYPE_PREFIX
+      };
+
+      Type          type;
+      std::uint32_t first;
+      std::uint32_t last;
+      std::string   prefix;
+      std::string   home;
+      std::string   scope;
+      std::string   service_anchor;
+      std::string   description;
+
+      Route(void)
+        : type(TYPE_EXACT), first(0), last(0)
+      {
+      }
+    };
+
+    struct TalkgroupPattern
+    {
+      enum Type
+      {
+        TYPE_EXACT,
+        TYPE_PREFIX
+      };
+
+      Type          type;
+      std::uint32_t exact;
+      std::string   prefix;
+
+      TalkgroupPattern(void)
+        : type(TYPE_EXACT), exact(0)
+      {
+      }
+    };
+
+    struct PeerPolicy
+    {
+      std::string                   peer;
+      std::vector<TalkgroupPattern> import_patterns;
+      std::vector<TalkgroupPattern> export_patterns;
+    };
+
+    FederationLibrary(void);
+    ~FederationLibrary(void);
+
+    bool load(const std::string& path,
+              const std::string& expected_domain,
+              std::string& error);
+
+    unsigned schema(void) const { return m_schema; }
+    std::uint64_t generation(void) const { return m_generation; }
+    const std::string& domain(void) const { return m_domain; }
+
+    std::size_t routeCount(void) const
+    {
+      return m_routes.size();
+    }
+
+    const std::vector<Route>& routes(void) const
+    {
+      return m_routes;
+    }
+
+    const Route* findRoute(std::uint32_t tg) const;
+    bool hasPeerPolicy(const std::string& peer) const;
+    bool mayImport(const std::string& peer, std::uint32_t tg) const;
+    bool mayExport(const std::string& peer, std::uint32_t tg) const;
+
+    const std::vector<PeerPolicy>& peerPolicies(void) const
+    {
+      return m_peer_policies;
+    }
+
+  private:
+    unsigned       m_schema;
+    std::uint64_t  m_generation;
+    std::string    m_domain;
+    std::vector<Route>  m_routes;
+    std::vector<PeerPolicy>  m_peer_policies;
+
+    FederationLibrary(const FederationLibrary&);
+    FederationLibrary& operator=(const FederationLibrary&);
+};  /* class FederationLibrary */
+
+
+#endif /* FEDERATION_LIBRARY_INCLUDED */

--- a/src/svxlink/reflector/FederationMsg.h
+++ b/src/svxlink/reflector/FederationMsg.h
@@ -1,0 +1,421 @@
+/**
+@file   FederationMsg.h
+@brief  SVXReflector federation protocol messages
+@author Chris Jackson / G4NAB
+@date   2026-08-14
+
+\verbatim
+Copyright (C) 2026 Chris Jackson / G4NAB
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#ifndef FEDERATION_MSG_INCLUDED
+#define FEDERATION_MSG_INCLUDED
+
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "ReflectorMsg.h"
+
+
+/****************************************************************************
+ *
+ * Protocol definitions
+ *
+ ****************************************************************************/
+
+namespace FederationProtocol
+{
+  enum
+  {
+    VERSION_MAJOR = 1,
+    VERSION_MINOR = 0,
+
+        CAP_MULTIPLEXED_OPUS = 1U << 0,
+
+    STREAM_ACCEPTED              = 0,
+    STREAM_REJECT_POLICY         = 1,
+    STREAM_REJECT_INVALID_ORIGIN = 2,
+    STREAM_REJECT_DUPLICATE      = 3,
+    STREAM_REJECT_CODEC          = 4,
+    STREAM_REJECT_LOCAL_BUSY     = 5,
+    STREAM_REJECT_PROTOCOL       = 6
+  };
+}
+
+
+/****************************************************************************
+ *
+ * TCP message definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief  Advertise an authenticated reflector's federation identity
+*/
+class MsgFederationHello : public ReflectorMsgBase<200>
+{
+  public:
+    MsgFederationHello(void)
+      : m_major(FederationProtocol::VERSION_MAJOR),
+        m_minor(FederationProtocol::VERSION_MINOR),
+        m_generation(0),
+        m_capabilities(FederationProtocol::CAP_MULTIPLEXED_OPUS)
+    {
+    }
+
+    MsgFederationHello(std::uint16_t major,
+                       std::uint16_t minor,
+                       const std::string& reflector_id,
+                       const std::string& domain,
+                       std::uint64_t generation,
+                       std::uint32_t capabilities)
+      : m_major(major),
+        m_minor(minor),
+        m_reflector_id(reflector_id),
+        m_domain(domain),
+        m_generation(generation),
+        m_capabilities(capabilities)
+    {
+    }
+
+    std::uint16_t major(void) const { return m_major; }
+    std::uint16_t minor(void) const { return m_minor; }
+
+    const std::string& reflectorId(void) const
+    {
+      return m_reflector_id;
+    }
+
+    const std::string& domain(void) const
+    {
+      return m_domain;
+    }
+
+    std::uint64_t generation(void) const
+    {
+      return m_generation;
+    }
+
+    std::uint32_t capabilities(void) const
+    {
+      return m_capabilities;
+    }
+
+    ASYNC_MSG_MEMBERS(m_major,
+                      m_minor,
+                      m_reflector_id,
+                      m_domain,
+                      m_generation,
+                      m_capabilities)
+
+  private:
+    std::uint16_t m_major;
+    std::uint16_t m_minor;
+    std::string   m_reflector_id;
+    std::string   m_domain;
+    std::uint64_t m_generation;
+    std::uint32_t m_capabilities;
+}; /* MsgFederationHello */
+
+
+/**
+@brief  Accept a federation hello and report negotiated capabilities
+*/
+class MsgFederationHelloAck : public ReflectorMsgBase<201>
+{
+  public:
+    MsgFederationHelloAck(void)
+      : m_major(FederationProtocol::VERSION_MAJOR),
+        m_minor(FederationProtocol::VERSION_MINOR),
+        m_capabilities(FederationProtocol::CAP_MULTIPLEXED_OPUS)
+    {
+    }
+
+    MsgFederationHelloAck(std::uint16_t major,
+                          std::uint16_t minor,
+                          const std::string& reflector_id,
+                          const std::string& domain,
+                          std::uint32_t capabilities)
+      : m_major(major),
+        m_minor(minor),
+        m_reflector_id(reflector_id),
+        m_domain(domain),
+        m_capabilities(capabilities)
+    {
+    }
+
+    std::uint16_t major(void) const { return m_major; }
+    std::uint16_t minor(void) const { return m_minor; }
+
+    const std::string& reflectorId(void) const
+    {
+      return m_reflector_id;
+    }
+
+    const std::string& domain(void) const
+    {
+      return m_domain;
+    }
+
+    std::uint32_t capabilities(void) const
+    {
+      return m_capabilities;
+    }
+
+    ASYNC_MSG_MEMBERS(m_major,
+                      m_minor,
+                      m_reflector_id,
+                      m_domain,
+                      m_capabilities)
+
+  private:
+    std::uint16_t m_major;
+    std::uint16_t m_minor;
+    std::string   m_reflector_id;
+    std::string   m_domain;
+    std::uint32_t m_capabilities;
+}; /* MsgFederationHelloAck */
+
+/**
+@brief  Request permission to begin one federated talkgroup stream
+*/
+class MsgFederationStreamStart : public ReflectorMsgBase<202>
+{
+  public:
+    MsgFederationStreamStart(void)
+      : m_tg(0), m_stream_id(0)
+    {
+    }
+
+    MsgFederationStreamStart(const std::string& origin_reflector_id,
+                             std::uint32_t tg,
+                             std::uint64_t stream_id,
+                             const std::string& source_callsign,
+                             const std::string& codec)
+      : m_origin_reflector_id(origin_reflector_id),
+        m_tg(tg),
+        m_stream_id(stream_id),
+        m_source_callsign(source_callsign),
+        m_codec(codec)
+    {
+    }
+
+    const std::string& originReflectorId(void) const
+    {
+      return m_origin_reflector_id;
+    }
+
+    std::uint32_t tg(void) const { return m_tg; }
+    std::uint64_t streamId(void) const { return m_stream_id; }
+
+    const std::string& sourceCallsign(void) const
+    {
+      return m_source_callsign;
+    }
+
+    const std::string& codec(void) const
+    {
+      return m_codec;
+    }
+
+    ASYNC_MSG_MEMBERS(m_origin_reflector_id,
+                      m_tg,
+                      m_stream_id,
+                      m_source_callsign,
+                      m_codec)
+
+  private:
+    std::string   m_origin_reflector_id;
+    std::uint32_t m_tg;
+    std::uint64_t m_stream_id;
+    std::string   m_source_callsign;
+    std::string   m_codec;
+}; /* MsgFederationStreamStart */
+
+
+/**
+@brief  Accept or reject a federated talkgroup stream
+*/
+class MsgFederationStreamResult : public ReflectorMsgBase<203>
+{
+  public:
+    MsgFederationStreamResult(void)
+      : m_tg(0),
+        m_stream_id(0),
+        m_accepted(0),
+        m_reason(FederationProtocol::STREAM_REJECT_PROTOCOL)
+    {
+    }
+
+    MsgFederationStreamResult(
+        const std::string& origin_reflector_id,
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        bool accepted,
+        std::uint16_t reason,
+        const std::string& detail="")
+      : m_origin_reflector_id(origin_reflector_id),
+        m_tg(tg),
+        m_stream_id(stream_id),
+        m_accepted(accepted ? 1 : 0),
+        m_reason(reason),
+        m_detail(detail)
+    {
+    }
+
+    const std::string& originReflectorId(void) const
+    {
+      return m_origin_reflector_id;
+    }
+
+    std::uint32_t tg(void) const { return m_tg; }
+    std::uint64_t streamId(void) const { return m_stream_id; }
+    bool accepted(void) const { return m_accepted != 0; }
+    std::uint16_t reason(void) const { return m_reason; }
+
+    const std::string& detail(void) const
+    {
+      return m_detail;
+    }
+
+    ASYNC_MSG_MEMBERS(m_origin_reflector_id,
+                      m_tg,
+                      m_stream_id,
+                      m_accepted,
+                      m_reason,
+                      m_detail)
+
+  private:
+    std::string   m_origin_reflector_id;
+    std::uint32_t m_tg;
+    std::uint64_t m_stream_id;
+    std::uint8_t  m_accepted;
+    std::uint16_t m_reason;
+    std::string   m_detail;
+}; /* MsgFederationStreamResult */
+
+
+/**
+@brief  Close one federated talkgroup stream
+*/
+class MsgFederationStreamStop : public ReflectorMsgBase<204>
+{
+  public:
+    MsgFederationStreamStop(void)
+      : m_tg(0), m_stream_id(0)
+    {
+    }
+
+    MsgFederationStreamStop(const std::string& origin_reflector_id,
+                            std::uint32_t tg,
+                            std::uint64_t stream_id)
+      : m_origin_reflector_id(origin_reflector_id),
+        m_tg(tg),
+        m_stream_id(stream_id)
+    {
+    }
+
+    const std::string& originReflectorId(void) const
+    {
+      return m_origin_reflector_id;
+    }
+
+    std::uint32_t tg(void) const { return m_tg; }
+    std::uint64_t streamId(void) const { return m_stream_id; }
+
+    ASYNC_MSG_MEMBERS(m_origin_reflector_id,
+                      m_tg,
+                      m_stream_id)
+
+  private:
+    std::string   m_origin_reflector_id;
+    std::uint32_t m_tg;
+    std::uint64_t m_stream_id;
+}; /* MsgFederationStreamStop */
+
+/****************************************************************************
+ *
+ * UDP message definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief  Carry one Opus frame for one federated talkgroup stream
+*/
+class MsgUdpFederationAudio : public ReflectorUdpMsgBase<201>
+{
+  public:
+    MsgUdpFederationAudio(void)
+      : m_tg(0), m_stream_id(0), m_sequence(0)
+    {
+    }
+
+    MsgUdpFederationAudio(
+        const std::string& origin_reflector_id,
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        std::uint32_t sequence,
+        const std::vector<std::uint8_t>& audio_data)
+      : m_origin_reflector_id(origin_reflector_id),
+        m_tg(tg),
+        m_stream_id(stream_id),
+        m_sequence(sequence),
+        m_audio_data(audio_data)
+    {
+    }
+
+    const std::string& originReflectorId(void) const
+    {
+      return m_origin_reflector_id;
+    }
+
+    std::uint32_t tg(void) const { return m_tg; }
+    std::uint64_t streamId(void) const { return m_stream_id; }
+    std::uint32_t sequence(void) const { return m_sequence; }
+
+    std::vector<std::uint8_t>& audioData(void)
+    {
+      return m_audio_data;
+    }
+
+    const std::vector<std::uint8_t>& audioData(void) const
+    {
+      return m_audio_data;
+    }
+
+    ASYNC_MSG_MEMBERS(m_origin_reflector_id,
+                      m_tg,
+                      m_stream_id,
+                      m_sequence,
+                      m_audio_data)
+
+  private:
+    std::string               m_origin_reflector_id;
+    std::uint32_t             m_tg;
+    std::uint64_t             m_stream_id;
+    std::uint32_t             m_sequence;
+    std::vector<std::uint8_t> m_audio_data;
+}; /* MsgUdpFederationAudio */
+
+#endif /* FEDERATION_MSG_INCLUDED */

--- a/src/svxlink/reflector/FederationPeerConnection.cpp
+++ b/src/svxlink/reflector/FederationPeerConnection.cpp
@@ -1,0 +1,1141 @@
+/**
+@file   FederationPeerConnection.cpp
+@brief  Outgoing V2 connection to a federated SVXReflector peer
+@author Chris Jackson / G4NAB
+@date   2026-08-15
+
+\verbatim
+Copyright (C) 2026 Chris Jackson / G4NAB
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+#include <AsyncUdpSocket.h>
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "FederationPeerConnection.h"
+#include "FederationMsg.h"
+#include "ReflectorMsg.h"
+
+
+/****************************************************************************
+ *
+ * Namespaces to use
+ *
+ ****************************************************************************/
+
+using namespace Async;
+using namespace sigc;
+
+
+/****************************************************************************
+ *
+ * Local constants
+ *
+ ****************************************************************************/
+
+namespace
+{
+  const unsigned RECONNECT_INTERVAL_MS = 60000;
+  const unsigned UDP_HEARTBEAT_TX_RESET = 15;
+  const unsigned UDP_HEARTBEAT_RX_RESET = 60;
+  const unsigned TCP_HEARTBEAT_TX_RESET = 10;
+  const unsigned TCP_HEARTBEAT_RX_RESET = 15;
+  const std::size_t MAX_PENDING_AUDIO_FRAMES = 25;
+}
+
+
+/****************************************************************************
+ *
+ * Public member functions
+ *
+ ****************************************************************************/
+
+FederationPeerConnection::FederationPeerConnection(
+    const std::string& peer,
+    const std::string& remote_reflector_id,
+    const std::string& local_reflector_id,
+    const std::string& local_domain,
+    std::uint64_t library_generation,
+    const std::string& callsign,
+    const std::string& host,
+    std::uint16_t port,
+    const std::string& auth_key)
+  : m_peer(peer),
+    m_remote_reflector_id(remote_reflector_id),
+    m_local_reflector_id(local_reflector_id),
+    m_local_domain(local_domain),
+    m_library_generation(library_generation),
+    m_callsign(callsign),
+    m_host(host),
+    m_port(port),
+    m_auth_key(auth_key),
+    m_udp_sock(0),
+    m_reconnect_timer(
+        RECONNECT_INTERVAL_MS,
+        Timer::TYPE_ONESHOT,
+        false),
+    m_heartbeat_timer(
+        1000,
+        Timer::TYPE_PERIODIC,
+        false),
+    m_state(STATE_DISCONNECTED),
+    m_started(false),
+    m_udp_registered(false),
+    m_client_id(0),
+    m_next_udp_tx_sequence(0),
+    m_next_udp_rx_sequence(0),
+    m_udp_heartbeat_tx_count(0),
+    m_udp_heartbeat_rx_count(0),
+    m_tcp_heartbeat_tx_count(0),
+    m_tcp_heartbeat_rx_count(0)
+{
+  m_con.addStaticSRVRecord(
+      0,
+      100,
+      100,
+      m_port,
+      m_host);
+
+  m_con.connected.connect(
+      mem_fun(*this, &FederationPeerConnection::onConnected));
+
+  m_con.disconnected.connect(
+      mem_fun(*this, &FederationPeerConnection::onDisconnected));
+
+  m_con.frameReceived.connect(
+      mem_fun(*this, &FederationPeerConnection::onFrameReceived));
+
+  m_reconnect_timer.expired.connect(
+      hide(mem_fun(*this, &FederationPeerConnection::reconnect)));
+
+  m_heartbeat_timer.expired.connect(
+      mem_fun(*this, &FederationPeerConnection::heartbeatTick));
+
+  m_con.setMaxFrameSize(ReflectorMsg::MAX_PREAUTH_FRAME_SIZE);
+} /* FederationPeerConnection::FederationPeerConnection */
+
+
+FederationPeerConnection::~FederationPeerConnection(void)
+{
+  stop();
+
+  delete m_udp_sock;
+  m_udp_sock = 0;
+} /* FederationPeerConnection::~FederationPeerConnection */
+
+
+void FederationPeerConnection::start(void)
+{
+  if (m_started)
+  {
+    return;
+  }
+
+  m_started = true;
+  connect();
+} /* FederationPeerConnection::start */
+
+
+void FederationPeerConnection::stop(void)
+{
+  m_started = false;
+  m_reconnect_timer.setEnable(false);
+  m_heartbeat_timer.setEnable(false);
+  disconnect();
+} /* FederationPeerConnection::stop */
+
+
+const FederationPeerConnection::OutgoingStream*
+FederationPeerConnection::findOutgoingStream(
+    std::uint32_t tg) const
+{
+  std::map<std::uint32_t, OutgoingStream>::const_iterator it =
+      m_outgoing_streams.find(tg);
+
+  return (it == m_outgoing_streams.end())
+      ? 0
+      : &it->second;
+} /* FederationPeerConnection::findOutgoingStream */
+
+
+bool FederationPeerConnection::startOutgoingStream(
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    const std::string& source_callsign,
+    const std::string& codec,
+    std::string& error)
+{
+  error.clear();
+
+  if (!isConnected())
+  {
+    error = "Federation peer is not connected";
+    return false;
+  }
+
+  if (!isUdpRegistered())
+  {
+    error = "Federation peer UDP path is not registered";
+    return false;
+  }
+
+  if (tg == 0)
+  {
+    error = "Talkgroup zero is not a valid federation stream";
+    return false;
+  }
+
+  if (stream_id == 0)
+  {
+    error = "Stream ID zero is invalid";
+    return false;
+  }
+
+  if (source_callsign.empty())
+  {
+    error = "Stream source callsign is missing";
+    return false;
+  }
+
+  if (codec != "OPUS")
+  {
+    error = "Only OPUS federation streams are supported";
+    return false;
+  }
+
+  if (m_outgoing_streams.find(tg) !=
+      m_outgoing_streams.end())
+  {
+    error = "Talkgroup already has an outgoing federation stream";
+    return false;
+  }
+
+  OutgoingStream stream;
+  stream.tg = tg;
+  stream.stream_id = stream_id;
+  stream.source_callsign = source_callsign;
+  stream.codec = codec;
+  stream.state = OUTGOING_STREAM_PENDING;
+
+  m_outgoing_streams[tg] = stream;
+
+  sendMsg(MsgFederationStreamStart(
+      m_local_reflector_id,
+      tg,
+      stream_id,
+      source_callsign,
+      codec));
+
+  std::cout << "Federation peer " << m_peer
+            << ": Requested outgoing stream:"
+            << " tg=" << tg
+            << " stream_id=" << stream_id
+            << " source=" << source_callsign
+            << " codec=" << codec
+            << std::endl;
+
+  return true;
+} /* FederationPeerConnection::startOutgoingStream */
+
+
+bool FederationPeerConnection::stopOutgoingStream(
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    std::string& error)
+{
+  error.clear();
+
+  if (!isConnected())
+  {
+    error = "Federation peer is not connected";
+    return false;
+  }
+
+  std::map<std::uint32_t, OutgoingStream>::iterator it =
+      m_outgoing_streams.find(tg);
+
+  if (it == m_outgoing_streams.end())
+  {
+    error = "Outgoing federation stream is not active";
+    return false;
+  }
+
+  if (it->second.stream_id != stream_id)
+  {
+    error = "Outgoing federation stream identity does not match";
+    return false;
+  }
+
+  sendMsg(MsgFederationStreamStop(
+      m_local_reflector_id,
+      tg,
+      stream_id));
+
+  m_outgoing_streams.erase(it);
+
+  std::cout << "Federation peer " << m_peer
+            << ": Stopped outgoing stream:"
+            << " tg=" << tg
+            << " stream_id=" << stream_id
+            << std::endl;
+
+  return true;
+} /* FederationPeerConnection::stopOutgoingStream */
+
+
+bool FederationPeerConnection::sendOutgoingAudio(
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    const std::vector<std::uint8_t>& audio_data,
+    std::string& error)
+{
+  error.clear();
+
+  if (!isConnected())
+  {
+    error = "Federation peer is not connected";
+    return false;
+  }
+
+  if (!isUdpRegistered())
+  {
+    error = "Federation peer UDP path is not registered";
+    return false;
+  }
+
+  std::map<std::uint32_t, OutgoingStream>::iterator it =
+      m_outgoing_streams.find(tg);
+
+  if (it == m_outgoing_streams.end())
+  {
+    error = "Outgoing federation stream does not exist";
+    return false;
+  }
+
+  if (stream_id == 0)
+  {
+    error = "Stream ID zero is invalid";
+    return false;
+  }
+
+  if (it->second.stream_id != stream_id)
+  {
+    error = "Outgoing federation stream identity does not match";
+    return false;
+  }
+
+  if (audio_data.empty())
+  {
+    error = "Federation audio data is empty";
+    return false;
+  }
+
+  if (it->second.state == OUTGOING_STREAM_PENDING)
+  {
+    if (it->second.pending_audio.size() >=
+        MAX_PENDING_AUDIO_FRAMES)
+    {
+      it->second.pending_audio.pop_front();
+    }
+
+    it->second.pending_audio.push_back(audio_data);
+    return true;
+  }
+
+  if (it->second.state != OUTGOING_STREAM_ACTIVE)
+  {
+    error = "Outgoing federation stream has an invalid state";
+    return false;
+  }
+
+  sendOutgoingAudioFrame(it->second, audio_data);
+  return true;
+} /* FederationPeerConnection::sendOutgoingAudio */
+
+
+/****************************************************************************
+ *
+ * Private member functions
+ *
+ ****************************************************************************/
+
+void FederationPeerConnection::sendOutgoingAudioFrame(
+    OutgoingStream& stream,
+    const std::vector<std::uint8_t>& audio_data)
+{
+  MsgUdpFederationAudio msg(
+      m_local_reflector_id,
+      stream.tg,
+      stream.stream_id,
+      stream.next_audio_sequence,
+      audio_data);
+
+  sendUdpMsg(msg);
+  ++stream.next_audio_sequence;
+} /* FederationPeerConnection::sendOutgoingAudioFrame */
+
+
+void FederationPeerConnection::connect(void)
+{
+  if (!m_started || m_con.isConnected())
+  {
+    return;
+  }
+
+  m_reconnect_timer.setEnable(false);
+
+  std::cout << "Federation peer " << m_peer
+            << ": Connecting to "
+            << m_host << ":" << m_port
+            << std::endl;
+
+  m_con.connect();
+} /* FederationPeerConnection::connect */
+
+
+void FederationPeerConnection::disconnect(void)
+{
+  const bool was_connected = m_con.isConnected();
+  m_con.disconnect();
+
+  if (was_connected)
+  {
+    onDisconnected(
+        &m_con,
+        TcpConnection::DR_ORDERED_DISCONNECT);
+  }
+
+  m_state = STATE_DISCONNECTED;
+} /* FederationPeerConnection::disconnect */
+
+
+void FederationPeerConnection::reconnect(void)
+{
+  if (!m_started)
+  {
+    return;
+  }
+
+  disconnect();
+  connect();
+} /* FederationPeerConnection::reconnect */
+
+
+void FederationPeerConnection::onConnected(void)
+{
+  std::cout << "Federation peer " << m_peer
+            << ": TCP connection established to "
+            << m_con.remoteHost() << ":"
+            << m_con.remotePort()
+            << std::endl;
+
+  m_state = STATE_EXPECT_AUTH_CHALLENGE;
+  m_udp_registered = false;
+  m_client_id = 0;
+  m_next_udp_tx_sequence = 0;
+  m_next_udp_rx_sequence = 0;
+  m_udp_heartbeat_tx_count = UDP_HEARTBEAT_TX_RESET;
+  m_udp_heartbeat_rx_count = UDP_HEARTBEAT_RX_RESET;
+  m_tcp_heartbeat_tx_count = TCP_HEARTBEAT_TX_RESET;
+  m_tcp_heartbeat_rx_count = TCP_HEARTBEAT_RX_RESET;
+
+  m_con.setMaxFrameSize(ReflectorMsg::MAX_PREAUTH_FRAME_SIZE);
+  m_heartbeat_timer.setEnable(true);
+
+  sendMsg(MsgProtoVer(2, 0));
+} /* FederationPeerConnection::onConnected */
+
+
+void FederationPeerConnection::onDisconnected(
+    Async::TcpConnection* con,
+    Async::TcpConnection::DisconnectReason reason)
+{
+  (void)con;
+
+  std::cout << "Federation peer " << m_peer
+            << ": Disconnected: "
+            << TcpConnection::disconnectReasonStr(reason)
+            << std::endl;
+
+  m_heartbeat_timer.setEnable(false);
+  delete m_udp_sock;
+  m_udp_sock = 0;
+  m_udp_registered = false;
+  m_state = STATE_DISCONNECTED;
+  m_client_id = 0;
+  m_next_udp_tx_sequence = 0;
+  m_next_udp_rx_sequence = 0;
+  m_udp_heartbeat_tx_count = 0;
+  m_udp_heartbeat_rx_count = 0;
+  m_outgoing_streams.clear();
+  m_tcp_heartbeat_tx_count = 0;
+  m_tcp_heartbeat_rx_count = 0;
+
+  if (m_started)
+  {
+    m_reconnect_timer.setEnable(true);
+  }
+} /* FederationPeerConnection::onDisconnected */
+
+
+void FederationPeerConnection::onFrameReceived(
+    Async::FramedTcpConnection* con,
+    std::vector<std::uint8_t>& data)
+{
+  (void)con;
+
+  if (data.empty())
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer << ": Empty TCP frame received"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  std::stringstream stream;
+  stream.write(
+      reinterpret_cast<const char*>(&data.front()),
+      data.size());
+
+  ReflectorMsg header;
+  if (!header.unpack(stream))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Could not unpack TCP message header"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if ((header.type() >= 100) &&
+      (m_state < STATE_EXPECT_SERVER_INFO))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": User message received before authentication"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  m_tcp_heartbeat_rx_count = TCP_HEARTBEAT_RX_RESET;
+
+  switch (header.type())
+  {
+    case MsgHeartbeat::TYPE:
+      break;
+
+    case MsgError::TYPE:
+    {
+      MsgError msg;
+      if (!msg.unpack(stream))
+      {
+        std::cerr << "*** ERROR: Federation peer "
+                  << m_peer
+                  << ": Could not unpack MsgError"
+                  << std::endl;
+      }
+      else
+      {
+        std::cerr << "*** ERROR: Federation peer "
+                  << m_peer << ": "
+                  << msg.message()
+                  << std::endl;
+      }
+      disconnect();
+      break;
+    }
+
+    case MsgProtoVerDowngrade::TYPE:
+      std::cerr << "*** ERROR: Federation peer "
+                << m_peer
+                << ": Remote reflector rejected V2 protocol"
+                << std::endl;
+      disconnect();
+      break;
+
+    case MsgAuthChallenge::TYPE:
+      handleAuthChallenge(stream);
+      break;
+
+    case MsgAuthOk::TYPE:
+      if (m_state != STATE_EXPECT_AUTH_OK)
+      {
+        std::cerr << "*** ERROR: Federation peer "
+                  << m_peer
+                  << ": Unexpected MsgAuthOk"
+                  << std::endl;
+        disconnect();
+        return;
+      }
+
+      std::cout << "Federation peer " << m_peer
+                << ": V2 authentication accepted"
+                << std::endl;
+
+      m_state = STATE_EXPECT_SERVER_INFO;
+      m_con.setMaxFrameSize(
+          ReflectorMsg::MAX_POSTAUTH_FRAME_SIZE);
+      break;
+
+    case MsgServerInfo::TYPE:
+      handleServerInfo(stream);
+      break;
+
+    case MsgFederationHelloAck::TYPE:
+      handleFederationAck(stream);
+      break;
+
+    case MsgFederationStreamResult::TYPE:
+      handleFederationStreamResult(stream);
+      break;
+
+    default:
+      break;
+  }
+} /* FederationPeerConnection::onFrameReceived */
+
+
+void FederationPeerConnection::handleAuthChallenge(
+    std::istream& is)
+{
+  if (m_state != STATE_EXPECT_AUTH_CHALLENGE)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Unexpected MsgAuthChallenge"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  MsgAuthChallenge msg;
+  if (!msg.unpack(is) || (msg.challenge() == 0))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Invalid authentication challenge"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  sendMsg(MsgAuthResponse(
+      m_callsign,
+      m_auth_key,
+      msg.challenge()));
+
+  m_state = STATE_EXPECT_AUTH_OK;
+} /* FederationPeerConnection::handleAuthChallenge */
+
+
+void FederationPeerConnection::handleServerInfo(
+    std::istream& is)
+{
+  if (m_state != STATE_EXPECT_SERVER_INFO)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Unexpected MsgServerInfo"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  MsgServerInfo msg;
+  if (!msg.unpack(is))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Could not unpack MsgServerInfo"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if (msg.clientId() == 0)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Remote reflector supplied client ID zero"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  const std::vector<std::string>& codecs = msg.codecs();
+  if (std::find(codecs.begin(), codecs.end(), "OPUS") ==
+      codecs.end())
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Remote reflector does not advertise OPUS"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  m_client_id = msg.clientId();
+
+  delete m_udp_sock;
+  m_udp_sock = new UdpSocket;
+  m_udp_sock->dataReceived.connect(
+      mem_fun(
+          *this,
+          &FederationPeerConnection::udpDatagramReceived));
+
+  m_state = STATE_EXPECT_FEDERATION_ACK;
+
+  sendMsg(MsgFederationHello(
+      FederationProtocol::VERSION_MAJOR,
+      FederationProtocol::VERSION_MINOR,
+      m_local_reflector_id,
+      m_local_domain,
+      m_library_generation,
+      FederationProtocol::CAP_MULTIPLEXED_OPUS));
+} /* FederationPeerConnection::handleServerInfo */
+
+
+void FederationPeerConnection::handleFederationAck(
+    std::istream& is)
+{
+  if (m_state != STATE_EXPECT_FEDERATION_ACK)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Unexpected MsgFederationHelloAck"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  MsgFederationHelloAck msg;
+  if (!msg.unpack(is))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Could not unpack MsgFederationHelloAck"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if (msg.major() != FederationProtocol::VERSION_MAJOR)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Federation major version mismatch"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if (msg.minor() > FederationProtocol::VERSION_MINOR)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Invalid negotiated federation minor version"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if (msg.reflectorId() != m_remote_reflector_id)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Federation acknowledgment identity mismatch"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if (msg.domain() != m_peer)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Federation acknowledgment domain mismatch"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if ((msg.capabilities() &
+       FederationProtocol::CAP_MULTIPLEXED_OPUS) == 0)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Mandatory multiplexed OPUS capability missing"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  m_state = STATE_CONNECTED;
+  m_udp_heartbeat_tx_count = UDP_HEARTBEAT_TX_RESET;
+  m_udp_heartbeat_rx_count = UDP_HEARTBEAT_RX_RESET;
+
+  sendUdpMsg(MsgUdpHeartbeat());
+
+  std::cout << "Federation peer " << m_peer
+            << ": Federation session established:"
+            << " reflector_id=" << msg.reflectorId()
+            << " version=" << msg.major()
+            << "." << msg.minor()
+            << " capabilities=" << msg.capabilities()
+            << std::endl;
+} /* FederationPeerConnection::handleFederationAck */
+
+
+void FederationPeerConnection::handleFederationStreamResult(
+    std::istream& is)
+{
+  if (!isConnected())
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Stream result received before federation connection"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  MsgFederationStreamResult msg;
+  if (!msg.unpack(is))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Could not unpack MsgFederationStreamResult"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  if (msg.originReflectorId() != m_local_reflector_id)
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Stream result origin identity mismatch"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  std::map<std::uint32_t, OutgoingStream>::iterator it =
+      m_outgoing_streams.find(msg.tg());
+
+  if ((it == m_outgoing_streams.end()) ||
+      (it->second.stream_id != msg.streamId()) ||
+      (it->second.state != OUTGOING_STREAM_PENDING))
+  {
+    std::cerr << "*** WARNING: Federation peer "
+              << m_peer
+              << ": Stream result does not match a pending stream:"
+              << " tg=" << msg.tg()
+              << " stream_id=" << msg.streamId()
+              << std::endl;
+    return;
+  }
+
+  if (msg.accepted() &&
+      (msg.reason() == FederationProtocol::STREAM_ACCEPTED))
+  {
+    it->second.state = OUTGOING_STREAM_ACTIVE;
+
+    const std::size_t queued_frames =
+        it->second.pending_audio.size();
+
+    while (!it->second.pending_audio.empty())
+    {
+      const std::vector<std::uint8_t> audio_data(
+          it->second.pending_audio.front());
+
+      it->second.pending_audio.pop_front();
+      sendOutgoingAudioFrame(it->second, audio_data);
+    }
+
+    std::cout << "Federation peer " << m_peer
+              << ": Outgoing stream accepted:"
+              << " tg=" << msg.tg()
+              << " stream_id=" << msg.streamId()
+              << " queued_audio_frames=" << queued_frames
+              << std::endl;
+    return;
+  }
+
+  if (msg.accepted() ||
+      (msg.reason() == FederationProtocol::STREAM_ACCEPTED))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Inconsistent stream result"
+              << std::endl;
+    m_outgoing_streams.erase(it);
+    disconnect();
+    return;
+  }
+
+  std::cerr << "*** WARNING: Federation peer "
+            << m_peer
+            << ": Outgoing stream rejected:"
+            << " tg=" << msg.tg()
+            << " stream_id=" << msg.streamId()
+            << " reason=" << msg.reason()
+            << " detail=" << msg.detail()
+            << std::endl;
+
+  m_outgoing_streams.erase(it);
+} /* FederationPeerConnection::handleFederationStreamResult */
+
+
+void FederationPeerConnection::udpDatagramReceived(
+    const Async::IpAddress& address,
+    std::uint16_t port,
+    void* buffer,
+    int count)
+{
+  if (!isConnected() || (buffer == 0) || (count <= 0))
+  {
+    return;
+  }
+
+  if (address != m_con.remoteHost())
+  {
+    std::cerr << "*** WARNING: Federation peer "
+              << m_peer
+              << ": UDP packet received from wrong address "
+              << address
+              << std::endl;
+    return;
+  }
+
+  if (port != m_con.remotePort())
+  {
+    std::cerr << "*** WARNING: Federation peer "
+              << m_peer
+              << ": UDP packet received from wrong port "
+              << port
+              << std::endl;
+    return;
+  }
+
+  std::stringstream stream;
+  stream.write(
+      reinterpret_cast<const char*>(buffer),
+      count);
+
+  ReflectorUdpMsgV2 header;
+  if (!header.unpack(stream))
+  {
+    std::cerr << "*** WARNING: Federation peer "
+              << m_peer
+              << ": Could not unpack V2 UDP header"
+              << std::endl;
+    return;
+  }
+
+  if (header.clientId() != m_client_id)
+  {
+    std::cerr << "*** WARNING: Federation peer "
+              << m_peer
+              << ": UDP client ID mismatch"
+              << std::endl;
+    return;
+  }
+
+  const std::uint16_t difference =
+      header.sequenceNum() - m_next_udp_rx_sequence;
+
+  if (difference > 0x7fff)
+  {
+    std::cerr << "*** WARNING: Federation peer "
+              << m_peer
+              << ": Dropping out-of-order UDP packet"
+              << std::endl;
+    return;
+  }
+
+  if (difference > 0)
+  {
+    std::cout << "Federation peer " << m_peer
+              << ": UDP packet loss: expected="
+              << m_next_udp_rx_sequence
+              << " received=" << header.sequenceNum()
+              << std::endl;
+  }
+
+  m_next_udp_rx_sequence = header.sequenceNum() + 1;
+  m_udp_heartbeat_rx_count = UDP_HEARTBEAT_RX_RESET;
+
+  switch (header.type())
+  {
+    case MsgUdpHeartbeat::TYPE:
+      if (!m_udp_registered)
+      {
+        m_udp_registered = true;
+
+        std::cout << "Federation peer " << m_peer
+                  << ": V2 UDP path registered"
+                  << std::endl;
+      }
+      break;
+
+    default:
+      break;
+  }
+} /* FederationPeerConnection::udpDatagramReceived */
+
+
+void FederationPeerConnection::sendUdpMsg(
+    const ReflectorUdpMsg& msg)
+{
+  if (!isConnected() ||
+      (m_udp_sock == 0) ||
+      (m_client_id == 0))
+  {
+    return;
+  }
+
+  m_udp_heartbeat_tx_count = UDP_HEARTBEAT_TX_RESET;
+
+  ReflectorUdpMsgV2 header(
+      msg.type(),
+      m_client_id,
+      m_next_udp_tx_sequence++);
+
+  std::ostringstream stream;
+  if (!header.pack(stream) || !msg.pack(stream))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Could not pack V2 UDP message"
+              << std::endl;
+    return;
+  }
+
+  const std::string datagram(stream.str());
+  m_udp_sock->write(
+      m_con.remoteHost(),
+      m_con.remotePort(),
+      datagram.data(),
+      datagram.size());
+} /* FederationPeerConnection::sendUdpMsg */
+
+
+void FederationPeerConnection::heartbeatTick(
+    Async::Timer* timer)
+{
+  (void)timer;
+
+  if (m_state == STATE_DISCONNECTED)
+  {
+    return;
+  }
+
+  if (m_state == STATE_CONNECTED)
+  {
+    if ((m_udp_heartbeat_tx_count > 0) &&
+        (--m_udp_heartbeat_tx_count == 0))
+    {
+      sendUdpMsg(MsgUdpHeartbeat());
+    }
+
+    if ((m_udp_heartbeat_rx_count > 0) &&
+        (--m_udp_heartbeat_rx_count == 0))
+    {
+      std::cerr << "*** ERROR: Federation peer "
+                << m_peer
+                << ": UDP heartbeat timeout"
+                << std::endl;
+      disconnect();
+      return;
+    }
+  }
+
+  if ((m_tcp_heartbeat_tx_count > 0) &&
+      (--m_tcp_heartbeat_tx_count == 0))
+  {
+    sendMsg(MsgHeartbeat());
+  }
+
+  if ((m_tcp_heartbeat_rx_count > 0) &&
+      (--m_tcp_heartbeat_rx_count == 0))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": TCP heartbeat timeout"
+              << std::endl;
+    disconnect();
+  }
+} /* FederationPeerConnection::heartbeatTick */
+
+
+void FederationPeerConnection::sendMsg(
+    const ReflectorMsg& msg)
+{
+  if (!m_con.isConnected())
+  {
+    return;
+  }
+
+  if ((msg.type() >= 100) &&
+      (m_state < STATE_EXPECT_FEDERATION_ACK))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Attempt to send user message before authentication"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  m_tcp_heartbeat_tx_count = TCP_HEARTBEAT_TX_RESET;
+
+  std::ostringstream stream;
+  ReflectorMsg header(msg.type());
+
+  if (!header.pack(stream) || !msg.pack(stream))
+  {
+    std::cerr << "*** ERROR: Federation peer "
+              << m_peer
+              << ": Could not pack TCP message"
+              << std::endl;
+    disconnect();
+    return;
+  }
+
+  const std::string frame(stream.str());
+  if (m_con.write(frame.data(), frame.size()) == -1)
+  {
+    disconnect();
+  }
+} /* FederationPeerConnection::sendMsg */

--- a/src/svxlink/reflector/FederationPeerConnection.h
+++ b/src/svxlink/reflector/FederationPeerConnection.h
@@ -1,0 +1,237 @@
+/**
+@file   FederationPeerConnection.h
+@brief  Outgoing V2 connection to a federated SVXReflector peer
+@author Chris Jackson / G4NAB
+@date   2026-08-15
+
+\verbatim
+Copyright (C) 2026 Chris Jackson / G4NAB
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#ifndef FEDERATION_PEER_CONNECTION_INCLUDED
+#define FEDERATION_PEER_CONNECTION_INCLUDED
+
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <cstdint>
+#include <deque>
+#include <istream>
+#include <map>
+#include <string>
+#include <vector>
+
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+#include <AsyncFramedTcpConnection.h>
+#include <AsyncIpAddress.h>
+#include <AsyncTcpPrioClient.h>
+#include <AsyncTimer.h>
+
+
+/****************************************************************************
+ *
+ * Forward declarations
+ *
+ ****************************************************************************/
+
+namespace Async
+{
+  class UdpSocket;
+}
+
+class ReflectorMsg;
+class ReflectorUdpMsg;
+
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+/**
+@brief  Maintain one outgoing V2 federation peer connection
+
+The TCP connection is configured during initialization but remains inert until
+start() is called. A successfully authenticated V2 connection is upgraded to a
+federation session using MsgFederationHello.
+*/
+class FederationPeerConnection : public sigc::trackable
+{
+  public:
+    enum State
+    {
+      STATE_DISCONNECTED,
+      STATE_EXPECT_AUTH_CHALLENGE,
+      STATE_EXPECT_AUTH_OK,
+      STATE_EXPECT_SERVER_INFO,
+      STATE_EXPECT_FEDERATION_ACK,
+      STATE_CONNECTED
+    };
+
+    enum OutgoingStreamState
+    {
+      OUTGOING_STREAM_PENDING,
+      OUTGOING_STREAM_ACTIVE
+    };
+
+    struct OutgoingStream
+    {
+      std::uint32_t       tg;
+      std::uint64_t       stream_id;
+      std::string         source_callsign;
+      std::string         codec;
+      OutgoingStreamState state;
+      std::uint32_t       next_audio_sequence;
+      std::deque<std::vector<std::uint8_t> > pending_audio;
+      OutgoingStream(void)
+        : tg(0),
+          stream_id(0),
+          state(OUTGOING_STREAM_PENDING),
+          next_audio_sequence(0)
+      {
+      }
+    };
+
+    FederationPeerConnection(
+        const std::string& peer,
+        const std::string& remote_reflector_id,
+        const std::string& local_reflector_id,
+        const std::string& local_domain,
+        std::uint64_t library_generation,
+        const std::string& callsign,
+        const std::string& host,
+        std::uint16_t port,
+        const std::string& auth_key);
+
+    ~FederationPeerConnection(void);
+
+    const std::string& peer(void) const { return m_peer; }
+    const std::string& host(void) const { return m_host; }
+    std::uint16_t port(void) const { return m_port; }
+    State state(void) const { return m_state; }
+
+    bool isConnected(void) const
+    {
+      return m_state == STATE_CONNECTED;
+    }
+
+    bool isUdpRegistered(void) const
+    {
+      return m_udp_registered;
+    }
+
+    void start(void);
+    void stop(void);
+
+    bool startOutgoingStream(
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        const std::string& source_callsign,
+        const std::string& codec,
+        std::string& error);
+
+    bool stopOutgoingStream(
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        std::string& error);
+
+    bool sendOutgoingAudio(
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        const std::vector<std::uint8_t>& audio_data,
+        std::string& error);
+
+    const OutgoingStream* findOutgoingStream(
+        std::uint32_t tg) const;
+
+    std::size_t outgoingStreamCount(void) const
+    {
+      return m_outgoing_streams.size();
+    }
+
+  private:
+    typedef Async::TcpPrioClient<
+        Async::FramedTcpConnection> FramedTcpClient;
+
+    std::string       m_peer;
+    std::string       m_remote_reflector_id;
+    std::string       m_local_reflector_id;
+    std::string       m_local_domain;
+    std::uint64_t     m_library_generation;
+    std::string       m_callsign;
+    std::string       m_host;
+    std::uint16_t     m_port;
+    std::string       m_auth_key;
+    FramedTcpClient   m_con;
+    Async::UdpSocket*  m_udp_sock;
+    Async::Timer      m_reconnect_timer;
+    Async::Timer      m_heartbeat_timer;
+    State             m_state;
+    bool              m_started;
+    bool              m_udp_registered;
+    std::uint32_t     m_client_id;
+    std::uint16_t     m_next_udp_tx_sequence;
+    std::uint16_t     m_next_udp_rx_sequence;
+    unsigned          m_udp_heartbeat_tx_count;
+    unsigned          m_udp_heartbeat_rx_count;
+    unsigned          m_tcp_heartbeat_tx_count;
+    unsigned          m_tcp_heartbeat_rx_count;
+    std::map<std::uint32_t, OutgoingStream> m_outgoing_streams;
+
+    FederationPeerConnection(const FederationPeerConnection&);
+    FederationPeerConnection& operator=(
+        const FederationPeerConnection&);
+
+    void connect(void);
+    void disconnect(void);
+    void reconnect(void);
+
+    void onConnected(void);
+    void onDisconnected(
+        Async::TcpConnection* con,
+        Async::TcpConnection::DisconnectReason reason);
+
+    void onFrameReceived(
+        Async::FramedTcpConnection* con,
+        std::vector<std::uint8_t>& data);
+
+    void handleAuthChallenge(std::istream& is);
+    void handleServerInfo(std::istream& is);
+    void handleFederationAck(std::istream& is);
+    void handleFederationStreamResult(std::istream& is);
+    void udpDatagramReceived(
+        const Async::IpAddress& address,
+        std::uint16_t port,
+        void* buffer,
+        int count);
+
+    void sendOutgoingAudioFrame(
+        OutgoingStream& stream,
+        const std::vector<std::uint8_t>& audio_data);
+
+    void sendUdpMsg(const ReflectorUdpMsg& msg);
+
+    void heartbeatTick(Async::Timer* timer);
+
+    void sendMsg(const ReflectorMsg& msg);
+}; /* class FederationPeerConnection */
+
+
+#endif /* FEDERATION_PEER_CONNECTION_INCLUDED */

--- a/src/svxlink/reflector/Reflector.cpp
+++ b/src/svxlink/reflector/Reflector.cpp
@@ -67,6 +67,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Reflector.h"
 #include "ReflectorClient.h"
 #include "TGHandler.h"
+#include "FederationMsg.h"
+#include "ReflectorFederation.h"
+
 
 
 /****************************************************************************
@@ -231,6 +234,7 @@ time_t Reflector::timeToRenewCert(const Async::SslX509& cert)
 Reflector::Reflector(void)
   : m_srv(0), m_udp_sock(0), m_tg_for_v1_clients(1), m_random_qsy_lo(0),
     m_random_qsy_hi(0), m_random_qsy_tg(0), m_http_server(0), m_cmd_pty(0),
+    m_federation(0),
     m_keys_dir("private/"), m_pending_csrs_dir("pending_csrs/"),
     m_csrs_dir("csrs/"), m_certs_dir("certs/"), m_pki_dir("pki/")
 {
@@ -272,6 +276,8 @@ Reflector::~Reflector(void)
   m_cmd_pty = 0;
   m_client_con_map.clear();
   ReflectorClient::cleanup();
+  delete m_federation;
+  m_federation = 0;
   delete TGHandler::instance();
 } /* Reflector::~Reflector */
 
@@ -367,8 +373,27 @@ bool Reflector::initialize(Async::Config &cfg)
   }
 
   m_cfg->getValue("GLOBAL", "ACCEPT_CERT_EMAIL", m_accept_cert_email);
+  m_federation = new ReflectorFederation;
+  if ((m_federation == 0) || !m_federation->initialize(cfg))
+  {
+    std::cerr << "*** ERROR: Could not initialize reflector federation"
+              << std::endl;
+    return false;
+  }
+
+  m_federation->incomingStreamStarted.connect(
+      sigc::mem_fun(
+          *this,
+          &Reflector::onFederationStreamStarted));
+
+  m_federation->incomingStreamStopped.connect(
+      sigc::mem_fun(
+          *this,
+          &Reflector::onFederationStreamStopped));
 
   m_cfg->valueUpdated.connect(sigc::mem_fun(*this, &Reflector::cfgUpdated));
+
+  m_federation->startPeerConnections();
 
   return true;
 } /* Reflector::initialize */
@@ -1167,28 +1192,68 @@ void Reflector::udpDatagramReceived(const IpAddress& addr, uint16_t port,
                << "]: Could not unpack incoming MsgUdpAudioV1 message" << endl;
           return;
         }
+
         uint32_t tg = TGHandler::instance()->TGForClient(client);
         if (!msg.audioData().empty() && (tg > 0))
         {
-          ReflectorClient* talker = TGHandler::instance()->talkerForTG(tg);
+          if ((m_federation != 0) &&
+              (m_federation->findIncomingStream(tg) != 0))
+          {
+            break;
+          }
+
+          ReflectorClient* talker =
+              TGHandler::instance()->talkerForTG(tg);
+
           if (talker == 0)
           {
             TGHandler::instance()->setTalkerForTG(tg, client);
             talker = TGHandler::instance()->talkerForTG(tg);
           }
+
           if (talker == client)
           {
             TGHandler::instance()->setTalkerForTG(tg, client);
-            broadcastUdpMsg(msg,
+
+            broadcastUdpMsg(
+                msg,
                 ReflectorClient::mkAndFilter(
-                  ReflectorClient::ExceptFilter(client),
-                  ReflectorClient::TgFilter(tg)));
-            //broadcastUdpMsgExcept(tg, client, msg,
-            //    ProtoVerRange(ProtoVer(0, 6),
-            //                  ProtoVer(1, ProtoVer::max().minor())));
-            //MsgUdpAudio msg_v2(msg);
-            //broadcastUdpMsgExcept(tg, client, msg_v2,
-            //    ProtoVerRange(ProtoVer(2, 0), ProtoVer::max()));
+                    ReflectorClient::ExceptFilter(client),
+                    ReflectorClient::TgFilter(tg)));
+
+            if ((m_federation != 0) &&
+                m_federation->isEnabled())
+            {
+              if (m_federation->findLocalStream(tg) == 0)
+              {
+                std::uint64_t stream_id = 0;
+                std::vector<std::string> started_peers;
+                std::string error;
+
+                if (!m_federation->beginLocalStream(
+                        tg,
+                        client->callsign(),
+                        "OPUS",
+                        stream_id,
+                        started_peers,
+                        error))
+                {
+                  std::cerr << "*** WARNING["
+                            << client->callsign()
+                            << "]: Could not begin local federation stream:"
+                            << " tg=" << tg
+                            << " detail=" << error
+                            << std::endl;
+                }
+              }
+
+              if (m_federation->findLocalStream(tg) != 0)
+              {
+                m_federation->sendLocalStreamAudio(
+                    tg,
+                    msg.audioData());
+              }
+            }
           }
         }
       }
@@ -1229,14 +1294,85 @@ void Reflector::udpDatagramReceived(const IpAddress& addr, uint16_t port,
     //  break;
     //}
 
+    case MsgUdpFederationAudio::TYPE:
+    {
+      if (!client->isFederationPeer())
+      {
+        cerr << "*** WARNING[" << client->callsign()
+             << "]: Federation audio received from a non-federation client"
+             << endl;
+        return;
+      }
+
+      if ((m_federation == 0) ||
+          (m_federation->peerSession(client->federationPeer()) != client))
+      {
+        cerr << "*** WARNING[" << client->callsign()
+             << "]: Federation audio received from an unregistered session"
+             << endl;
+        return;
+      }
+
+      if (client->isBlocked())
+      {
+        break;
+      }
+
+      MsgUdpFederationAudio msg;
+      if (!msg.unpack(ss))
+      {
+        cerr << "*** WARNING[" << client->callsign()
+             << "]: Could not unpack MsgUdpFederationAudio message"
+             << endl;
+        return;
+      }
+
+      if (msg.audioData().empty())
+      {
+        break;
+      }
+
+      string error;
+      if (!m_federation->acceptIncomingAudio(
+              client->federationPeer(),
+              msg.originReflectorId(),
+              msg.tg(),
+              msg.streamId(),
+              msg.sequence(),
+              error))
+      {
+        cerr << "*** WARNING[" << client->callsign()
+             << "]: Federation audio rejected:"
+             << " peer=" << client->federationPeer()
+             << " origin=" << msg.originReflectorId()
+             << " tg=" << msg.tg()
+             << " stream_id=" << msg.streamId()
+             << " sequence=" << msg.sequence()
+             << " detail=" << error
+             << endl;
+        return;
+      }
+
+      MsgUdpAudio local_audio(msg.audioData());
+      broadcastUdpMsg(
+          local_audio,
+          ReflectorClient::mkAndFilter(
+              ReflectorClient::ExceptFilter(client),
+              ReflectorClient::TgFilter(msg.tg())));
+      break;
+    }
+
     case MsgUdpFlushSamples::TYPE:
     {
       uint32_t tg = TGHandler::instance()->TGForClient(client);
-      ReflectorClient* talker = TGHandler::instance()->talkerForTG(tg);
+      ReflectorClient* talker =
+          TGHandler::instance()->talkerForTG(tg);
+
       if ((tg > 0) && (client == talker))
       {
         TGHandler::instance()->setTalkerForTG(tg, 0);
       }
+
         // To be 100% correct the reflector should wait for all connected
         // clients to send a MsgUdpAllSamplesFlushed message but that will
         // probably lead to problems, especially on reflectors with many
@@ -1299,20 +1435,52 @@ void Reflector::onTalkerUpdated(uint32_t tg, ReflectorClient* old_talker,
 {
   if (old_talker != 0)
   {
-    cout << old_talker->callsign() << ": Talker stop on TG #" << tg << endl;
+    if ((m_federation != 0) &&
+        m_federation->isEnabled() &&
+        (m_federation->findLocalStream(tg) != 0))
+    {
+      std::vector<std::string> stopped_peers;
+      std::string error;
+
+      m_federation->endLocalStream(
+          tg,
+          stopped_peers,
+          error);
+
+      if (!error.empty())
+      {
+        std::cerr << "*** WARNING["
+                  << old_talker->callsign()
+                  << "]: Could not end local federation stream:"
+                  << " tg=" << tg
+                  << " detail=" << error
+                  << std::endl;
+      }
+    }
+
+    cout << old_talker->callsign()
+         << ": Talker stop on TG #" << tg << endl;
+
     old_talker->updateIsTalker();
-    broadcastMsg(MsgTalkerStop(tg, old_talker->callsign()),
+
+    broadcastMsg(
+        MsgTalkerStop(tg, old_talker->callsign()),
         ReflectorClient::mkAndFilter(
-          ge_v2_client_filter,
-          ReflectorClient::mkOrFilter(
-            ReflectorClient::TgFilter(tg),
-            ReflectorClient::TgMonitorFilter(tg))));
+            ge_v2_client_filter,
+            ReflectorClient::mkOrFilter(
+                ReflectorClient::TgFilter(tg),
+                ReflectorClient::TgMonitorFilter(tg))));
+
     if (tg == tgForV1Clients())
     {
-      broadcastMsg(MsgTalkerStopV1(old_talker->callsign()), v1_client_filter);
+      broadcastMsg(
+          MsgTalkerStopV1(old_talker->callsign()),
+          v1_client_filter);
     }
-    broadcastUdpMsg(MsgUdpFlushSamples(),
-          ReflectorClient::mkAndFilter(
+
+    broadcastUdpMsg(
+        MsgUdpFlushSamples(),
+        ReflectorClient::mkAndFilter(
             ReflectorClient::TgFilter(tg),
             ReflectorClient::ExceptFilter(old_talker)));
   }
@@ -1332,6 +1500,52 @@ void Reflector::onTalkerUpdated(uint32_t tg, ReflectorClient* old_talker,
     }
   }
 } /* Reflector::onTalkerUpdated */
+
+
+void Reflector::onFederationStreamStarted(
+    uint32_t tg,
+    const std::string& source_callsign)
+{
+  broadcastMsg(
+      MsgTalkerStart(tg, source_callsign),
+      ReflectorClient::mkAndFilter(
+          ge_v2_client_filter,
+          ReflectorClient::mkOrFilter(
+              ReflectorClient::TgFilter(tg),
+              ReflectorClient::TgMonitorFilter(tg))));
+
+  if (tg == tgForV1Clients())
+  {
+    broadcastMsg(
+        MsgTalkerStartV1(source_callsign),
+        v1_client_filter);
+  }
+} /* Reflector::onFederationStreamStarted */
+
+
+void Reflector::onFederationStreamStopped(
+    uint32_t tg,
+    const std::string& source_callsign)
+{
+  broadcastMsg(
+      MsgTalkerStop(tg, source_callsign),
+      ReflectorClient::mkAndFilter(
+          ge_v2_client_filter,
+          ReflectorClient::mkOrFilter(
+              ReflectorClient::TgFilter(tg),
+              ReflectorClient::TgMonitorFilter(tg))));
+
+  if (tg == tgForV1Clients())
+  {
+    broadcastMsg(
+        MsgTalkerStopV1(source_callsign),
+        v1_client_filter);
+  }
+
+  broadcastUdpMsg(
+      MsgUdpFlushSamples(),
+      ReflectorClient::TgFilter(tg));
+} /* Reflector::onFederationStreamStopped */
 
 
 void Reflector::httpRequestReceived(Async::HttpServerConnection *con,

--- a/src/svxlink/reflector/Reflector.h
+++ b/src/svxlink/reflector/Reflector.h
@@ -78,6 +78,7 @@ namespace Async
   class Pty;
 };
 
+class ReflectorFederation;
 class ReflectorMsg;
 class ReflectorUdpMsg;
 
@@ -163,6 +164,16 @@ class Reflector : public sigc::trackable
      * @return	Return \em true on success or else \em false
      */
     bool initialize(Async::Config &cfg);
+
+    ReflectorFederation* federation(void)
+    {
+      return m_federation;
+    }
+
+    const ReflectorFederation* federation(void) const
+    {
+      return m_federation;
+    }
 
     /**
      * @brief   Return a list of all connected nodes
@@ -264,6 +275,7 @@ class Reflector : public sigc::trackable
     uint32_t                    m_random_qsy_tg;
     HttpServer*                 m_http_server;
     Async::Pty*                 m_cmd_pty;
+    ReflectorFederation*        m_federation;
     Async::SslContext           m_ssl_ctx;
     std::string                 m_keys_dir;
     std::string                 m_pending_csrs_dir;
@@ -294,6 +306,15 @@ class Reflector : public sigc::trackable
                              void* aad, void *buf, int count);
     void onTalkerUpdated(uint32_t tg, ReflectorClient* old_talker,
                          ReflectorClient *new_talker);
+
+    void onFederationStreamStarted(
+        uint32_t tg,
+        const std::string& source_callsign);
+
+    void onFederationStreamStopped(
+        uint32_t tg,
+        const std::string& source_callsign);
+
     void httpRequestReceived(Async::HttpServerConnection *con,
                              Async::HttpServerConnection::Request& req);
     void httpClientConnected(Async::HttpServerConnection *con);

--- a/src/svxlink/reflector/ReflectorClient.cpp
+++ b/src/svxlink/reflector/ReflectorClient.cpp
@@ -62,6 +62,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "ReflectorClient.h"
 #include "Reflector.h"
+#include "FederationMsg.h"
+#include "ReflectorFederation.h"
 #include "TGHandler.h"
 
 
@@ -244,6 +246,12 @@ ReflectorClient::ReflectorClient(Reflector *ref, Async::FramedTcpConnection *con
 
 ReflectorClient::~ReflectorClient(void)
 {
+  ReflectorFederation* federation = m_reflector->federation();
+  if (federation != 0)
+  {
+    federation->unregisterPeerSession(this);
+  }
+
   m_status = nullptr;
   auto client_it = client_map.find(m_client_id);
   assert(client_it != client_map.end());
@@ -313,7 +321,9 @@ void ReflectorClient::udpMsgReceived(const ReflectorUdpMsg &header)
 {
   m_udp_heartbeat_rx_cnt = UDP_HEARTBEAT_RX_CNT_RESET;
 
-  if ((m_blocktime > 0) && (header.type() == MsgUdpAudio::TYPE))
+  if ((m_blocktime > 0) &&
+      ((header.type() == MsgUdpAudio::TYPE) ||
+       (header.type() == MsgUdpFederationAudio::TYPE)))
   {
     m_remaining_blocktime = m_blocktime;
   }
@@ -546,6 +556,15 @@ void ReflectorClient::onFrameReceived(FramedTcpConnection *con,
       break;
     case MsgClientCsr::TYPE:
       handleMsgClientCsr(ss);
+      break;
+    case MsgFederationHello::TYPE:
+      handleFederationHello(ss);
+      break;
+    case MsgFederationStreamStart::TYPE:
+      handleFederationStreamStart(ss);
+      break;
+    case MsgFederationStreamStop::TYPE:
+      handleFederationStreamStop(ss);
       break;
     case MsgSelectTG::TYPE:
       handleSelectTG(ss);
@@ -850,6 +869,267 @@ void ReflectorClient::handleMsgClientCsr(std::istream& is)
     m_con_state = STATE_EXPECT_AUTH_RESPONSE;
   }
 } /* ReflectorClient::handleMsgClientCsr */
+
+
+void ReflectorClient::handleFederationHello(std::istream& is)
+{
+  if (m_con_state != STATE_CONNECTED)
+  {
+    sendError("Federation hello received before authentication");
+    return;
+  }
+
+  if (m_federation_session)
+  {
+    sendError("Federation hello already accepted");
+    return;
+  }
+
+  MsgFederationHello msg;
+  if (!msg.unpack(is))
+  {
+    std::cerr << "*** ERROR[" << m_callsign
+              << "]: Could not unpack MsgFederationHello"
+              << std::endl;
+    sendError("Illegal federation hello");
+    return;
+  }
+
+  ReflectorFederation* federation = m_reflector->federation();
+  if (federation == 0)
+  {
+    sendError("Federation is unavailable");
+    return;
+  }
+
+  std::string peer;
+  uint16_t negotiated_minor = 0;
+  uint32_t negotiated_capabilities = 0;
+  std::string error;
+
+  if (!federation->validatePeerHello(
+          m_callsign,
+          msg.reflectorId(),
+          msg.domain(),
+          msg.major(),
+          msg.minor(),
+          msg.capabilities(),
+          peer,
+          negotiated_minor,
+          negotiated_capabilities,
+          error))
+  {
+    std::cerr << "*** ERROR[" << m_callsign
+              << "]: Federation hello rejected: "
+              << error << std::endl;
+    sendError(error);
+    return;
+  }
+
+  if (!federation->registerPeerSession(peer, this, error))
+  {
+    std::cerr << "*** ERROR[" << m_callsign
+              << "]: Federation session rejected: "
+              << error << std::endl;
+    sendError(error);
+    return;
+  }
+
+  MsgFederationHelloAck ack(
+      FederationProtocol::VERSION_MAJOR,
+      negotiated_minor,
+      federation->reflectorId(),
+      federation->domain(),
+      negotiated_capabilities);
+
+  if (sendMsg(ack) < 0)
+  {
+    std::cerr << "*** ERROR[" << m_callsign
+              << "]: Could not send federation hello acknowledgement"
+              << std::endl;
+    federation->unregisterPeerSession(this);
+    disconnect();
+    return;
+  }
+
+  m_federation_session = true;
+  m_federation_peer = peer;
+  m_federation_reflector_id = msg.reflectorId();
+  m_federation_minor = negotiated_minor;
+  m_federation_capabilities = negotiated_capabilities;
+
+  std::cout << m_callsign
+            << ": Federation peer accepted:"
+            << " peer=" << m_federation_peer
+            << " reflector_id=" << m_federation_reflector_id
+            << " version=" << FederationProtocol::VERSION_MAJOR
+            << "." << m_federation_minor
+            << " capabilities=" << m_federation_capabilities
+            << std::endl;
+} /* ReflectorClient::handleFederationHello */
+
+void ReflectorClient::handleFederationStreamStart(std::istream& is)
+{
+  if (!m_federation_session)
+  {
+    sendError("Federation stream start received before federation hello");
+    return;
+  }
+
+  ReflectorFederation* federation = m_reflector->federation();
+  if ((federation == 0) ||
+      (federation->peerSession(m_federation_peer) != this))
+  {
+    sendError("Federation session is not registered");
+    return;
+  }
+
+  MsgFederationStreamStart msg;
+  if (!msg.unpack(is))
+  {
+    std::cerr << "*** ERROR[" << m_callsign
+              << "]: Could not unpack MsgFederationStreamStart"
+              << std::endl;
+    sendError("Illegal federation stream start");
+    return;
+  }
+
+  std::string error;
+  uint16_t reason = FederationProtocol::STREAM_ACCEPTED;
+
+  ReflectorClient* talker =
+      TGHandler::instance()->talkerForTG(msg.tg());
+
+  if (talker != 0)
+  {
+    reason = FederationProtocol::STREAM_REJECT_LOCAL_BUSY;
+    error = "Talkgroup already has an active local talker";
+  }
+  else
+  {
+    reason = federation->startIncomingStream(
+        m_federation_peer,
+        msg.originReflectorId(),
+        msg.tg(),
+        msg.streamId(),
+        msg.sourceCallsign(),
+        msg.codec(),
+        error);
+  }
+
+  const bool accepted =
+      reason == FederationProtocol::STREAM_ACCEPTED;
+
+  MsgFederationStreamResult result(
+      msg.originReflectorId(),
+      msg.tg(),
+      msg.streamId(),
+      accepted,
+      reason,
+      error);
+
+  if (sendMsg(result) < 0)
+  {
+    std::cerr << "*** ERROR[" << m_callsign
+              << "]: Could not send federation stream result"
+              << std::endl;
+
+    if (accepted)
+    {
+      std::string rollback_error;
+      federation->stopIncomingStream(
+          m_federation_peer,
+          msg.originReflectorId(),
+          msg.tg(),
+          msg.streamId(),
+          rollback_error);
+    }
+
+    disconnect();
+    return;
+  }
+
+  if (accepted)
+  {
+    std::cout << m_callsign
+              << ": Federation stream accepted:"
+              << " peer=" << m_federation_peer
+              << " origin=" << msg.originReflectorId()
+              << " tg=" << msg.tg()
+              << " stream_id=" << msg.streamId()
+              << " source=" << msg.sourceCallsign()
+              << " codec=" << msg.codec()
+              << std::endl;
+  }
+  else
+  {
+    std::cerr << "*** WARNING[" << m_callsign
+              << "]: Federation stream rejected:"
+              << " peer=" << m_federation_peer
+              << " origin=" << msg.originReflectorId()
+              << " tg=" << msg.tg()
+              << " stream_id=" << msg.streamId()
+              << " reason=" << reason
+              << " detail=" << error
+              << std::endl;
+  }
+} /* ReflectorClient::handleFederationStreamStart */
+
+
+void ReflectorClient::handleFederationStreamStop(std::istream& is)
+{
+  if (!m_federation_session)
+  {
+    sendError("Federation stream stop received before federation hello");
+    return;
+  }
+
+  ReflectorFederation* federation = m_reflector->federation();
+  if ((federation == 0) ||
+      (federation->peerSession(m_federation_peer) != this))
+  {
+    sendError("Federation session is not registered");
+    return;
+  }
+
+  MsgFederationStreamStop msg;
+  if (!msg.unpack(is))
+  {
+    std::cerr << "*** ERROR[" << m_callsign
+              << "]: Could not unpack MsgFederationStreamStop"
+              << std::endl;
+    sendError("Illegal federation stream stop");
+    return;
+  }
+
+  std::string error;
+  if (!federation->stopIncomingStream(
+          m_federation_peer,
+          msg.originReflectorId(),
+          msg.tg(),
+          msg.streamId(),
+          error))
+  {
+    std::cerr << "*** WARNING[" << m_callsign
+              << "]: Federation stream stop rejected:"
+              << " peer=" << m_federation_peer
+              << " origin=" << msg.originReflectorId()
+              << " tg=" << msg.tg()
+              << " stream_id=" << msg.streamId()
+              << " detail=" << error
+              << std::endl;
+    sendError(error);
+    return;
+  }
+
+  std::cout << m_callsign
+            << ": Federation stream stopped:"
+            << " peer=" << m_federation_peer
+            << " origin=" << msg.originReflectorId()
+            << " tg=" << msg.tg()
+            << " stream_id=" << msg.streamId()
+            << std::endl;
+} /* ReflectorClient::handleFederationStreamStop */
 
 
 void ReflectorClient::handleSelectTG(std::istream& is)
@@ -1230,6 +1510,12 @@ void ReflectorClient::onDiscTimeout(Timer *t)
 void ReflectorClient::disconnectCleanup(
     Async::FramedTcpConnection::DisconnectReason reason)
 {
+  ReflectorFederation* federation = m_reflector->federation();
+  if (federation != 0)
+  {
+    federation->unregisterPeerSession(this);
+  }
+
   m_disc_timer.setEnable(false);
   m_heartbeat_timer.setEnable(false);
   m_remote_udp_port = 0;

--- a/src/svxlink/reflector/ReflectorClient.h
+++ b/src/svxlink/reflector/ReflectorClient.h
@@ -432,6 +432,31 @@ class ReflectorClient : public sigc::trackable
      */
     ConState conState(void) const { return m_con_state; }
 
+    bool isFederationPeer(void) const
+    {
+      return m_federation_session;
+    }
+
+    const std::string& federationPeer(void) const
+    {
+      return m_federation_peer;
+    }
+
+    const std::string& federationReflectorId(void) const
+    {
+      return m_federation_reflector_id;
+    }
+
+    uint16_t federationMinor(void) const
+    {
+      return m_federation_minor;
+    }
+
+    uint32_t federationCapabilities(void) const
+    {
+      return m_federation_capabilities;
+    }
+
     /**
      * @brief   Get the protocol version of the client
      * @return  Returns the protocol version of the client
@@ -528,6 +553,11 @@ class ReflectorClient : public sigc::trackable
     ConState                    m_con_state;
     Async::Timer                m_disc_timer;
     std::string                 m_callsign;
+    bool                        m_federation_session {false};
+    std::string                 m_federation_peer;
+    std::string                 m_federation_reflector_id;
+    uint16_t                    m_federation_minor {0};
+    uint32_t                    m_federation_capabilities {0};
     ClientId                    m_client_id;
     ClientSrc                   m_client_src;
     uint16_t                    m_remote_udp_port;
@@ -565,6 +595,9 @@ class ReflectorClient : public sigc::trackable
     void handleMsgStartEncryptionRequest(std::istream& is);
     void handleMsgAuthResponse(std::istream& is);
     void handleMsgClientCsr(std::istream& is);
+    void handleFederationHello(std::istream& is);
+    void handleFederationStreamStart(std::istream& is);
+    void handleFederationStreamStop(std::istream& is);
     void handleSelectTG(std::istream& is);
     void handleTgMonitor(std::istream& is);
     void handleNodeInfo(std::istream& is);

--- a/src/svxlink/reflector/ReflectorFederation.cpp
+++ b/src/svxlink/reflector/ReflectorFederation.cpp
@@ -1,0 +1,1436 @@
+/**
+@file   ReflectorFederation.cpp
+@brief  Federation support for SVXReflector
+@author Chris Jackson / G4NAB
+@date   2026-08-14
+
+\verbatim
+Copyright (C) 2026 Chris Jackson / G4NAB
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <iostream>
+#include <list>
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "ReflectorFederation.h"
+#include "FederationMsg.h"
+#include "FederationPeerConnection.h"
+
+
+/****************************************************************************
+ *
+ * Public member functions
+ *
+ ****************************************************************************/
+
+ReflectorFederation::ReflectorFederation(void)
+  : m_enabled(false),
+    m_library_path("/etc/svxlink/federation.json"),
+    m_next_local_stream_id(1)
+{
+} /* ReflectorFederation::ReflectorFederation */
+
+ReflectorFederation::~ReflectorFederation(void)
+{
+  stopPeerConnections();
+
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    delete *it;
+  }
+
+  m_peer_connections.clear();
+} /* ReflectorFederation::~ReflectorFederation */
+
+
+const ReflectorFederation::PeerConfig*
+ReflectorFederation::findPeerConfig(
+    const std::string& peer) const
+{
+  for (std::vector<PeerConfig>::const_iterator
+           it=m_peer_configs.begin();
+       it!=m_peer_configs.end(); ++it)
+  {
+    if (it->name == peer)
+    {
+      return &(*it);
+    }
+  }
+
+  return 0;
+} /* ReflectorFederation::findPeerConfig */
+
+
+const ReflectorFederation::TrustEntry*
+ReflectorFederation::findTrustByCallsign(
+    const std::string& callsign) const
+{
+  for (std::vector<TrustEntry>::const_iterator
+           it=m_trust_entries.begin();
+       it!=m_trust_entries.end(); ++it)
+  {
+    if (it->callsign == callsign)
+    {
+      return &(*it);
+    }
+  }
+
+  return 0;
+} /* ReflectorFederation::findTrustByCallsign */
+
+
+const ReflectorFederation::TrustEntry*
+ReflectorFederation::findTrustByPeer(
+    const std::string& peer) const
+{
+  for (std::vector<TrustEntry>::const_iterator
+           it=m_trust_entries.begin();
+       it!=m_trust_entries.end(); ++it)
+  {
+    if (it->peer == peer)
+    {
+      return &(*it);
+    }
+  }
+
+  return 0;
+} /* ReflectorFederation::findTrustByPeer */
+
+
+bool ReflectorFederation::validatePeerHello(
+    const std::string& authenticated_callsign,
+    const std::string& reflector_id,
+    const std::string& domain,
+    std::uint16_t major,
+    std::uint16_t minor,
+    std::uint32_t capabilities,
+    std::string& peer,
+    std::uint16_t& negotiated_minor,
+    std::uint32_t& negotiated_capabilities,
+    std::string& error) const
+
+{
+  peer.clear();
+  negotiated_minor = 0;
+  negotiated_capabilities = 0;
+  error.clear();
+
+  if (!m_enabled)
+  {
+    error = "Federation is disabled";
+    return false;
+  }
+
+  const TrustEntry* trust =
+      findTrustByCallsign(authenticated_callsign);
+
+  if (trust == 0)
+  {
+    error = "Authenticated callsign is not a trusted federation peer";
+    return false;
+  }
+
+  const PeerConfig* peer_config =
+      findPeerConfig(trust->peer);
+
+  if (peer_config == 0)
+  {
+    error = "Trusted callsign refers to an unconfigured peer";
+    return false;
+  }
+
+  if (reflector_id != peer_config->reflector_id)
+  {
+    error = "Federation hello reflector identity does not match peer";
+    return false;
+  }
+
+  if (domain != peer_config->name)
+  {
+    error = "Federation hello domain does not match peer";
+    return false;
+  }
+
+  if (major != FederationProtocol::VERSION_MAJOR)
+  {
+    error = "Unsupported federation protocol major version";
+    return false;
+  }
+
+  const std::uint32_t local_capabilities =
+      FederationProtocol::CAP_MULTIPLEXED_OPUS;
+
+  const std::uint32_t common_capabilities =
+      capabilities & local_capabilities;
+
+  if ((common_capabilities &
+       FederationProtocol::CAP_MULTIPLEXED_OPUS) == 0)
+  {
+    error = "Peer does not support multiplexed Opus federation";
+    return false;
+  }
+
+  peer = peer_config->name;
+  negotiated_minor =
+      (minor < FederationProtocol::VERSION_MINOR)
+      ? minor
+      : FederationProtocol::VERSION_MINOR;
+  negotiated_capabilities = common_capabilities;
+
+  return true;
+} /* ReflectorFederation::validatePeerHello */
+
+
+std::uint16_t ReflectorFederation::validateIncomingStream(
+    const std::string& peer,
+    const std::string& origin_reflector_id,
+    std::uint32_t tg,
+    const std::string& codec,
+    std::string& error) const
+{
+  error.clear();
+
+  if (!m_enabled)
+  {
+    error = "Federation is disabled";
+    return FederationProtocol::STREAM_REJECT_PROTOCOL;
+  }
+
+  const PeerConfig* peer_config = findPeerConfig(peer);
+  if (peer_config == 0)
+  {
+    error = "Stream received from an unconfigured peer";
+    return FederationProtocol::STREAM_REJECT_PROTOCOL;
+  }
+
+  if (origin_reflector_id.empty() ||
+      (origin_reflector_id == m_reflector_id) ||
+      (origin_reflector_id != peer_config->reflector_id))
+  {
+    error = "Stream origin does not match the trusted peer";
+    return FederationProtocol::STREAM_REJECT_INVALID_ORIGIN;
+  }
+
+  if (tg == 0)
+  {
+    error = "Talkgroup zero is not a valid federation stream";
+    return FederationProtocol::STREAM_REJECT_PROTOCOL;
+  }
+
+  if (codec != "OPUS")
+  {
+    error = "Only OPUS federation streams are supported";
+    return FederationProtocol::STREAM_REJECT_CODEC;
+  }
+
+  const FederationLibrary::Route* route =
+      m_library.findRoute(tg);
+
+  if ((route == 0) ||
+      (route->scope != "family"))
+  {
+    error = "Talkgroup is not configured as a family federation route";
+    return FederationProtocol::STREAM_REJECT_POLICY;
+  }
+
+  if (!m_library.mayImport(peer, tg))
+  {
+    error = "Talkgroup is denied by local import policy";
+    return FederationProtocol::STREAM_REJECT_POLICY;
+  }
+
+  return FederationProtocol::STREAM_ACCEPTED;
+} /* ReflectorFederation::validateIncomingStream */
+
+const ReflectorFederation::IncomingStream*
+ReflectorFederation::findIncomingStream(std::uint32_t tg) const
+{
+  std::map<std::uint32_t, IncomingStream>::const_iterator it =
+      m_incoming_streams.find(tg);
+
+  return (it == m_incoming_streams.end())
+      ? 0
+      : &it->second;
+} /* ReflectorFederation::findIncomingStream */
+
+
+std::uint16_t ReflectorFederation::startIncomingStream(
+    const std::string& peer,
+    const std::string& origin_reflector_id,
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    const std::string& source_callsign,
+    const std::string& codec,
+    std::string& error)
+{
+  const std::uint16_t validation =
+      validateIncomingStream(
+          peer, origin_reflector_id, tg, codec, error);
+
+  if (validation != FederationProtocol::STREAM_ACCEPTED)
+  {
+    return validation;
+  }
+
+  if (stream_id == 0)
+  {
+    error = "Stream ID zero is invalid";
+    return FederationProtocol::STREAM_REJECT_PROTOCOL;
+  }
+
+  if (source_callsign.empty())
+  {
+    error = "Stream source callsign is missing";
+    return FederationProtocol::STREAM_REJECT_PROTOCOL;
+  }
+
+  std::map<std::uint32_t, IncomingStream>::const_iterator existing =
+      m_incoming_streams.find(tg);
+
+  if (existing != m_incoming_streams.end())
+  {
+    if ((existing->second.peer == peer) &&
+        (existing->second.origin_reflector_id ==
+         origin_reflector_id) &&
+        (existing->second.stream_id == stream_id))
+    {
+      error = "Federation stream is already active";
+      return FederationProtocol::STREAM_REJECT_DUPLICATE;
+    }
+
+    error = "Talkgroup already has an active federation stream";
+    return FederationProtocol::STREAM_REJECT_LOCAL_BUSY;
+  }
+
+  IncomingStream stream;
+  stream.peer = peer;
+  stream.origin_reflector_id = origin_reflector_id;
+  stream.tg = tg;
+  stream.stream_id = stream_id;
+  stream.source_callsign = source_callsign;
+  stream.codec = codec;
+
+  m_incoming_streams[tg] = stream;
+  error.clear();
+
+  incomingStreamStarted(
+      tg,
+      source_callsign);
+
+  return FederationProtocol::STREAM_ACCEPTED;
+} /* ReflectorFederation::startIncomingStream */
+
+
+bool ReflectorFederation::stopIncomingStream(
+    const std::string& peer,
+    const std::string& origin_reflector_id,
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    std::string& error)
+{
+  error.clear();
+
+  std::map<std::uint32_t, IncomingStream>::iterator it =
+      m_incoming_streams.find(tg);
+
+  if (it == m_incoming_streams.end())
+  {
+    error = "Federation stream is not active";
+    return false;
+  }
+
+  if ((it->second.peer != peer) ||
+      (it->second.origin_reflector_id != origin_reflector_id) ||
+      (it->second.stream_id != stream_id))
+  {
+    error = "Federation stream identity does not match active stream";
+    return false;
+  }
+
+  const std::string source_callsign(
+      it->second.source_callsign);
+
+  m_incoming_streams.erase(it);
+
+  incomingStreamStopped(
+      tg,
+      source_callsign);
+
+  return true;
+} /* ReflectorFederation::stopIncomingStream */
+
+
+bool ReflectorFederation::acceptIncomingAudio(
+    const std::string& peer,
+    const std::string& origin_reflector_id,
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    std::uint32_t sequence,
+    std::string& error)
+{
+  error.clear();
+
+  std::map<std::uint32_t, IncomingStream>::iterator it =
+      m_incoming_streams.find(tg);
+
+  if (it == m_incoming_streams.end())
+  {
+    error = "Federation audio has no active stream";
+    return false;
+  }
+
+  IncomingStream& stream = it->second;
+
+  if ((stream.peer != peer) ||
+      (stream.origin_reflector_id != origin_reflector_id) ||
+      (stream.stream_id != stream_id))
+  {
+    error = "Federation audio identity does not match active stream";
+    return false;
+  }
+
+  if (stream.sequence_seen)
+  {
+    const std::uint32_t difference =
+        sequence - stream.last_sequence;
+
+    if ((difference == 0) || (difference > 0x7fffffffU))
+    {
+      error = "Federation audio sequence is duplicate or out of order";
+      return false;
+    }
+  }
+
+  stream.last_sequence = sequence;
+  stream.sequence_seen = true;
+  return true;
+} /* ReflectorFederation::acceptIncomingAudio */
+
+
+ReflectorClient* ReflectorFederation::peerSession(
+    const std::string& peer) const
+{
+  std::map<std::string, ReflectorClient*>::const_iterator it =
+      m_peer_sessions.find(peer);
+
+  return (it == m_peer_sessions.end())
+      ? 0
+      : it->second;
+} /* ReflectorFederation::peerSession */
+
+
+bool ReflectorFederation::registerPeerSession(
+    const std::string& peer,
+    ReflectorClient* client,
+    std::string& error)
+{
+  error.clear();
+
+  if (!m_enabled)
+  {
+    error = "Federation is disabled";
+    return false;
+  }
+
+  if (client == 0)
+  {
+    error = "Cannot register a null federation session";
+    return false;
+  }
+
+  if (findPeerConfig(peer) == 0)
+  {
+    error = "Cannot register an unconfigured federation peer";
+    return false;
+  }
+
+  if (m_peer_sessions.find(peer) != m_peer_sessions.end())
+  {
+    error = "Federation peer already has an active session";
+    return false;
+  }
+
+  for (std::map<std::string, ReflectorClient*>::const_iterator
+           it=m_peer_sessions.begin();
+       it!=m_peer_sessions.end(); ++it)
+  {
+    if (it->second == client)
+    {
+      error = "Federation session is already registered to another peer";
+      return false;
+    }
+  }
+
+  m_peer_sessions[peer] = client;
+  return true;
+} /* ReflectorFederation::registerPeerSession */
+
+
+void ReflectorFederation::unregisterPeerSession(
+    ReflectorClient* client)
+{
+  if (client == 0)
+  {
+    return;
+  }
+
+  std::map<std::string, ReflectorClient*>::iterator it =
+      m_peer_sessions.begin();
+
+  while (it != m_peer_sessions.end())
+  {
+    if (it->second == client)
+    {
+      const std::string peer(it->first);
+      it = m_peer_sessions.erase(it);
+      removeIncomingStreams(peer);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+} /* ReflectorFederation::unregisterPeerSession */
+
+
+std::size_t ReflectorFederation::removeIncomingStreams(
+    const std::string& peer)
+{
+  std::size_t removed = 0;
+
+  std::map<std::uint32_t, IncomingStream>::iterator it =
+      m_incoming_streams.begin();
+
+  while (it != m_incoming_streams.end())
+  {
+    if (it->second.peer == peer)
+    {
+      const std::uint32_t tg = it->second.tg;
+      const std::string source_callsign(
+          it->second.source_callsign);
+
+      it = m_incoming_streams.erase(it);
+      ++removed;
+
+      incomingStreamStopped(
+          tg,
+          source_callsign);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+
+  return removed;
+} /* ReflectorFederation::removeIncomingStreams */
+
+
+const ReflectorFederation::LocalStream*
+ReflectorFederation::findLocalStream(
+    std::uint32_t tg) const
+{
+  std::map<std::uint32_t, LocalStream>::const_iterator it =
+      m_local_streams.find(tg);
+
+  return (it == m_local_streams.end())
+      ? 0
+      : &it->second;
+} /* ReflectorFederation::findLocalStream */
+
+
+bool ReflectorFederation::beginLocalStream(
+    std::uint32_t tg,
+    const std::string& source_callsign,
+    const std::string& codec,
+    std::uint64_t& stream_id,
+    std::vector<std::string>& started_peers,
+    std::string& error)
+{
+  stream_id = 0;
+  started_peers.clear();
+  error.clear();
+
+  if (!m_enabled)
+  {
+    error = "Federation is disabled";
+    return false;
+  }
+
+  if (tg == 0)
+  {
+    error = "Talkgroup zero is not a valid federation stream";
+    return false;
+  }
+
+  if (source_callsign.empty())
+  {
+    error = "Stream source callsign is missing";
+    return false;
+  }
+
+  if (codec != "OPUS")
+  {
+    error = "Only OPUS federation streams are supported";
+    return false;
+  }
+
+  if (m_local_streams.find(tg) != m_local_streams.end())
+  {
+    error = "Talkgroup already has a local federation stream";
+    return false;
+  }
+
+  stream_id = m_next_local_stream_id++;
+
+  if (stream_id == 0)
+  {
+    stream_id = m_next_local_stream_id++;
+  }
+
+  if (m_next_local_stream_id == 0)
+  {
+    m_next_local_stream_id = 1;
+  }
+
+  LocalStream stream;
+  stream.tg = tg;
+  stream.stream_id = stream_id;
+  stream.source_callsign = source_callsign;
+  stream.codec = codec;
+
+  const std::size_t started =
+      startLocalStream(
+          tg,
+          stream_id,
+          source_callsign,
+          codec,
+          started_peers,
+          error);
+
+  stream.export_requested = (started > 0);
+  m_local_streams[tg] = stream;
+
+  return true;
+} /* ReflectorFederation::beginLocalStream */
+
+
+std::size_t ReflectorFederation::sendLocalStreamAudio(
+    std::uint32_t tg,
+    const std::vector<std::uint8_t>& audio_data)
+{
+  if (!m_enabled || audio_data.empty())
+  {
+    return 0;
+  }
+
+  std::map<std::uint32_t, LocalStream>::const_iterator local_it =
+      m_local_streams.find(tg);
+
+  if ((local_it == m_local_streams.end()) ||
+      !local_it->second.export_requested)
+  {
+    return 0;
+  }
+
+  std::size_t handled = 0;
+  std::string peer_error;
+
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    FederationPeerConnection* connection = *it;
+
+    if ((connection == 0) ||
+        !mayExport(connection->peer(), tg))
+    {
+      continue;
+    }
+
+    const FederationPeerConnection::OutgoingStream* stream =
+        connection->findOutgoingStream(tg);
+
+    if ((stream == 0) ||
+        (stream->stream_id != local_it->second.stream_id))
+    {
+      continue;
+    }
+
+    if (connection->sendOutgoingAudio(
+            tg,
+            local_it->second.stream_id,
+            audio_data,
+            peer_error))
+    {
+      ++handled;
+    }
+  }
+
+  return handled;
+} /* ReflectorFederation::sendLocalStreamAudio */
+
+
+std::size_t ReflectorFederation::endLocalStream(
+    std::uint32_t tg,
+    std::vector<std::string>& stopped_peers,
+    std::string& error)
+{
+  stopped_peers.clear();
+  error.clear();
+
+  std::map<std::uint32_t, LocalStream>::iterator it =
+      m_local_streams.find(tg);
+
+  if (it == m_local_streams.end())
+  {
+    error = "Talkgroup does not have a local federation stream";
+    return 0;
+  }
+
+  const std::uint64_t stream_id = it->second.stream_id;
+  const bool export_requested = it->second.export_requested;
+
+  if (!export_requested)
+  {
+    m_local_streams.erase(it);
+    return 0;
+  }
+
+  const std::size_t stopped =
+      stopLocalStream(
+          tg,
+          stream_id,
+          stopped_peers,
+          error);
+
+  m_local_streams.erase(it);
+  return stopped;
+} /* ReflectorFederation::endLocalStream */
+
+
+std::size_t ReflectorFederation::startLocalStream(
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    const std::string& source_callsign,
+    const std::string& codec,
+    std::vector<std::string>& started_peers,
+    std::string& error)
+{
+  started_peers.clear();
+  error.clear();
+
+  if (!m_enabled)
+  {
+    error = "Federation is disabled";
+    return 0;
+  }
+
+  if (tg == 0)
+  {
+    error = "Talkgroup zero is not a valid federation stream";
+    return 0;
+  }
+
+  if (stream_id == 0)
+  {
+    error = "Stream ID zero is invalid";
+    return 0;
+  }
+
+  if (source_callsign.empty())
+  {
+    error = "Stream source callsign is missing";
+    return 0;
+  }
+
+  if (codec != "OPUS")
+  {
+    error = "Only OPUS federation streams are supported";
+    return 0;
+  }
+
+  std::size_t policy_matches = 0;
+  std::size_t ready_matches = 0;
+  std::string last_error;
+
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    FederationPeerConnection* connection = *it;
+
+    if ((connection == 0) ||
+        !mayExport(connection->peer(), tg))
+    {
+      continue;
+    }
+
+    ++policy_matches;
+
+    if (!connection->isConnected() ||
+        !connection->isUdpRegistered())
+    {
+      continue;
+    }
+
+    ++ready_matches;
+
+    std::string peer_error;
+    if (connection->startOutgoingStream(
+            tg,
+            stream_id,
+            source_callsign,
+            codec,
+            peer_error))
+    {
+      started_peers.push_back(connection->peer());
+    }
+    else
+    {
+      last_error = peer_error;
+
+      std::cerr << "*** WARNING: Federation peer "
+                << connection->peer()
+                << ": Could not start local stream:"
+                << " tg=" << tg
+                << " stream_id=" << stream_id
+                << " detail=" << peer_error
+                << std::endl;
+    }
+  }
+
+  if (!started_peers.empty())
+  {
+    return started_peers.size();
+  }
+
+  if (policy_matches == 0)
+  {
+    error = "Talkgroup is denied by federation export policy";
+  }
+  else if (ready_matches == 0)
+  {
+    error = "No permitted federation peer is connected and UDP registered";
+  }
+  else if (!last_error.empty())
+  {
+    error = last_error;
+  }
+  else
+  {
+    error = "No federation peer accepted the local stream request";
+  }
+
+  return 0;
+} /* ReflectorFederation::startLocalStream */
+
+
+std::size_t ReflectorFederation::sendLocalAudio(
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    const std::vector<std::uint8_t>& audio_data,
+    std::vector<std::string>& sent_peers,
+    std::string& error)
+{
+  sent_peers.clear();
+  error.clear();
+
+  if (!m_enabled)
+  {
+    error = "Federation is disabled";
+    return 0;
+  }
+
+  if (tg == 0)
+  {
+    error = "Talkgroup zero is not a valid federation stream";
+    return 0;
+  }
+
+  if (stream_id == 0)
+  {
+    error = "Stream ID zero is invalid";
+    return 0;
+  }
+
+  if (audio_data.empty())
+  {
+    error = "Federation audio data is empty";
+    return 0;
+  }
+
+  std::size_t matching_streams = 0;
+  std::size_t sendable_streams = 0;
+  std::size_t permitted_streams = 0;
+  std::string last_error;
+
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    FederationPeerConnection* connection = *it;
+    if (connection == 0)
+    {
+      continue;
+    }
+
+    const FederationPeerConnection::OutgoingStream* stream =
+        connection->findOutgoingStream(tg);
+
+    if ((stream == 0) ||
+        (stream->stream_id != stream_id))
+    {
+      continue;
+    }
+
+    ++matching_streams;
+
+    if ((stream->state !=
+         FederationPeerConnection::OUTGOING_STREAM_PENDING) &&
+        (stream->state !=
+         FederationPeerConnection::OUTGOING_STREAM_ACTIVE))
+    {
+      continue;
+    }
+
+    ++sendable_streams;
+
+    if (!mayExport(connection->peer(), tg))
+    {
+      continue;
+    }
+
+    ++permitted_streams;
+
+    std::string peer_error;
+    if (connection->sendOutgoingAudio(
+            tg,
+            stream_id,
+            audio_data,
+            peer_error))
+    {
+      sent_peers.push_back(connection->peer());
+    }
+    else
+    {
+      last_error = peer_error;
+
+      std::cerr << "*** WARNING: Federation peer "
+                << connection->peer()
+                << ": Could not send local audio:"
+                << " tg=" << tg
+                << " stream_id=" << stream_id
+                << " detail=" << peer_error
+                << std::endl;
+    }
+  }
+
+  if (!sent_peers.empty())
+  {
+    return sent_peers.size();
+  }
+
+  if (matching_streams == 0)
+  {
+    error = "No outgoing federation stream matches the local stream";
+  }
+  else if (sendable_streams == 0)
+  {
+    error = "No matching outgoing federation stream can accept audio";
+  }
+  else if (permitted_streams == 0)
+  {
+    error = "No matching outgoing stream is permitted by export policy";
+  }
+  else if (!last_error.empty())
+  {
+    error = last_error;
+  }
+  else
+  {
+    error = "No federation peer accepted the local audio";
+  }
+
+  return 0;
+} /* ReflectorFederation::sendLocalAudio */
+
+
+std::size_t ReflectorFederation::stopLocalStream(
+    std::uint32_t tg,
+    std::uint64_t stream_id,
+    std::vector<std::string>& stopped_peers,
+    std::string& error)
+{
+  stopped_peers.clear();
+  error.clear();
+
+  if (!m_enabled)
+  {
+    error = "Federation is disabled";
+    return 0;
+  }
+
+  if (tg == 0)
+  {
+    error = "Talkgroup zero is not a valid federation stream";
+    return 0;
+  }
+
+  if (stream_id == 0)
+  {
+    error = "Stream ID zero is invalid";
+    return 0;
+  }
+
+  std::size_t matching_streams = 0;
+  std::string last_error;
+
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    FederationPeerConnection* connection = *it;
+    if (connection == 0)
+    {
+      continue;
+    }
+
+    const FederationPeerConnection::OutgoingStream* stream =
+        connection->findOutgoingStream(tg);
+
+    if ((stream == 0) ||
+        (stream->stream_id != stream_id))
+    {
+      continue;
+    }
+
+    ++matching_streams;
+
+    std::string peer_error;
+    if (connection->stopOutgoingStream(
+            tg,
+            stream_id,
+            peer_error))
+    {
+      stopped_peers.push_back(connection->peer());
+    }
+    else
+    {
+      last_error = peer_error;
+
+      std::cerr << "*** WARNING: Federation peer "
+                << connection->peer()
+                << ": Could not stop local stream:"
+                << " tg=" << tg
+                << " stream_id=" << stream_id
+                << " detail=" << peer_error
+                << std::endl;
+    }
+  }
+
+  if (!stopped_peers.empty())
+  {
+    return stopped_peers.size();
+  }
+
+  if (matching_streams == 0)
+  {
+    error = "No outgoing federation stream matches the local stream";
+  }
+  else if (!last_error.empty())
+  {
+    error = last_error;
+  }
+  else
+  {
+    error = "No federation peer stopped the local stream";
+  }
+
+  return 0;
+} /* ReflectorFederation::stopLocalStream */
+
+
+FederationPeerConnection* ReflectorFederation::peerConnection(
+    const std::string& peer) const
+{
+  for (std::vector<FederationPeerConnection*>::const_iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    if (((*it) != 0) && ((*it)->peer() == peer))
+    {
+      return *it;
+    }
+  }
+
+  return 0;
+} /* ReflectorFederation::peerConnection */
+
+
+void ReflectorFederation::startPeerConnections(void)
+{
+  if (!m_enabled)
+  {
+    return;
+  }
+
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    (*it)->start();
+  }
+} /* ReflectorFederation::startPeerConnections */
+
+
+void ReflectorFederation::stopPeerConnections(void)
+{
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    (*it)->stop();
+  }
+} /* ReflectorFederation::stopPeerConnections */
+
+
+bool ReflectorFederation::initialize(Async::Config& cfg)
+{
+  cfg.getValue("FEDERATION", "ENABLE", m_enabled);
+
+  if (!m_enabled)
+  {
+    return true;
+  }
+
+  bool config_ok = true;
+
+  if (!cfg.getValue("FEDERATION", "DOMAIN", m_domain) || m_domain.empty())
+  {
+    std::cerr << "*** ERROR: FEDERATION/DOMAIN is missing or empty"
+              << std::endl;
+    config_ok = false;
+  }
+
+  if (!cfg.getValue("FEDERATION", "REFLECTOR_ID", m_reflector_id) ||
+      m_reflector_id.empty())
+  {
+    std::cerr << "*** ERROR: FEDERATION/REFLECTOR_ID is missing or empty"
+              << std::endl;
+    config_ok = false;
+  }
+
+  if (!cfg.getValue("FEDERATION", "CALLSIGN", m_callsign) ||
+      m_callsign.empty())
+  {
+    std::cerr << "*** ERROR: FEDERATION/CALLSIGN is missing or empty"
+              << std::endl;
+    config_ok = false;
+  }
+
+  cfg.getValue("FEDERATION", "LIBRARY", m_library_path);
+  cfg.getValue("FEDERATION", "PEERS", m_peers);
+
+  if (!config_ok)
+  {
+    return false;
+  }
+
+  std::string library_error;
+  if (!m_library.load(m_library_path, m_domain, library_error))
+  {
+    std::cerr << "*** ERROR: " << library_error << std::endl;
+    return false;
+  }
+
+  std::vector<PeerConfig> candidate_peer_configs;
+
+  for (std::vector<std::string>::const_iterator it=m_peers.begin();
+       it!=m_peers.end(); ++it)
+  {
+    if (it->empty())
+    {
+      std::cerr << "*** ERROR: FEDERATION/PEERS contains an empty peer"
+                << std::endl;
+      return false;
+    }
+
+    if (!m_library.hasPeerPolicy(*it))
+    {
+      std::cerr << "*** ERROR: Federation peer " << *it
+                << " has no entry in the library peer_policy"
+                << std::endl;
+      return false;
+    }
+
+    const std::string section("FEDERATION_PEER_" + *it);
+    PeerConfig peer;
+    peer.name = *it;
+
+    if (!cfg.getValue(section, "HOST", peer.host) ||
+        peer.host.empty())
+    {
+      std::cerr << "*** ERROR: " << section
+                << "/HOST is missing or empty"
+                << std::endl;
+      return false;
+    }
+
+    // The stable federation identity defaults to the current endpoint.
+    peer.reflector_id = peer.host;
+    cfg.getValue(section, "REFLECTOR_ID", peer.reflector_id);
+
+    if (peer.reflector_id.empty())
+    {
+      std::cerr << "*** ERROR: " << section
+                << "/REFLECTOR_ID must not be empty"
+                << std::endl;
+      return false;
+    }
+
+    unsigned port = peer.port;
+    cfg.getValue(section, "PORT", port);
+
+    if ((port == 0) || (port > 65535))
+    {
+      std::cerr << "*** ERROR: " << section
+                << "/PORT must be between 1 and 65535"
+                << std::endl;
+      return false;
+    }
+    peer.port = static_cast<std::uint16_t>(port);
+
+    cfg.getValue(section, "PROTOCOL", peer.protocol);
+    if (peer.protocol != 2)
+    {
+      std::cerr << "*** ERROR: " << section
+                << "/PROTOCOL must currently be 2"
+                << std::endl;
+      return false;
+    }
+
+    if (!cfg.getValue(section, "AUTH_KEY", peer.auth_key) ||
+        peer.auth_key.empty())
+    {
+      std::cerr << "*** ERROR: " << section
+                << "/AUTH_KEY is missing or empty"
+                << std::endl;
+      return false;
+    }
+
+    cfg.getValue(section, "CONNECT", peer.connect);
+    candidate_peer_configs.push_back(peer);
+  }
+  std::vector<TrustEntry> candidate_trust_entries;
+  const std::list<std::string> trust_callsigns =
+      cfg.listSection("FEDERATION_TRUST");
+
+  for (std::list<std::string>::const_iterator
+           it=trust_callsigns.begin();
+       it!=trust_callsigns.end(); ++it)
+  {
+    TrustEntry trust;
+    trust.callsign = *it;
+
+    if (trust.callsign.empty())
+    {
+      std::cerr << "*** ERROR: FEDERATION_TRUST contains an empty callsign"
+                << std::endl;
+      return false;
+    }
+
+    for (std::string::const_iterator ch=trust.callsign.begin();
+         ch!=trust.callsign.end(); ++ch)
+    {
+      if ((*ch >= 'a') && (*ch <= 'z'))
+      {
+        std::cerr << "*** ERROR: Federation trust callsign "
+                  << trust.callsign
+                  << " must use upper case"
+                  << std::endl;
+        return false;
+      }
+    }
+
+    if (trust.callsign == m_callsign)
+    {
+      std::cerr << "*** ERROR: Federation trust callsign "
+                << trust.callsign
+                << " is the local federation callsign"
+                << std::endl;
+      return false;
+    }
+
+    if (!cfg.getValue("FEDERATION_TRUST",
+                      trust.callsign,
+                      trust.peer) ||
+        trust.peer.empty())
+    {
+      std::cerr << "*** ERROR: FEDERATION_TRUST/"
+                << trust.callsign
+                << " is missing or empty"
+                << std::endl;
+      return false;
+    }
+
+    bool peer_exists = false;
+    for (std::vector<PeerConfig>::const_iterator
+             peer_it=candidate_peer_configs.begin();
+         peer_it!=candidate_peer_configs.end(); ++peer_it)
+    {
+      if (peer_it->name == trust.peer)
+      {
+        peer_exists = true;
+        break;
+      }
+    }
+
+    if (!peer_exists)
+    {
+      std::cerr << "*** ERROR: Federation trust callsign "
+                << trust.callsign
+                << " refers to unknown peer "
+                << trust.peer
+                << std::endl;
+      return false;
+    }
+
+    for (std::vector<TrustEntry>::const_iterator
+             trust_it=candidate_trust_entries.begin();
+         trust_it!=candidate_trust_entries.end(); ++trust_it)
+    {
+      if (trust_it->peer == trust.peer)
+      {
+        std::cerr << "*** ERROR: Federation peer "
+                  << trust.peer
+                  << " has more than one trusted callsign"
+                  << std::endl;
+        return false;
+      }
+    }
+
+    candidate_trust_entries.push_back(trust);
+  }
+
+  for (std::vector<PeerConfig>::const_iterator
+           peer_it=candidate_peer_configs.begin();
+       peer_it!=candidate_peer_configs.end(); ++peer_it)
+  {
+    bool trust_exists = false;
+
+    for (std::vector<TrustEntry>::const_iterator
+             trust_it=candidate_trust_entries.begin();
+         trust_it!=candidate_trust_entries.end(); ++trust_it)
+    {
+      if (trust_it->peer == peer_it->name)
+      {
+        trust_exists = true;
+        break;
+      }
+    }
+
+    if (!trust_exists)
+    {
+      std::cerr << "*** ERROR: Federation peer "
+                << peer_it->name
+                << " has no FEDERATION_TRUST callsign"
+                << std::endl;
+      return false;
+    }
+  }
+
+  m_peer_configs.swap(candidate_peer_configs);
+  m_trust_entries.swap(candidate_trust_entries);
+
+  std::vector<FederationPeerConnection*> candidate_connections;
+
+  for (std::vector<PeerConfig>::const_iterator
+           it=m_peer_configs.begin();
+       it!=m_peer_configs.end(); ++it)
+  {
+    if (!it->connect)
+    {
+      continue;
+    }
+
+    candidate_connections.push_back(
+        new FederationPeerConnection(
+            it->name,
+            it->reflector_id,
+            m_reflector_id,
+            m_domain,
+            m_library.generation(),
+            m_callsign,
+            it->host,
+            it->port,
+            it->auth_key));
+  }
+
+  for (std::vector<FederationPeerConnection*>::iterator
+           it=m_peer_connections.begin();
+       it!=m_peer_connections.end(); ++it)
+  {
+    delete *it;
+  }
+
+  m_peer_connections.clear();
+
+  m_peer_connections.swap(candidate_connections);
+
+  std::cout << "Reflector federation enabled:"
+            << " domain=" << m_domain
+            << " reflector_id=" << m_reflector_id
+            << " callsign=" << m_callsign
+            << " peers=" << m_peers.size()
+            << " library=" << m_library_path
+            << " generation=" << m_library.generation()
+            << " routes=" << m_library.routeCount()
+            << " outgoing_connections="
+            << m_peer_connections.size()
+            << std::endl;
+
+  for (std::vector<PeerConfig>::const_iterator
+          it=m_peer_configs.begin();
+      it!=m_peer_configs.end(); ++it)
+  {
+    std::cout << "  Federation peer:"
+              << " name=" << it->name
+              << " reflector_id=" << it->reflector_id
+              << " host=" << it->host
+              << " port=" << it->port
+              << " protocol=" << it->protocol
+              << " connect=" << (it->connect ? "yes" : "no")
+              << std::endl;
+  }
+
+  for (std::vector<TrustEntry>::const_iterator
+           it=m_trust_entries.begin();
+       it!=m_trust_entries.end(); ++it)
+  {
+    std::cout << "  Federation trust:"
+              << " callsign=" << it->callsign
+              << " peer=" << it->peer
+              << std::endl;
+  }
+
+  return true;
+} /* ReflectorFederation::initialize */

--- a/src/svxlink/reflector/ReflectorFederation.h
+++ b/src/svxlink/reflector/ReflectorFederation.h
@@ -1,0 +1,337 @@
+/**
+@file   ReflectorFederation.h
+@brief  Federation support for SVXReflector
+@author Chris Jackson / G4NAB
+@date   2026-08-14
+
+\verbatim
+Copyright (C) 2026 Chris Jackson / G4NAB
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+\endverbatim
+*/
+
+#ifndef REFLECTOR_FEDERATION_INCLUDED
+#define REFLECTOR_FEDERATION_INCLUDED
+
+/****************************************************************************
+ *
+ * System Includes
+ *
+ ****************************************************************************/
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <sigc++/sigc++.h>
+#include <string>
+#include <vector>
+
+/****************************************************************************
+ *
+ * Project Includes
+ *
+ ****************************************************************************/
+
+#include <AsyncConfig.h>
+
+
+/****************************************************************************
+ *
+ * Local Includes
+ *
+ ****************************************************************************/
+
+#include "FederationLibrary.h"
+
+/****************************************************************************
+ *
+ * Class definitions
+ *
+ ****************************************************************************/
+
+class ReflectorClient;
+
+class FederationPeerConnection;
+
+/**
+@brief  Manage federation between autonomous SVXReflectors
+
+This class will own federation peers, talkgroup routing policy and runtime
+federation state. The initial implementation is deliberately inert.
+*/
+class ReflectorFederation
+{
+  public:
+    struct PeerConfig
+    {
+      std::string   name;
+      std::string   reflector_id;
+      std::string   host;
+      std::uint16_t port;
+      unsigned      protocol;
+      std::string   auth_key;
+      bool          connect;
+
+      PeerConfig(void)
+        : port(5300), protocol(2), connect(true)
+      {
+      }
+    };
+
+    struct TrustEntry
+    {
+      std::string callsign;
+      std::string peer;
+    };
+
+    struct IncomingStream
+    {
+      std::string   peer;
+      std::string   origin_reflector_id;
+      std::uint32_t tg;
+      std::uint64_t stream_id;
+      std::string   source_callsign;
+      std::string   codec;
+      std::uint32_t last_sequence;
+      bool          sequence_seen;
+
+      IncomingStream(void)
+        : tg(0),
+          stream_id(0),
+          last_sequence(0),
+          sequence_seen(false)
+      {
+      }
+    };
+
+    struct LocalStream
+    {
+      std::uint32_t tg;
+      std::uint64_t stream_id;
+      std::string   source_callsign;
+      std::string   codec;
+      bool          export_requested;
+
+      LocalStream(void)
+        : tg(0),
+          stream_id(0),
+          export_requested(false)
+      {
+      }
+    };
+
+    sigc::signal<void(std::uint32_t, const std::string&)>
+        incomingStreamStarted;
+
+    sigc::signal<void(std::uint32_t, const std::string&)>
+        incomingStreamStopped;
+
+
+    ReflectorFederation(void);
+    ~ReflectorFederation(void);
+
+    bool initialize(Async::Config& cfg);
+    bool isEnabled(void) const { return m_enabled; }
+
+    const std::string& domain(void) const { return m_domain; }
+    const std::string& reflectorId(void) const { return m_reflector_id; }
+    const std::string& callsign(void) const { return m_callsign; }
+    const std::string& libraryPath(void) const { return m_library_path; }
+
+    const std::vector<std::string>& peers(void) const
+    {
+      return m_peers;
+    }
+
+    const std::vector<PeerConfig>& peerConfigs(void) const
+    {
+      return m_peer_configs;
+    }
+
+    const PeerConfig* findPeerConfig(
+        const std::string& peer) const;
+
+    bool validatePeerHello(
+        const std::string& authenticated_callsign,
+        const std::string& reflector_id,
+        const std::string& domain,
+        std::uint16_t major,
+        std::uint16_t minor,
+        std::uint32_t capabilities,
+        std::string& peer,
+        std::uint16_t& negotiated_minor,
+        std::uint32_t& negotiated_capabilities,
+        std::string& error) const;
+
+    std::uint16_t validateIncomingStream(
+        const std::string& peer,
+        const std::string& origin_reflector_id,
+        std::uint32_t tg,
+        const std::string& codec,
+        std::string& error) const;
+
+    std::uint16_t startIncomingStream(
+        const std::string& peer,
+        const std::string& origin_reflector_id,
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        const std::string& source_callsign,
+        const std::string& codec,
+        std::string& error);
+
+    bool stopIncomingStream(
+        const std::string& peer,
+        const std::string& origin_reflector_id,
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        std::string& error);
+
+    bool acceptIncomingAudio(
+        const std::string& peer,
+        const std::string& origin_reflector_id,
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        std::uint32_t sequence,
+        std::string& error);
+
+    std::size_t removeIncomingStreams(
+        const std::string& peer);
+
+    bool registerPeerSession(
+        const std::string& peer,
+        ReflectorClient* client,
+        std::string& error);
+
+    void unregisterPeerSession(
+        ReflectorClient* client);
+
+    ReflectorClient* peerSession(
+        const std::string& peer) const;
+
+    std::size_t peerSessionCount(void) const
+    {
+      return m_peer_sessions.size();
+    }
+
+    const IncomingStream* findIncomingStream(
+        std::uint32_t tg) const;
+
+    std::size_t incomingStreamCount(void) const
+    {
+      return m_incoming_streams.size();
+    }
+
+    const std::vector<TrustEntry>& trustEntries(void) const
+    {
+      return m_trust_entries;
+    }
+
+    const TrustEntry* findTrustByCallsign(
+        const std::string& callsign) const;
+
+    const TrustEntry* findTrustByPeer(
+        const std::string& peer) const;
+
+    std::uint64_t libraryGeneration(void) const
+    {
+      return m_library.generation();
+    }
+
+    std::size_t routeCount(void) const
+    {
+      return m_library.routeCount();
+    }
+
+    bool mayImport(const std::string& peer, std::uint32_t tg) const
+    {
+      return m_enabled && m_library.mayImport(peer, tg);
+    }
+
+    bool mayExport(const std::string& peer, std::uint32_t tg) const
+    {
+      return m_enabled && m_library.mayExport(peer, tg);
+    }
+
+    bool beginLocalStream(
+        std::uint32_t tg,
+        const std::string& source_callsign,
+        const std::string& codec,
+        std::uint64_t& stream_id,
+        std::vector<std::string>& started_peers,
+        std::string& error);
+
+    std::size_t sendLocalStreamAudio(
+        std::uint32_t tg,
+        const std::vector<std::uint8_t>& audio_data);
+
+    std::size_t endLocalStream(
+        std::uint32_t tg,
+        std::vector<std::string>& stopped_peers,
+        std::string& error);
+
+    const LocalStream* findLocalStream(
+        std::uint32_t tg) const;
+
+    std::size_t localStreamCount(void) const
+    {
+      return m_local_streams.size();
+    }
+
+    std::size_t startLocalStream(
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        const std::string& source_callsign,
+        const std::string& codec,
+        std::vector<std::string>& started_peers,
+        std::string& error);
+
+    std::size_t sendLocalAudio(
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        const std::vector<std::uint8_t>& audio_data,
+        std::vector<std::string>& sent_peers,
+        std::string& error);
+
+    std::size_t stopLocalStream(
+        std::uint32_t tg,
+        std::uint64_t stream_id,
+        std::vector<std::string>& stopped_peers,
+        std::string& error);
+
+    std::size_t outgoingConnectionCount(void) const
+    {
+      return m_peer_connections.size();
+    }
+
+    FederationPeerConnection* peerConnection(
+        const std::string& peer) const;
+
+    void startPeerConnections(void);
+    void stopPeerConnections(void);
+
+  private:
+    bool                      m_enabled;
+    std::string               m_domain;
+    std::string               m_reflector_id;
+    std::string               m_callsign;
+    std::string               m_library_path;
+    std::vector<std::string>  m_peers;
+    std::vector<PeerConfig>   m_peer_configs;
+    std::vector<TrustEntry>   m_trust_entries;
+    std::vector<FederationPeerConnection*>  m_peer_connections;
+    std::map<std::uint32_t, IncomingStream>  m_incoming_streams;
+    std::map<std::uint32_t, LocalStream>     m_local_streams;
+    std::uint64_t                            m_next_local_stream_id;
+    std::map<std::string, ReflectorClient*>  m_peer_sessions;
+    FederationLibrary         m_library;
+
+    ReflectorFederation(const ReflectorFederation&);
+    ReflectorFederation& operator=(const ReflectorFederation&);
+};  /* class ReflectorFederation */
+
+
+#endif /* REFLECTOR_FEDERATION_INCLUDED */

--- a/src/svxlink/reflector/ReflectorFederation.md
+++ b/src/svxlink/reflector/ReflectorFederation.md
@@ -355,6 +355,274 @@ The library generation is announced during federation hello negotiation for
 diagnostic and compatibility purposes. Libraries are not advertised or
 remotely installed by the current implementation.
 
+## Federation configuration builder
+
+`svx_federation_builder.py` is installed with SVXReflector to provide a
+repeatable per-reflector planning and configuration workflow. It creates and
+validates a planning JSON file and generates the corresponding
+`Federation.conf` and federation library.
+
+The planning file is the administrator's editable source of truth. It records
+the reflector, peers, talkgroups and distribution decisions, but deliberately
+does not store authentication keys.
+
+The builder supports three commands:
+
+```text
+svx_federation_builder.py new PLAN
+svx_federation_builder.py check PLAN
+svx_federation_builder.py build PLAN [--output DIRECTORY] [--placeholders]
+```
+
+### Create a reflector plan
+
+Run the interactive questionnaire once for each reflector:
+
+```sh
+svx_federation_builder.py new UK-TEST-plan.json
+```
+
+The questionnaire requests:
+
+- the local federation `DOMAIN`;
+- the stable and globally unique local `REFLECTOR_ID`;
+- the federation access `CALLSIGN` used for outgoing authentication;
+- the installed federation library path;
+- whether the generated configuration should initially use `ENABLE=1`;
+- each peer's name, host, expected reflector ID, port and protocol;
+- whether an outgoing connector should be maintained for each peer;
+- the trusted incoming federation identity assigned to each peer;
+- the talkgroups and their administrative and distribution policy;
+- the initial federation library generation.
+
+The default safety state is `ENABLE=0`. Leave federation disabled until the
+generated files, peer authentication and reciprocal trust configuration have
+been reviewed.
+
+Peer names are converted to uppercase by the questionnaire. They must match
+the peer names used in the generated policy and in the remote deployment
+plans.
+
+Each talkgroup records:
+
+- `tg`: the positive integer talkgroup number;
+- `description`: the service or talkgroup description;
+- `ownership`: `domain`, `peer` or `network-wide`;
+- `home`: its administrative home domain or peer;
+- `distribution`: `local`, `selected-peers` or `network-wide`;
+- `service_anchor`: optional network or gateway identity metadata;
+- `allstar_node`: an optional associated AllStar node number;
+- `import_from`: peers permitted to originate this talkgroup locally;
+- `export_to`: peers to which locally originated audio may be sent.
+
+The ownership field records administrative responsibility. It does not grant
+transport permission. Import and export permission is determined independently
+from `import_from` and `export_to`.
+
+A `local` talkgroup has no peer permissions and is not emitted as a federated
+route. For `selected-peers`, the administrator chooses the import and export
+peers individually. For `network-wide`, all configured peers are offered as
+the default import and export selection, which may still be edited during the
+questionnaire.
+
+The builder currently creates exact numeric routes. Prefix routes supported by
+the runtime library must be written and administered separately.
+
+### Planning JSON structure
+
+The `new` command writes a JSON object with this overall structure:
+
+```json
+{
+  "plan_schema": 1,
+  "library_generation": 1,
+  "reflector": {
+    "domain": "UK-TEST",
+    "reflector_id": "uk-test.example.org",
+    "callsign": "REFLECTOR-FUK",
+    "library": "/etc/svxlink/federation.json",
+    "enable": false
+  },
+  "peers": [
+    {
+      "name": "NORTH-AMERICA",
+      "host": "reflector.example.org",
+      "reflector_id": "north-america.example.org",
+      "port": 35300,
+      "protocol": 2,
+      "connect": true,
+      "trust_callsign": "REFLECTOR-FNA"
+    }
+  ],
+  "talkgroups": [
+    {
+      "tg": 91,
+      "description": "Network-wide calling",
+      "ownership": "network-wide",
+      "home": "NETWORK-WIDE",
+      "distribution": "network-wide",
+      "service_anchor": "Network-wide service",
+      "allstar_node": "",
+      "import_from": [
+        "NORTH-AMERICA"
+      ],
+      "export_to": [
+        "NORTH-AMERICA"
+      ]
+    }
+  ]
+}
+```
+
+This example illustrates the format only. Reflector identities, hostnames,
+trust identities and policy must be assigned for the actual deployment.
+
+Authentication keys must not be added to the planning JSON.
+
+### Validate a plan
+
+Validate the plan after creating or manually editing it:
+
+```sh
+svx_federation_builder.py check UK-TEST-plan.json
+```
+
+Validation rejects, among other errors:
+
+- a wrong planning schema;
+- missing reflector identity fields;
+- invalid or duplicate peer definitions;
+- duplicate talkgroups;
+- invalid talkgroup ownership or distribution values;
+- references to unknown peers;
+- peer permissions assigned to a local talkgroup;
+- invalid ports or library generations.
+
+Warnings identify configurations that are valid but deserve administrative
+review, such as a federated talkgroup with no peer permissions, a non-standard
+protocol value or a network-wide talkgroup without a service anchor.
+
+A successful check reports the number of peers, talkgroups and federated
+routes that will be emitted.
+
+### Generate the deployment files
+
+Generate the files beneath the default `generated` directory:
+
+```sh
+svx_federation_builder.py build \
+  UK-TEST-plan.json
+```
+
+For each outgoing peer, the command privately requests its `AUTH_KEY` using a
+non-echoing terminal prompt. Authentication keys are written only to the
+generated `Federation.conf`; they are not added to the planning JSON.
+
+For unattended preparation, placeholders may be requested explicitly:
+
+```sh
+svx_federation_builder.py build \
+  UK-TEST-plan.json \
+  --placeholders
+```
+
+This writes `CHANGE_ME` for every authentication key and prints a warning.
+A configuration containing `CHANGE_ME` is not ready for deployment.
+
+An alternative output root may be selected:
+
+```sh
+svx_federation_builder.py build \
+  UK-TEST-plan.json \
+  --output generated
+```
+
+For a domain named `UK-TEST`, the generated files are:
+
+```text
+generated/UK-TEST/Federation.conf
+generated/UK-TEST/federation.json
+```
+
+`Federation.conf` is written with mode `0600` because it contains authentication
+keys. `federation.json` is written with mode `0644`. Both files are replaced
+atomically when regenerated.
+
+The generated library contains only non-local exact routes. Every emitted
+route has `scope` set to `family`, and the peer import and export lists are
+constructed from the plan's talkgroup permissions.
+
+### Review and install
+
+Inspect every generated file before installation:
+
+```sh
+sed -n '1,240p' \
+  generated/UK-TEST/Federation.conf
+
+python3 -m json.tool \
+  generated/UK-TEST/federation.json
+
+stat -c '%a %n' \
+  generated/UK-TEST/Federation.conf \
+  generated/UK-TEST/federation.json
+```
+
+Confirm that:
+
+- the local domain, reflector ID and service identity are correct;
+- every peer name exactly matches its policy name;
+- every expected remote reflector ID, host and port is correct;
+- each outgoing authentication key belongs to the local service identity on
+  that specific remote reflector;
+- every incoming trusted identity is registered locally and maps to the
+  intended peer;
+- import and export permissions are intentional;
+- no `CHANGE_ME` value remains;
+- the library path in `Federation.conf` matches the installation path.
+
+Install the reviewed files using explicit permissions:
+
+```sh
+sudo install \
+  -o root \
+  -g root \
+  -m 600 \
+  generated/UK-TEST/Federation.conf \
+  /etc/svxlink/svxreflector.d/Federation.conf
+
+sudo install \
+  -o root \
+  -g root \
+  -m 644 \
+  generated/UK-TEST/federation.json \
+  /etc/svxlink/federation.json
+```
+
+Do not enable or restart a production reflector until the reciprocal peer
+authentication, trust mappings and policies have been prepared and checked.
+
+### Updating a deployment
+
+Retain the planning JSON as the deployment record for that reflector. When a
+peer or talkgroup policy changes:
+
+1. edit the appropriate plan;
+2. increment `library_generation`;
+3. run `check`;
+4. run `build`;
+5. review both generated files;
+6. install them using the required ownership and modes;
+7. restart the reflector during an approved maintenance period.
+
+Use a separate plan for every reflector because identities, connection
+directions, trust mappings and import/export policy are evaluated locally.
+
+Planning files may be retained in a private administrative repository if they
+contain no locally sensitive site information. Generated `Federation.conf`
+files and authentication keys must never be committed to the SvxLink source
+repository.
+
 ## Locally originated streams
 
 Ordinary client audio follows the existing SVXReflector talker arbitration.
@@ -371,6 +639,7 @@ When the first accepted OPUS frame arrives on a talkgroup:
 5. It sends an independent stream-start request to each selected peer.
 6. The local stream is recorded once even when no peer is currently eligible,
    preventing repeated start attempts for every audio frame.
+
 
 ### Pending audio
 

--- a/src/svxlink/reflector/ReflectorFederation.md
+++ b/src/svxlink/reflector/ReflectorFederation.md
@@ -1,0 +1,516 @@
+# SVXReflector Federation
+
+## Status
+
+SVXReflector federation is implemented as an integrated component of each
+participating SVXReflector. The current implementation uses the established
+V2-compatible reflector transport for authentication and framing, with a
+separate federation application protocol carried over that connection.
+
+The implementation has been exercised between independently configured
+SVXReflectors in both directions, including authentication, federation session
+establishment, UDP registration, stream acceptance, OPUS audio forwarding,
+normal stream termination and cleanup after an originating client disconnect.
+
+The protocol and configuration should still be treated as development
+interfaces until they have received broader interoperability testing.
+
+## Provenance
+
+This work is based solely on the official SvxLink/SVXReflector source by
+Tobias Blomberg, SM0SVX, and the observed behaviour required by the G4NAB
+reflector-family deployment.
+
+GeuReflector is explicitly excluded as a source or technical reference. Its
+source code, architecture and implementation details have not been consulted,
+copied, translated or adapted.
+
+## Purpose
+
+Federation provides controlled, distributed, on-demand talkgroup routing
+between autonomous SVXReflectors without an independent central federation
+server and without client-side ReflectorLogic bridges between every server.
+
+Each reflector remains locally administered. A talkgroup is exchanged with a
+peer only when that reflector's own configuration and policy explicitly permit
+it.
+
+## Implemented principles
+
+- Federation is integrated into every participating SVXReflector.
+- There is no central federation process or mandatory hub.
+- Peer relationships, credentials and policy are configured locally.
+- Each talkgroup has independent stream and talker state.
+- Different talkgroups may be active simultaneously.
+- Only OPUS audio is federated.
+- Encoded OPUS frames are forwarded without transcoding.
+- Imported audio is delivered locally but is never re-exported.
+- A locally originated stream is sent directly to every connected peer for
+  which export policy permits that talkgroup.
+- Import and export are independently denied by default.
+- Failure or restart of a peer causes its connector to disconnect and retry.
+- A peer disconnect removes its incoming streams and releases local listener
+  state.
+
+## Architecture
+
+### `ReflectorFederation`
+
+`ReflectorFederation` owns the local federation configuration, policy library,
+trusted incoming sessions, incoming stream state, outgoing peer connectors and
+locally originated stream lifecycle.
+
+It coordinates stream start, audio and stop operations across every eligible
+outgoing peer. It also reports incoming stream start and stop events to
+`Reflector`, allowing ordinary local clients to receive the normal talker and
+flush notifications.
+
+### `FederationPeerConnection`
+
+`FederationPeerConnection` represents one locally initiated connection to a
+configured peer. It performs:
+
+- V2-compatible challenge-response authentication;
+- federation hello and capability negotiation;
+- UDP path registration;
+- TCP and UDP heartbeat maintenance;
+- reconnect after connection failure;
+- outgoing stream request, result and stop handling;
+- outgoing OPUS audio sequencing;
+- bounded audio buffering while stream acceptance is pending.
+
+Only peers with `CONNECT=1` have a locally initiated connector.
+
+### `FederationLibrary`
+
+`FederationLibrary` loads and validates the JSON talkgroup and peer-policy
+library. The library provides route classification and explicit per-peer import
+and export decisions.
+
+The library is read during reflector initialisation. Runtime hot reload,
+rollback and route advertisement are not part of the current implementation.
+
+## Connection model
+
+An outgoing connector is directional. `CONNECT=1` means that the local
+reflector initiates and maintains a connection to that peer. `CONNECT=0` means
+that no local connector is created, although a correctly authenticated and
+trusted incoming session from that peer may still be accepted.
+
+Bidirectional federation normally uses reciprocal configuration:
+
+1. Reflector A configures Reflector B with `CONNECT=1`.
+2. Reflector B configures Reflector A with `CONNECT=1`.
+3. A establishes an authenticated outgoing session to B.
+4. B independently establishes an authenticated outgoing session to A.
+
+There are therefore two directional sessions between a fully bidirectional
+pair. Each direction has its own authentication, hello negotiation, UDP
+registration, heartbeat state and reconnect behaviour.
+
+Restarting either reflector is an ordinary operational event. The surviving
+connector detects the lost session and retries until its peer is available
+again.
+
+## Federation access identities
+
+Each reflector has one stable federation access identity configured by
+`CALLSIGN`. The name is retained because authentication uses the existing V2
+callsign/password mechanism, but the value may be an administrator-issued
+service identity rather than an on-air amateur callsign.
+
+A consistent family allocation is recommended:
+
+```text
+REFLECTOR-FUK    UK-WIDE
+REFLECTOR-FNA    NORTH-AMERICA
+REFLECTOR-FYK    YORKSHIRENET
+REFLECTOR-FAU    AUSTRALIA
+```
+
+The access identity:
+
+- must be unique within the federation family;
+- remains stable when a hostname or address changes;
+- is authorised through the receiving reflector's normal user/password
+  configuration;
+- must be accepted by the receiving reflector's configured callsign rules;
+- is mapped to exactly one peer through `[FEDERATION_TRUST]`.
+
+The stable `REFLECTOR_ID` is a separate identity. It identifies the reflector
+in federation messages and should normally be a globally unique DNS-style
+name.
+
+## Federation access registration and trust
+
+Each participating reflector uses a dedicated federation access identity, for
+example `REFLECTOR-FUK` or `REFLECTOR-FNA`.
+
+Before federation can operate, the administrator of each receiving reflector
+must register and accept the remote reflector's federation access identity
+through the normal SVXReflector callsign and X.509 certificate administration
+process.
+
+This is an administrative prerequisite. It does not change talkgroup handling,
+UDP transport, OPUS audio, stream identity or routing policy.
+
+After the federation access identity has been accepted:
+
+1. The identity must appear in `[FEDERATION_TRUST]`.
+2. The trust entry maps that identity to exactly one configured peer.
+3. The federation hello must contain the expected `REFLECTOR_ID` and domain.
+4. Only then is the authenticated connection granted federation privileges.
+
+An accepted ordinary client identity has no federation privileges unless it is
+also explicitly mapped in `[FEDERATION_TRUST]`.
+
+The federation access identity identifies the peer reflector. It is separate
+from the callsign of the user originating a talkgroup stream. For example,
+`REFLECTOR-FNA` may carry a stream whose source callsign is `G4NAB-10`.
+
+## Transport and wire protocol
+
+Federation control messages use the authenticated TCP connection. Federation
+OPUS frames use its associated registered UDP path.
+
+The federation application protocol has its own version and capability flags,
+independent of the underlying reflector transport version. The current hello
+negotiation uses federation protocol version 1.0.
+
+### Control messages
+
+| Type | Message | Purpose |
+| ---: | --- | --- |
+| 200 | `MsgFederationHello` | Present reflector identity, domain, library generation and capabilities |
+| 201 | `MsgFederationHelloAck` | Accept the federation session and negotiated capabilities |
+| 202 | `MsgFederationStreamStart` | Request an outgoing talkgroup stream |
+| 203 | `MsgFederationStreamResult` | Accept or reject the requested stream |
+| 204 | `MsgFederationStreamStop` | End an established or pending stream |
+
+### UDP audio
+
+`MsgUdpFederationAudio` identifies every audio frame by:
+
+- originating reflector ID;
+- talkgroup;
+- stream ID;
+- audio sequence number;
+- encoded OPUS payload.
+
+Federation audio is distinct from ordinary client `MsgUdpAudio`. A receiving
+reflector validates the federation session, stream identity and sequence
+before converting the payload into ordinary local reflector audio for its
+listeners.
+
+### Stream identity
+
+A federation stream is identified by:
+
+```text
+origin_reflector_id
+talkgroup
+stream_id
+```
+
+The locally generated stream ID distinguishes successive streams on the same
+talkgroup. The origin identity prevents a peer from presenting a stream as if
+it came from another configured reflector.
+
+## Configuration
+
+Federation configuration is kept in `Federation.conf`, normally installed from
+`Federation.conf.in`. Its directory is included through `GLOBAL/CFG_DIR` in
+the main SVXReflector configuration.
+
+Federation is inactive unless `[FEDERATION]` contains `ENABLE=1`.
+
+### Local configuration
+
+```ini
+[FEDERATION]
+ENABLE=1
+DOMAIN=UK-WIDE
+REFLECTOR_ID=uk-wide.example.org
+CALLSIGN=REFLECTOR-FUK
+LIBRARY=/etc/svxlink/federation.json
+PEERS=NORTH-AMERICA
+
+[FEDERATION_PEER_NORTH-AMERICA]
+HOST=north-america.example.org
+REFLECTOR_ID=north-america.example.org
+PORT=35300
+PROTOCOL=2
+AUTH_KEY=replace-with-the-remote-access-key
+CONNECT=1
+
+[FEDERATION_TRUST]
+REFLECTOR-FNA=NORTH-AMERICA
+```
+
+### `[FEDERATION]` values
+
+| Value | Meaning |
+| --- | --- |
+| `ENABLE` | Enables federation when set to `1` |
+| `DOMAIN` | Administrative federation domain for the local reflector |
+| `REFLECTOR_ID` | Stable and unique local reflector identity |
+| `CALLSIGN` | Local federation access identity used for outgoing authentication |
+| `LIBRARY` | Path to the local JSON route and policy library |
+| `PEERS` | Comma-separated configured peer names |
+
+### Peer values
+
+Each entry in `PEERS` requires a matching
+`[FEDERATION_PEER_<name>]` section.
+
+| Value | Meaning |
+| --- | --- |
+| `HOST` | Remote hostname or address |
+| `REFLECTOR_ID` | Expected stable identity of the remote reflector; defaults to `HOST` when omitted |
+| `PORT` | Remote reflector service port |
+| `PROTOCOL` | Underlying reflector protocol used by the outgoing connector; currently `2` |
+| `AUTH_KEY` | Password used with the local federation access identity on the remote reflector |
+| `CONNECT` | Creates and maintains a local outgoing connector when set to `1` |
+
+Peer names are policy identifiers and must match consistently between
+`PEERS`, peer section names, `[FEDERATION_TRUST]` values and JSON
+`peer_policy` keys.
+
+### Incoming trust
+
+`[FEDERATION_TRUST]` maps a remote authenticated access identity to its local
+peer name:
+
+```ini
+[FEDERATION_TRUST]
+REFLECTOR-FNA=NORTH-AMERICA
+```
+
+Each configured peer requires exactly one trusted incoming identity. The same
+identity must also be authorised through the ordinary reflector access
+configuration.
+
+## Talkgroup library
+
+The JSON library contains route metadata and explicit peer policy. It contains
+no passwords or private keys.
+
+```json
+{
+  "schema": 1,
+  "generation": 3,
+  "domain": "UK-WIDE",
+  "routes": [
+    {
+      "type": "exact",
+      "value": 235,
+      "home": "UK-WIDE",
+      "scope": "family",
+      "description": "UK-wide calling"
+    },
+    {
+      "type": "exact",
+      "value": 9050,
+      "home": "UK-WIDE",
+      "scope": "family",
+      "description": "Example shared gateway talkgroup"
+    }
+  ],
+  "peer_policy": {
+    "NORTH-AMERICA": {
+      "import": ["235"],
+      "export": ["235", "9050"]
+    }
+  }
+}
+```
+
+### Routes
+
+Only a configured route with `scope` set to `family` is eligible for
+federation. A missing route, an unsupported route or any other scope leaves
+the talkgroup local.
+
+The `home` value records administrative ownership or routing metadata. It does
+not by itself authorise a peer to originate the talkgroup. This permits a
+family talkgroup to carry replies originating at another authorised
+reflector.
+
+### Peer policy
+
+Every peer has independent `import` and `export` lists:
+
+- `import` permits locally receiving a matching talkgroup from that peer;
+- `export` permits sending a locally originated matching talkgroup to that
+  peer.
+
+Entries may be exact talkgroup numbers such as `235` or supported prefix
+patterns such as `310*`. No match means deny.
+
+Policy is evaluated locally. Authentication, trust, a family-scoped route and
+the appropriate peer-policy match are all required; none of them alone grants
+permission.
+
+The library generation is announced during federation hello negotiation for
+diagnostic and compatibility purposes. Libraries are not advertised or
+remotely installed by the current implementation.
+
+## Locally originated streams
+
+Ordinary client audio follows the existing SVXReflector talker arbitration.
+Only the accepted local talker can originate a federation stream.
+
+When the first accepted OPUS frame arrives on a talkgroup:
+
+1. `Reflector` confirms that the talkgroup is not occupied by an incoming
+   federation stream.
+2. `ReflectorFederation` creates one local stream with a non-zero stream ID.
+3. It evaluates every locally configured outgoing connector.
+4. It selects only peers whose connector is connected, whose UDP path is
+   registered and whose export policy permits the talkgroup.
+5. It sends an independent stream-start request to each selected peer.
+6. The local stream is recorded once even when no peer is currently eligible,
+   preventing repeated start attempts for every audio frame.
+
+### Pending audio
+
+Audio may arrive before a peer accepts its stream-start request. Each outgoing
+peer stream therefore has a bounded pending queue:
+
+- up to 25 encoded OPUS frames are retained;
+- when full, the oldest frame is discarded;
+- sequence numbers are assigned only when frames are transmitted;
+- queued frames are sent in order immediately after acceptance;
+- rejection or disconnect removes the corresponding outgoing stream state.
+
+Once active, subsequent frames are sent immediately through the registered UDP
+path.
+
+### Local stream termination
+
+The local stream ends when the existing reflector talker state ends. This
+includes:
+
+- an ordinary client flush;
+- talker audio timeout;
+- SQL timeout handling;
+- originating client disconnect.
+
+`ReflectorFederation` sends a stream-stop message to every matching outgoing
+peer and removes the local stream state. Cleanup is tied to the central talker
+transition, so the different termination paths share the same behaviour.
+
+## Incoming streams
+
+An incoming stream request is accepted only when:
+
+- federation is enabled;
+- the session belongs to a configured and trusted peer;
+- the origin reflector ID matches that peer;
+- the talkgroup and stream ID are non-zero;
+- the source identity is present;
+- the codec is `OPUS`;
+- the talkgroup has a `family` route;
+- local import policy permits that peer and talkgroup;
+- the talkgroup does not already contain another incoming federation stream.
+
+After acceptance, UDP frames must match the peer, origin, talkgroup and stream
+identity. Sequence state is tracked independently for each talkgroup.
+
+The receiving reflector:
+
+1. announces the imported source to applicable V2 local clients with
+   `MsgTalkerStart`;
+2. broadcasts decoded federation payloads as ordinary encoded
+   `MsgUdpAudio` frames to local listeners on that talkgroup;
+3. never passes those imported frames into the outgoing local-stream path;
+4. announces `MsgTalkerStop` when the stream ends;
+5. sends `MsgUdpFlushSamples` to local listeners so buffered audio is released.
+
+If the peer session disconnects, all incoming streams owned by that peer are
+removed and the same local stop and flush lifecycle is emitted.
+
+## Loop prevention and direct distribution
+
+Loop prevention follows one simple boundary: only accepted ordinary local
+client audio may enter the outgoing federation lifecycle.
+
+`MsgUdpFederationAudio` is validated and delivered directly to local clients.
+It is not converted into a new locally originated federation stream. Imported
+audio therefore cannot be reflected back to its source or forwarded to a
+third peer.
+
+For a shared talkgroup across several reflectors, each possible origin must
+have direct export permission and connectivity to every intended recipient.
+A reflector does not act as a transit hub for another reflector's imported
+stream.
+
+A reply from a user on a receiving reflector is a new locally originated
+stream. It receives a new origin reflector ID and stream ID and is distributed
+according to that reflector's own export policy.
+
+## Operational behaviour
+
+### Startup
+
+When federation is enabled, SVXReflector validates the static configuration,
+trust mappings and JSON library during initialisation. It creates outgoing
+connectors only for peers with `CONNECT=1` and then starts their asynchronous
+connection attempts.
+
+The startup log reports local identity, policy generation, route count, peer
+configuration, trust mappings and outgoing connector count.
+
+### Reconnection
+
+Outgoing connectors reconnect after refusal, peer restart, transport failure
+or heartbeat timeout. Authentication, hello negotiation and UDP registration
+are repeated for every new session.
+
+Runtime streams are session state. They are not restored across a disconnect;
+the ordinary talker must establish a later stream if audio continues after
+connectivity returns.
+
+### Diagnostics
+
+Normal logs identify:
+
+- TCP connection and authentication;
+- federation hello acceptance;
+- UDP path registration;
+- outgoing stream request, acceptance, rejection and stop;
+- incoming stream acceptance and stop;
+- disconnect and reconnect causes.
+
+Credentials and authentication keys must not be written to logs.
+
+## Tested behaviour
+
+The development test environment has verified:
+
+- default-denied export policy;
+- disconnected peers receiving no stream request;
+- accepted peer authentication and federation hello negotiation;
+- confirmed UDP registration and heartbeats;
+- outgoing stream pending and active states;
+- OPUS audio queued before acceptance and flushed afterward;
+- normal local stream stop;
+- local stream cleanup after an originating client disconnect;
+- direct UK-WIDE to NORTH-AMERICA audio;
+- direct NORTH-AMERICA to UK-WIDE audio;
+- local listener talker-start, OPUS audio, flush and talker-stop notifications
+  for an imported stream.
+
+## Current limitations
+
+- Only OPUS federation streams are supported.
+- Peer and policy configuration is loaded at startup.
+- Runtime hot reload and rollback are not implemented.
+- Route advertisements and remote policy distribution are not implemented.
+- There is no federation administration API or dashboard interface.
+- Imported streams are not relayed to additional peers.
+- X.509 certification and the reflector protocol 3.0 certificate
+  infrastructure are implemented by the participating reflectors and remain
+  available.
+- Federation protocol and configuration compatibility are not yet declared
+  stable.

--- a/src/svxlink/reflector/ReflectorFederation.md
+++ b/src/svxlink/reflector/ReflectorFederation.md
@@ -357,97 +357,199 @@ remotely installed by the current implementation.
 
 ## Federation configuration builder
 
-`svx_federation_builder.py` is installed with SVXReflector to provide a
-repeatable per-reflector planning and configuration workflow. It creates and
-validates a planning JSON file and generates the corresponding
-`Federation.conf` and federation library.
+`svx_federation_builder.py` is installed with SVXReflector as an interactive
+planning and policy administration tool. It creates a separate planning JSON
+for each reflector and generates the corresponding `Federation.conf` and
+federation policy library.
 
-The planning file is the administrator's editable source of truth. It records
-the reflector, peers, talkgroups and distribution decisions, but deliberately
-does not store authentication keys.
+The planning JSON is the administrator's editable source of truth. It contains
+reflector identities, peer definitions, talkgroup ownership and two-way sharing
+decisions, but deliberately contains no authentication keys.
 
-The builder supports three commands:
+The builder never installs files into `/etc`, edits an installed
+`Federation.conf`, or restarts SVXReflector.
+
+The supported commands are:
 
 ```text
 svx_federation_builder.py new PLAN
+svx_federation_builder.py edit PLAN [--output DIRECTORY]
+svx_federation_builder.py show PLAN
 svx_federation_builder.py check PLAN
 svx_federation_builder.py build PLAN [--output DIRECTORY] [--placeholders]
+svx_federation_builder.py library PLAN [--output DIRECTORY]
 ```
 
-### Create a reflector plan
+### Administrative model
 
-Run the interactive questionnaire once for each reflector:
+Every reflector has its own plan and evaluates policy locally. Peer
+relationships are explicitly bilateral: technical reachability or membership
+of the same network family does not grant permission to federate.
+
+Adding a peer to one reflector does not add it to any other reflector. A
+manager should enter peer information only after the two participating
+managers have agreed the direct relationship and the information may be used
+for that deployment.
+
+Talkgroups shared through this builder are always two-way. A selected peer is
+added to both the runtime `import` and `export` policy for the talkgroup. The
+corresponding peer must independently configure the reciprocal permission.
+
+Federation remains non-transitive. Imported streams are never re-exported, so
+two reflectors that need to exchange a talkgroup must have an approved direct
+relationship. A genuinely family-wide talkgroup requires direct relationships
+between every pair of participating reflectors expected to hear one another.
+
+### Create a new reflector plan
+
+Run the staged questionnaire once for each reflector:
 
 ```sh
-svx_federation_builder.py new UK-TEST-plan.json
+svx_federation_builder.py new GREAT-BRITAIN-plan.json
 ```
 
-The questionnaire requests:
+The `new` command refuses to overwrite an existing plan. If the named file
+already exists, use `edit` instead.
 
-- the local federation `DOMAIN`;
-- the stable and globally unique local `REFLECTOR_ID`;
-- the federation access `CALLSIGN` used for outgoing authentication;
-- the installed federation library path;
-- whether the generated configuration should initially use `ENABLE=1`;
-- each peer's name, host, expected reflector ID, port and protocol;
-- whether an outgoing connector should be maintained for each peer;
-- the trusted incoming federation identity assigned to each peer;
-- the talkgroups and their administrative and distribution policy;
-- the initial federation library generation.
+The questionnaire has three stages:
 
-The default safety state is `ENABLE=0`. Leave federation disabled until the
-generated files, peer authentication and reciprocal trust configuration have
-been reviewed.
+1. local reflector identity;
+2. approved direct federation peers;
+3. talkgroup policy.
 
-Peer names are converted to uppercase by the questionnaire. They must match
-the peer names used in the generated policy and in the remote deployment
-plans.
+Administrative identifiers such as the domain, federation login identities
+and peer names are converted to uppercase. DNS hostnames and paths retain the
+case entered by the administrator.
 
-Each talkgroup records:
+#### Local reflector identity
 
-- `tg`: the positive integer talkgroup number;
-- `description`: the service or talkgroup description;
-- `ownership`: `domain`, `peer` or `network-wide`;
-- `home`: its administrative home domain or peer;
-- `distribution`: `local`, `selected-peers` or `network-wide`;
-- `service_anchor`: optional network or gateway identity metadata;
-- `allstar_node`: an optional associated AllStar node number;
-- `import_from`: peers permitted to originate this talkgroup locally;
-- `export_to`: peers to which locally originated audio may be sent.
+The local questions record:
 
-The ownership field records administrative responsibility. It does not grant
-transport permission. Import and export permission is determined independently
-from `import_from` and `export_to`.
+- the administrative federation domain, for example `GREAT-BRITAIN`;
+- the permanent federation service DNS hostname;
+- the dedicated outgoing federation login identity;
+- the final installed policy path;
+- the initial enabled state for a generated configuration.
 
-A `local` talkgroup has no peer permissions and is not emitted as a federated
-route. For `selected-peers`, the administrator chooses the import and export
-peers individually. For `network-wide`, all configured peers are offered as
-the default import and export selection, which may still be edited during the
-questionnaire.
+The federation service hostname is used as the local `REFLECTOR_ID`. It is the
+hostname of the SVXReflector service, not a public website URL. For example, a
+reflector may use `uk.wide.svxlink.uk` as its federation service hostname while
+publishing a dashboard at a different web address.
 
-The builder currently creates exact numeric routes. Prefix routes supported by
-the runtime library must be written and administered separately.
+The outgoing federation identity is a reflector service account, not the
+callsign of an amateur originating talkgroup audio. An example Great Britain
+identity is `REFLECTOR-FGB`. It must be registered and accepted by every
+receiving reflector and assigned to the correct peer in that reflector's
+`[FEDERATION_TRUST]` section.
+
+The standard policy installation path is:
+
+```text
+/etc/svxlink/federation.json
+```
+
+The initial safety default is `ENABLE=0`. The setting takes effect only after
+the generated file is reviewed, installed and SVXReflector is restarted.
+
+#### Direct peers
+
+A peer is another approved federation-enabled SVXReflector with which this
+reflector may exchange traffic directly. Before accepting a new peer, the
+questionnaire asks the administrator to confirm that the remote manager has
+approved the relationship.
+
+For each peer, the plan records:
+
+- an uppercase policy name such as `NORTH-AMERICA`;
+- the remote federation service DNS hostname;
+- the remote TCP/UDP service port;
+- whether this reflector maintains an outgoing connector;
+- the incoming federation login identity used by that peer.
+
+The remote federation service hostname is written as both `HOST` and the
+expected remote `REFLECTOR_ID`. It must not be a website URL or include an
+`https://` prefix or page path.
+
+Federation connections currently use the established protocol 2 callsign and
+password authentication path. The builder records `PROTOCOL=2` without asking
+the administrator to select an unsupported alternative. This does not remove
+the protocol 3 and X.509 capabilities of the installed SVXReflector software.
+
+For bidirectional transport, each reflector normally maintains its own
+outgoing connection to the other. `CONNECT=0` accepts the approved incoming
+relationship without starting a local outgoing connector.
+
+The incoming login identity is the service account presented by the remote
+reflector when it connects locally. It is mapped to the peer name under
+`[FEDERATION_TRUST]` and must already be registered and authenticated locally.
+
+The completed peer list is displayed for confirmation before talkgroup entry
+begins. Talkgroup ownership and sharing choices use this fixed list.
+
+#### Talkgroup policy
+
+Unlisted talkgroups remain local by default and cannot be imported or
+exported. An administrator may also record a talkgroup explicitly as local;
+it remains in the plan but is not emitted as a federation route.
+
+The builder creates exact positive integer routes. Prefix routes supported by
+the runtime library must currently be administered separately.
+
+Each entered talkgroup records:
+
+- its number and human-readable description;
+- administrative ownership and home;
+- its distribution class;
+- the approved peers sharing it in both directions.
+
+Administrative ownership has three choices:
+
+- `domain`: administered by the local federation domain;
+- `peer`: administered by one configured remote peer;
+- `network-wide`: a family service not assigned to one regional domain.
+
+For domain-owned and network-wide talkgroups, the administrative home is
+assigned automatically. For peer-owned talkgroups, the administrator selects
+the responsible peer from the configured list.
+
+Ownership does not grant transport permission. For example, TG 310 may be
+peer-owned by `NORTH-AMERICA` in the Great Britain plan while still permitting
+Great Britain users to participate through an approved two-way policy.
+
+Distribution has three administrator-facing choices:
+
+- local only;
+- selected approved peers;
+- all approved peers in this plan.
+
+The internal value for the third choice remains `network-wide`. It means all
+peers explicitly configured and approved in this local plan, not every current
+or future member of the wider network family. A newly added peer is never
+inserted into existing talkgroup policy automatically.
+
+The same selected peer list is stored in `import_from` and `export_to`.
+Validation rejects a manually edited plan whose two lists differ.
 
 ### Planning JSON structure
 
-The `new` command writes a JSON object with this overall structure:
+A new plan starts at generation 1. Its overall structure is:
 
 ```json
 {
   "plan_schema": 1,
   "library_generation": 1,
   "reflector": {
-    "domain": "UK-TEST",
-    "reflector_id": "uk-test.example.org",
-    "callsign": "REFLECTOR-FUK",
+    "domain": "GREAT-BRITAIN",
+    "reflector_id": "uk.wide.svxlink.uk",
+    "callsign": "REFLECTOR-FGB",
     "library": "/etc/svxlink/federation.json",
     "enable": false
   },
   "peers": [
     {
       "name": "NORTH-AMERICA",
-      "host": "reflector.example.org",
-      "reflector_id": "north-america.example.org",
+      "host": "na.example.org",
+      "reflector_id": "na.example.org",
       "port": 35300,
       "protocol": 2,
       "connect": true,
@@ -456,13 +558,11 @@ The `new` command writes a JSON object with this overall structure:
   ],
   "talkgroups": [
     {
-      "tg": 91,
-      "description": "Network-wide calling",
-      "ownership": "network-wide",
-      "home": "NETWORK-WIDE",
-      "distribution": "network-wide",
-      "service_anchor": "Network-wide service",
-      "allstar_node": "",
+      "tg": 235,
+      "description": "UK-wide calling",
+      "ownership": "domain",
+      "home": "GREAT-BRITAIN",
+      "distribution": "selected-peers",
       "import_from": [
         "NORTH-AMERICA"
       ],
@@ -474,154 +574,210 @@ The `new` command writes a JSON object with this overall structure:
 }
 ```
 
-This example illustrates the format only. Reflector identities, hostnames,
-trust identities and policy must be assigned for the actual deployment.
+The example identities and hostnames illustrate the format only. Actual peer
+information must be agreed by the participating managers. Authentication keys
+must never be added to the planning JSON.
 
-Authentication keys must not be added to the planning JSON.
+### Display and validate a plan
 
-### Validate a plan
-
-Validate the plan after creating or manually editing it:
+Display a readable summary without changing any file:
 
 ```sh
-svx_federation_builder.py check UK-TEST-plan.json
+svx_federation_builder.py show GREAT-BRITAIN-plan.json
 ```
 
-Validation rejects, among other errors:
+The summary lists the domain, reflector, generation, peers, talkgroups,
+administrative homes and two-way sharing relationships.
 
-- a wrong planning schema;
-- missing reflector identity fields;
-- invalid or duplicate peer definitions;
-- duplicate talkgroups;
-- invalid talkgroup ownership or distribution values;
-- references to unknown peers;
-- peer permissions assigned to a local talkgroup;
-- invalid ports or library generations.
+Validate a plan after creation or manual editing:
 
-Warnings identify configurations that are valid but deserve administrative
-review, such as a federated talkgroup with no peer permissions, a non-standard
-protocol value or a network-wide talkgroup without a service anchor.
+```sh
+svx_federation_builder.py check GREAT-BRITAIN-plan.json
+```
 
-A successful check reports the number of peers, talkgroups and federated
-routes that will be emitted.
+Validation rejects missing identities, duplicate peers or talkgroups, invalid
+ports, unknown peer references, asymmetric import/export policy, local
+talkgroups with peer permissions and peer-owned talkgroups whose home is not a
+configured peer.
 
-### Generate the deployment files
+### Create the initial deployment files
 
-Generate the files beneath the default `generated` directory:
+Generate an initial configuration and runtime library:
 
 ```sh
 svx_federation_builder.py build \
-  UK-TEST-plan.json
+  GREAT-BRITAIN-plan.json \
+  --output generated
 ```
 
-For each outgoing peer, the command privately requests its `AUTH_KEY` using a
-non-echoing terminal prompt. Authentication keys are written only to the
-generated `Federation.conf`; they are not added to the planning JSON.
+For each outgoing peer, the builder privately requests its `AUTH_KEY` through
+a non-echoing terminal prompt. Keys are written only to the generated
+`Federation.conf` and never to the plan.
 
 For unattended preparation, placeholders may be requested explicitly:
 
 ```sh
 svx_federation_builder.py build \
-  UK-TEST-plan.json \
+  GREAT-BRITAIN-plan.json \
+  --output generated \
   --placeholders
 ```
 
-This writes `CHANGE_ME` for every authentication key and prints a warning.
-A configuration containing `CHANGE_ME` is not ready for deployment.
+This writes `CHANGE_ME` for every key. Such a configuration is not ready for
+deployment.
 
-An alternative output root may be selected:
+For a `GREAT-BRITAIN` domain, initial output is:
+
+```text
+generated/GREAT-BRITAIN/Federation.conf
+generated/GREAT-BRITAIN/federation.json
+```
+
+`Federation.conf` is created with mode `0600`; `federation.json` is created
+with mode `0644`. `build` refuses to replace either existing output file and
+instructs the administrator to select another output directory.
+
+### Review and edit an existing plan
+
+Open the interactive editor with:
 
 ```sh
-svx_federation_builder.py build \
-  UK-TEST-plan.json \
+svx_federation_builder.py edit \
+  GREAT-BRITAIN-plan.json \
   --output generated
 ```
 
-For a domain named `UK-TEST`, the generated files are:
+The editor first presents the current reflector, peer and talkgroup policy. It
+provides separate menus for:
+
+- adding, removing or changing talkgroups;
+- changing the approved peers sharing a talkgroup;
+- adding, removing or changing peer definitions;
+- reviewing local reflector details;
+- displaying the proposed JSON changes;
+- saving or exiting without changes.
+
+Adding a peer never shares existing talkgroups with it automatically. The
+administrator must add the new peer deliberately to each agreed talkgroup.
+
+Removing a peer lists every affected talkgroup before confirmation and removes
+that peer from their two-way sharing lists. If a talkgroup has no remaining
+peer, it becomes local.
+
+Before saving, the builder validates the proposed plan, displays a unified
+diff and asks for final confirmation. On approval it:
+
+1. writes a timestamped backup beside the existing plan;
+2. increments `library_generation` automatically;
+3. atomically replaces the planning JSON;
+4. creates a generation-numbered candidate policy;
+5. leaves all installed files unchanged.
+
+Example output for generation 4 is:
 
 ```text
-generated/UK-TEST/Federation.conf
-generated/UK-TEST/federation.json
+GREAT-BRITAIN-plan.json.20260819-104500.bak
+generated/GREAT-BRITAIN/federation-generation-4.json
 ```
 
-`Federation.conf` is written with mode `0600` because it contains authentication
-keys. `federation.json` is written with mode `0644`. Both files are replaced
-atomically when regenerated.
+If a peer was added or changed, the editor also writes a mode `0600`
+peer-specific configuration snippet such as:
 
-The generated library contains only non-local exact routes. Every emitted
-route has `scope` set to `family`, and the peer import and export lists are
-constructed from the plan's talkgroup permissions.
+```text
+generated/GREAT-BRITAIN/peer-AUSTRALIA.conf
+```
 
-### Review and install
+The administrator merges this snippet into the installed `Federation.conf`
+and supplies the correct `AUTH_KEY`. Existing credentials are never collected
+or rewritten by the editor.
 
-Inspect every generated file before installation:
+If a peer was removed, the editor writes a removal checklist such as:
+
+```text
+generated/GREAT-BRITAIN/remove-peer-AUSTRALIA.txt
+```
+
+It identifies the `PEERS` entry, peer section and trust mapping that must be
+removed manually. The builder never edits the installed configuration.
+
+### Generate a versioned policy candidate
+
+Generate a policy from an unchanged valid plan without producing
+`Federation.conf`:
+
+```sh
+svx_federation_builder.py library \
+  GREAT-BRITAIN-plan.json \
+  --output generated
+```
+
+For generation 4 this creates:
+
+```text
+generated/GREAT-BRITAIN/federation-generation-4.json
+```
+
+The command refuses to replace an existing candidate of the same generation.
+Increment the generation only when making a deliberate policy revision.
+
+### Review and install generated files
+
+Inspect a candidate before installation:
+
+```sh
+python3 -m json.tool \
+  generated/GREAT-BRITAIN/federation-generation-4.json
+
+diff -u \
+  /etc/svxlink/federation.json \
+  generated/GREAT-BRITAIN/federation-generation-4.json
+```
+
+For an initial deployment, inspect the generated configuration and modes:
 
 ```sh
 sed -n '1,240p' \
-  generated/UK-TEST/Federation.conf
-
-python3 -m json.tool \
-  generated/UK-TEST/federation.json
+  generated/GREAT-BRITAIN/Federation.conf
 
 stat -c '%a %n' \
-  generated/UK-TEST/Federation.conf \
-  generated/UK-TEST/federation.json
+  generated/GREAT-BRITAIN/Federation.conf \
+  generated/GREAT-BRITAIN/federation.json
 ```
 
-Confirm that:
+Confirm that all identities, hostnames, ports, trust mappings, two-way
+talkgroup permissions and authentication keys are correct. No `CHANGE_ME`
+value may remain in a deployed configuration.
 
-- the local domain, reflector ID and service identity are correct;
-- every peer name exactly matches its policy name;
-- every expected remote reflector ID, host and port is correct;
-- each outgoing authentication key belongs to the local service identity on
-  that specific remote reflector;
-- every incoming trusted identity is registered locally and maps to the
-  intended peer;
-- import and export permissions are intentional;
-- no `CHANGE_ME` value remains;
-- the library path in `Federation.conf` matches the installation path.
+Install reviewed files deliberately using the required permissions. For a
+policy-only revision:
 
-Install the reviewed files using explicit permissions:
+```sh
+sudo install \
+  -o root \
+  -g root \
+  -m 644 \
+  generated/GREAT-BRITAIN/federation-generation-4.json \
+  /etc/svxlink/federation.json
+```
+
+For an initial configuration:
 
 ```sh
 sudo install \
   -o root \
   -g root \
   -m 600 \
-  generated/UK-TEST/Federation.conf \
+  generated/GREAT-BRITAIN/Federation.conf \
   /etc/svxlink/svxreflector.d/Federation.conf
-
-sudo install \
-  -o root \
-  -g root \
-  -m 644 \
-  generated/UK-TEST/federation.json \
-  /etc/svxlink/federation.json
 ```
 
-Do not enable or restart a production reflector until the reciprocal peer
-authentication, trust mappings and policies have been prepared and checked.
+Do not restart a production reflector until reciprocal authentication, trust
+and talkgroup policy have been agreed and prepared at every affected peer.
 
-### Updating a deployment
-
-Retain the planning JSON as the deployment record for that reflector. When a
-peer or talkgroup policy changes:
-
-1. edit the appropriate plan;
-2. increment `library_generation`;
-3. run `check`;
-4. run `build`;
-5. review both generated files;
-6. install them using the required ownership and modes;
-7. restart the reflector during an approved maintenance period.
-
-Use a separate plan for every reflector because identities, connection
-directions, trust mappings and import/export policy are evaluated locally.
-
-Planning files may be retained in a private administrative repository if they
-contain no locally sensitive site information. Generated `Federation.conf`
-files and authentication keys must never be committed to the SvxLink source
-repository.
+Use a separate plan for every reflector. Planning files may be retained in a
+private administrative repository when appropriate. Generated
+`Federation.conf` files, peer snippets and authentication keys must never be
+committed to the SvxLink source repository.
 
 ## Locally originated streams
 

--- a/src/svxlink/reflector/svx_federation_builder.py
+++ b/src/svxlink/reflector/svx_federation_builder.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
-"""Interactive planner and file generator for native SVXReflector federation.
+"""Plan and generate native SVXReflector federation configuration.
 
-The planning JSON deliberately contains no authentication keys.  The build
-command requests them privately, or writes CHANGE_ME placeholders when asked.
+Planning files contain no authentication keys.  The builder never installs a
+file into /etc and never restarts SVXReflector.
 """
 
 from __future__ import annotations
 
 import argparse
+import copy
+import datetime as dt
+import difflib
 import getpass
 import json
 import os
@@ -22,7 +25,8 @@ OWNERSHIP = ("domain", "peer", "network-wide")
 DISTRIBUTION = ("local", "selected-peers", "network-wide")
 
 
-def ask(prompt: str, default: str | None = None, required: bool = True) -> str:
+def ask(prompt: str, default: str | None = None,
+        required: bool = True) -> str:
     suffix = f" [{default}]" if default is not None else ""
     while True:
         value = input(f"{prompt}{suffix}: ").strip()
@@ -46,7 +50,8 @@ def ask_bool(prompt: str, default: bool = False) -> bool:
         print("Please answer yes or no.")
 
 
-def ask_int(prompt: str, default: int | None = None, minimum: int = 0) -> int:
+def ask_int(prompt: str, default: int | None = None,
+            minimum: int = 0, maximum: int | None = None) -> int:
     while True:
         raw = ask(prompt, str(default) if default is not None else None)
         try:
@@ -57,27 +62,64 @@ def ask_int(prompt: str, default: int | None = None, minimum: int = 0) -> int:
         if value < minimum:
             print(f"Enter a value of at least {minimum}.")
             continue
+        if maximum is not None and value > maximum:
+            print(f"Enter a value no greater than {maximum}.")
+            continue
         return value
 
 
-def ask_choice(prompt: str, choices: tuple[str, ...], default: str) -> str:
+def choose(prompt: str, labels: list[str], default: int | None = None) -> int:
+    if not labels:
+        raise ValueError("No choices are available")
+    print(f"\n{prompt}")
+    for number, label in enumerate(labels, 1):
+        print(f"  {number}. {label}")
     while True:
-        value = ask(f"{prompt} ({'/'.join(choices)})", default).lower()
-        if value in choices:
-            return value
-        print("Choose one of: " + ", ".join(choices))
-
-
-def ask_csv(prompt: str, allowed: set[str], default: list[str] | None = None) -> list[str]:
-    default_text = ",".join(default or [])
-    while True:
-        raw = ask(prompt, default_text, required=False)
-        values = [item.strip() for item in raw.split(",") if item.strip()]
-        unknown = sorted(set(values) - allowed)
-        if unknown:
-            print("Unknown peer name(s): " + ", ".join(unknown))
+        raw = ask("Selection", str(default) if default is not None else None)
+        try:
+            selected = int(raw)
+        except ValueError:
+            print("Enter one of the displayed numbers.")
             continue
-        return list(dict.fromkeys(values))
+        if 1 <= selected <= len(labels):
+            return selected - 1
+        print("Enter one of the displayed numbers.")
+
+
+def choose_many(prompt: str, peers: list[dict[str, Any]],
+                defaults: list[str] | None = None,
+                allow_none: bool = False) -> list[str]:
+    names = [str(peer["name"]) for peer in peers]
+    selected_defaults = set(defaults or [])
+    print(f"\n{prompt}")
+    for number, name in enumerate(names, 1):
+        marker = "selected" if name in selected_defaults else "not selected"
+        print(f"  {number}. {name} [{marker}]")
+    while True:
+        default_numbers = ",".join(
+            str(index + 1) for index, name in enumerate(names)
+            if name in selected_defaults)
+        raw = ask(
+            "Peer numbers separated by commas"
+            + (" (blank selects none)" if allow_none else ""),
+            default_numbers, required=not allow_none)
+        if not raw:
+            return []
+        try:
+            numbers = [int(item.strip()) for item in raw.split(",")]
+        except ValueError:
+            print("Enter only displayed peer numbers separated by commas.")
+            continue
+        if any(number < 1 or number > len(names) for number in numbers):
+            print("One or more selections are outside the displayed list.")
+            continue
+        result: list[str] = []
+        for number in numbers:
+            name = names[number - 1]
+            if name not in result:
+                result.append(name)
+        if result or allow_none:
+            return result
 
 
 def safe_name(value: str) -> str:
@@ -85,15 +127,14 @@ def safe_name(value: str) -> str:
     return cleaned or "reflector"
 
 
-def write_json(path: Path, value: Any, mode: int = 0o644) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(path.name + ".tmp")
-    temporary.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
-    os.chmod(temporary, mode)
-    temporary.replace(path)
+def json_text(value: Any) -> str:
+    return json.dumps(value, indent=2) + "\n"
 
 
-def write_text(path: Path, value: str, mode: int) -> None:
+def write_text(path: Path, value: str, mode: int,
+               replace: bool = False) -> None:
+    if path.exists() and not replace:
+        raise FileExistsError(f"File already exists: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(path.name + ".tmp")
     temporary.write_text(value, encoding="utf-8")
@@ -101,101 +142,9 @@ def write_text(path: Path, value: str, mode: int) -> None:
     temporary.replace(path)
 
 
-def new_plan(path: Path) -> int:
-    print("\nSVXReflector federation plan questionnaire")
-    print("Authentication keys are not collected or stored in this plan.\n")
-
-    domain = ask("Local federation DOMAIN", "UK-TEST")
-    reflector = {
-        "domain": domain,
-        "reflector_id": ask("Stable REFLECTOR_ID"),
-        "callsign": ask("Federation access CALLSIGN/service identity"),
-        "library": ask("Installed federation library path", "/etc/svxlink/federation.json"),
-        "enable": ask_bool("Generate Federation.conf with ENABLE=1", False),
-    }
-
-    peers: list[dict[str, Any]] = []
-    print("\nEnter configured peers. Peer names must match federation policy names.")
-    while ask_bool("Add a peer", not peers):
-        name = ask("Peer name").upper()
-        peers.append({
-            "name": name,
-            "host": ask("Remote hostname or address"),
-            "reflector_id": ask("Expected remote REFLECTOR_ID"),
-            "port": ask_int("Remote TCP/UDP service port", 35300, 1),
-            "protocol": ask_int("SVXReflector client protocol", 2, 1),
-            "connect": ask_bool("Maintain an outgoing connector", True),
-            "trust_callsign": ask("Trusted incoming federation identity from this peer"),
-        })
-
-    peer_names = {peer["name"] for peer in peers}
-    talkgroups: list[dict[str, Any]] = []
-    print("\nEnter talkgroups. Leave the TG prompt blank when finished.")
-    while True:
-        raw = ask("Talkgroup number", required=False)
-        if not raw:
-            break
-        try:
-            tg = int(raw)
-        except ValueError:
-            print("Talkgroup must be a positive whole number.")
-            continue
-        if tg <= 0:
-            print("Talkgroup must be greater than zero.")
-            continue
-
-        description = ask("Service or description")
-        ownership = ask_choice("Ownership", OWNERSHIP, "domain")
-        distribution = ask_choice("Distribution", DISTRIBUTION, "local")
-
-        if ownership == "domain":
-            home_default = domain
-        elif ownership == "network-wide":
-            home_default = "NETWORK-WIDE"
-        else:
-            home_default = next(iter(peer_names), "")
-
-        home = ask("Administrative home domain or peer", home_default or None)
-        service_anchor = ask("Service anchor (blank if none)", "", required=False)
-        allstar_node = ask("Associated AllStar node (blank if none)", "", required=False)
-
-        if distribution == "local":
-            import_from: list[str] = []
-            export_to: list[str] = []
-        else:
-            defaults = sorted(peer_names) if distribution == "network-wide" else []
-            import_from = ask_csv("Permit import from peers (comma-separated)", peer_names, defaults)
-            export_to = ask_csv("Permit export to peers (comma-separated)", peer_names, defaults)
-
-        talkgroups.append({
-            "tg": tg,
-            "description": description,
-            "ownership": ownership,
-            "home": home,
-            "distribution": distribution,
-            "service_anchor": service_anchor,
-            "allstar_node": int(allstar_node) if allstar_node.isdigit() else allstar_node,
-            "import_from": import_from,
-            "export_to": export_to,
-        })
-
-    plan = {
-        "plan_schema": PLAN_SCHEMA,
-        "library_generation": ask_int("Initial library generation", 1, 1),
-        "reflector": reflector,
-        "peers": peers,
-        "talkgroups": talkgroups,
-    }
-
-    errors, warnings = validate_plan(plan)
-    print_messages(errors, warnings)
-    if errors:
-        print("Plan was not written because validation failed.", file=sys.stderr)
-        return 1
-
-    write_json(path, plan)
-    print(f"\nPlan written: {path}")
-    return 0
+def write_json(path: Path, value: Any, mode: int = 0o644,
+               replace: bool = False) -> None:
+    write_text(path, json_text(value), mode, replace)
 
 
 def load_plan(path: Path) -> dict[str, Any]:
@@ -210,12 +159,231 @@ def load_plan(path: Path) -> dict[str, Any]:
     return value
 
 
+def print_identity_intro() -> None:
+    print("\nStep 1 of 3: Local reflector identity")
+    print("-" * 45)
+    print("The planning JSON contains no authentication keys.")
+    print("A DNS federation service hostname is used as REFLECTOR_ID. It is not")
+    print("a website URL and must not include https:// or a page path.\n")
+
+
+def ask_reflector() -> dict[str, Any]:
+    print_identity_intro()
+    print("Federation domain")
+    print("Enter the administrative network or geographical domain represented")
+    print("by this reflector. Examples: GREAT-BRITAIN, NORTH-AMERICA, AUSTRALIA.")
+    domain = ask("Federation domain").upper()
+
+    print("\nLocal federation service hostname")
+    print("Enter the permanent DNS hostname of this SVXReflector federation")
+    print("service. Do not enter its public website URL.")
+    hostname = ask("Federation service hostname")
+
+    print("\nOutgoing federation login identity")
+    print("Enter the dedicated service identity used by this reflector when it")
+    print("authenticates to peers. It is not an amateur user's callsign.")
+    print("Example: REFLECTOR-FGB")
+    callsign = ask("Outgoing federation identity").upper()
+
+    print("\nFederation policy file location")
+    print("This is the final installation path written as LIBRARY in")
+    print("Federation.conf. The standard path should normally be accepted.")
+    library = ask("Federation policy file", "/etc/svxlink/federation.json")
+
+    print("\nInitial federation state")
+    print("Choose No while preparing or reviewing a deployment. This setting")
+    print("takes effect only after installation and an SVXReflector restart.")
+    enable = ask_bool("Enable federation in the generated configuration", False)
+    return {
+        "domain": domain,
+        "reflector_id": hostname,
+        "callsign": callsign,
+        "library": library,
+        "enable": enable,
+    }
+
+
+def ask_peer(existing_names: set[str]) -> dict[str, Any] | None:
+    print("\nPeer relationship approval")
+    print("A peer is another federation-enabled SVXReflector authorised to")
+    print("communicate directly with this reflector. Imported audio is not relayed.")
+    if not ask_bool("Has the remote manager approved this direct relationship", False):
+        print("Peer not added.")
+        return None
+
+    while True:
+        name = ask("Peer policy name (for example NORTH-AMERICA)").upper()
+        if name not in existing_names:
+            break
+        print(f"Peer already exists: {name}")
+
+    print("\nRemote federation service hostname")
+    print("Enter the DNS hostname used to reach the remote SVXReflector service.")
+    print("It will also be used as the expected remote REFLECTOR_ID.")
+    host = ask("Remote federation service hostname")
+    port = ask_int("Remote SVXReflector TCP/UDP service port", 35300, 1, 65535)
+    print("Federation connection authentication: protocol 2, callsign and password")
+
+    print(f"\nOutgoing connection to {name}")
+    print("For bidirectional federation, each reflector normally maintains its")
+    print("own outgoing connection to the other.")
+    connect = ask_bool(f"Maintain an outgoing connection to {name}", True)
+
+    print(f"\nIncoming login identity for {name}")
+    print(f"Enter the service identity that {name} uses when connecting to this")
+    print("reflector. It must be registered and authenticated locally.")
+    trust = ask(f"Incoming identity used by {name}").upper()
+    return {
+        "name": name,
+        "host": host,
+        "reflector_id": host,
+        "port": port,
+        "protocol": 2,
+        "connect": connect,
+        "trust_callsign": trust,
+    }
+
+
+def print_peer_summary(peers: list[dict[str, Any]]) -> None:
+    print("\nConfigured direct peers:")
+    if not peers:
+        print("  None")
+        return
+    for number, peer in enumerate(peers, 1):
+        mode = "outgoing connector" if peer.get("connect") else "incoming only"
+        print(f"  {number}. {peer['name']:<20} {peer['host']} ({mode})")
+
+
+def collect_peers() -> list[dict[str, Any]]:
+    print("\nStep 2 of 3: Direct federation peers")
+    print("-" * 45)
+    print("Configure every approved reflector with which this reflector may")
+    print("exchange talkgroup traffic directly.\n")
+    peers: list[dict[str, Any]] = []
+    while True:
+        peer = ask_peer({str(item["name"]) for item in peers})
+        if peer is not None:
+            peers.append(peer)
+        print_peer_summary(peers)
+        if peers and ask_bool("Are all required direct peers listed", False):
+            return peers
+        if not ask_bool("Add a remote reflector peer", not peers):
+            if peers:
+                return peers
+            print("At least one peer is required for a federation plan.")
+
+
+def ownership_for_tg(domain: str, peers: list[dict[str, Any]]) -> tuple[str, str]:
+    labels = [
+        f"This domain - managed by {domain}",
+        "A remote peer - managed by a configured remote domain",
+        "Network-wide - shared service belonging to the reflector family",
+    ]
+    selected = choose("Administrative ownership", labels, 1)
+    if selected == 0:
+        return "domain", domain
+    if selected == 2:
+        return "network-wide", "NETWORK-WIDE"
+    peer_index = choose(
+        "Select the peer with administrative responsibility",
+        [str(peer["name"]) for peer in peers])
+    return "peer", str(peers[peer_index]["name"])
+
+
+def distribution_for_tg(peers: list[dict[str, Any]], tg: int) -> tuple[str, list[str]]:
+    labels = [
+        "Local only - no federation route",
+        "Selected peers - share with specifically approved peers",
+        "All approved peers - share with every peer in this plan",
+    ]
+    selected = choose("Talkgroup distribution", labels, 1)
+    if selected == 0:
+        return "local", []
+    if selected == 2:
+        defaults = [str(peer["name"]) for peer in peers]
+        print("\nAll configured peers are proposed. Each relationship remains")
+        print("subject to bilateral manager approval.")
+        shared = choose_many(
+            f"Peers sharing TG {tg} in both directions", peers, defaults)
+        return "network-wide", shared
+    shared = choose_many(
+        f"Peers sharing TG {tg} in both directions", peers)
+    return "selected-peers", shared
+
+
+def ask_talkgroup(domain: str, peers: list[dict[str, Any]],
+                  existing_tgs: set[int]) -> dict[str, Any] | None:
+    raw = ask("Talkgroup number, or press Enter to finish", required=False)
+    if not raw:
+        return None
+    try:
+        tg = int(raw)
+    except ValueError:
+        print("Talkgroup must be a positive whole number.")
+        return {}
+    if tg <= 0:
+        print("Talkgroup must be greater than zero.")
+        return {}
+    if tg in existing_tgs:
+        print(f"Talkgroup already exists: {tg}")
+        return {}
+    description = ask("Talkgroup description")
+    ownership, home = ownership_for_tg(domain, peers)
+    distribution, shared = distribution_for_tg(peers, tg)
+    return {
+        "tg": tg,
+        "description": description,
+        "ownership": ownership,
+        "home": home,
+        "distribution": distribution,
+        "import_from": shared,
+        "export_to": list(shared),
+    }
+
+
+def collect_talkgroups(domain: str,
+                       peers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    print("\nStep 3 of 3: Talkgroup policy")
+    print("-" * 45)
+    print("Unlisted talkgroups remain local by default. The builder creates exact")
+    print("numeric routes, not wildcard or prefix routes.")
+    talkgroups: list[dict[str, Any]] = []
+    while True:
+        route = ask_talkgroup(
+            domain, peers, {int(item["tg"]) for item in talkgroups})
+        if route is None:
+            return talkgroups
+        if route:
+            talkgroups.append(route)
+
+
+def normalise_plan(plan: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(plan)
+    reflector = result.get("reflector", {})
+    if isinstance(reflector, dict):
+        reflector["domain"] = str(reflector.get("domain", "")).upper()
+        reflector["callsign"] = str(reflector.get("callsign", "")).upper()
+    for peer in result.get("peers", []):
+        if isinstance(peer, dict):
+            peer["name"] = str(peer.get("name", "")).upper()
+            peer["trust_callsign"] = str(peer.get("trust_callsign", "")).upper()
+            peer["protocol"] = 2
+    for route in result.get("talkgroups", []):
+        if not isinstance(route, dict):
+            continue
+        route.pop("service_anchor", None)
+        route.pop("allstar_node", None)
+        shared = list(dict.fromkeys(route.get("import_from", [])))
+        route["import_from"] = shared
+        route["export_to"] = list(shared)
+    return result
+
+
 def validate_plan(plan: dict[str, Any]) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
     if plan.get("plan_schema") != PLAN_SCHEMA:
         errors.append(f"plan_schema must be {PLAN_SCHEMA}")
-
     reflector = plan.get("reflector")
     if not isinstance(reflector, dict):
         return ["reflector must be an object"], warnings
@@ -240,17 +408,18 @@ def validate_plan(plan: dict[str, Any]) -> tuple[list[str], list[str]]:
             if not isinstance(peer.get(field), str) or not peer[field].strip():
                 errors.append(f"{label}.{field} is required")
         name = str(peer.get("name", ""))
-        if name:
-            peer_names.append(name)
+        peer_names.append(name)
         peer_ids.append(str(peer.get("reflector_id", "")))
         trust_ids.append(str(peer.get("trust_callsign", "")))
         port = peer.get("port")
         if not isinstance(port, int) or not 1 <= port <= 65535:
             errors.append(f"{label}.port must be between 1 and 65535")
         if peer.get("protocol") != 2:
-            warnings.append(f"{label}.protocol is not the currently documented value 2")
-
-    for values, label in ((peer_names, "peer name"), (peer_ids, "peer reflector_id"), (trust_ids, "trust identity")):
+            errors.append(f"{label}.protocol must currently be 2")
+    for values, label in (
+            (peer_names, "peer name"),
+            (peer_ids, "peer reflector_id"),
+            (trust_ids, "trust identity")):
         duplicates = sorted({item for item in values if item and values.count(item) > 1})
         if duplicates:
             errors.append(f"Duplicate {label}(s): {', '.join(duplicates)}")
@@ -273,27 +442,27 @@ def validate_plan(plan: dict[str, Any]) -> tuple[list[str], list[str]]:
         else:
             seen_tgs.add(tg)
         if route.get("ownership") not in OWNERSHIP:
-            errors.append(f"{label}.ownership must be one of {', '.join(OWNERSHIP)}")
-        distribution = route.get("distribution")
-        if distribution not in DISTRIBUTION:
-            errors.append(f"{label}.distribution must be one of {', '.join(DISTRIBUTION)}")
+            errors.append(f"{label}.ownership is invalid")
+        if route.get("distribution") not in DISTRIBUTION:
+            errors.append(f"{label}.distribution is invalid")
         if not isinstance(route.get("home"), str) or not route["home"].strip():
             errors.append(f"{label}.home is required")
-        for field in ("import_from", "export_to"):
-            values = route.get(field, [])
-            if not isinstance(values, list) or any(not isinstance(item, str) for item in values):
-                errors.append(f"{label}.{field} must be an array of peer names")
-                continue
-            unknown = sorted(set(values) - peer_set)
-            if unknown:
-                errors.append(f"{label}.{field} contains unknown peers: {', '.join(unknown)}")
-        if distribution == "local" and (route.get("import_from") or route.get("export_to")):
-            errors.append(f"{label} is local but has peer permissions")
-        if distribution != "local" and not (route.get("import_from") or route.get("export_to")):
-            warnings.append(f"TG {tg} is federated but has no peer permissions")
-        if route.get("ownership") == "network-wide" and not route.get("service_anchor"):
-            warnings.append(f"Network-wide TG {tg} has no service anchor yet")
-
+        imports = route.get("import_from", [])
+        exports = route.get("export_to", [])
+        if not isinstance(imports, list) or not isinstance(exports, list):
+            errors.append(f"{label} peer permissions must be arrays")
+            continue
+        unknown = sorted((set(imports) | set(exports)) - peer_set)
+        if unknown:
+            errors.append(f"{label} contains unknown peers: {', '.join(unknown)}")
+        if imports != exports:
+            errors.append(f"{label} must use identical two-way import and export peers")
+        if route.get("distribution") == "local" and imports:
+            errors.append(f"{label} is local but has shared peers")
+        if route.get("distribution") != "local" and not imports:
+            errors.append(f"{label} is federated but has no shared peers")
+        if route.get("ownership") == "peer" and route.get("home") not in peer_set:
+            errors.append(f"{label}.home must name a configured peer")
     generation = plan.get("library_generation")
     if not isinstance(generation, int) or generation < 1:
         errors.append("library_generation must be a positive whole number")
@@ -308,41 +477,33 @@ def print_messages(errors: list[str], warnings: list[str]) -> None:
 
 
 def federation_library(plan: dict[str, Any]) -> dict[str, Any]:
-    domain = plan["reflector"]["domain"]
-    routes: list[dict[str, Any]] = []
     policies: dict[str, dict[str, list[str]]] = {
         peer["name"]: {"import": [], "export": []}
         for peer in plan["peers"]
     }
-
-    for tg in plan["talkgroups"]:
-        if tg["distribution"] == "local":
+    routes: list[dict[str, Any]] = []
+    for route in plan["talkgroups"]:
+        if route["distribution"] == "local":
             continue
-        route: dict[str, Any] = {
+        routes.append({
             "type": "exact",
-            "value": tg["tg"],
-            "home": tg["home"],
+            "value": route["tg"],
+            "home": route["home"],
             "scope": "family",
-            "description": tg["description"],
-        }
-        if tg.get("service_anchor"):
-            route["service_anchor"] = tg["service_anchor"]
-        routes.append(route)
-        value = str(tg["tg"])
-        for peer in tg.get("import_from", []):
+            "description": route["description"],
+        })
+        value = str(route["tg"])
+        for peer in route["import_from"]:
             policies[peer]["import"].append(value)
-        for peer in tg.get("export_to", []):
             policies[peer]["export"].append(value)
-
     for policy in policies.values():
         policy["import"] = sorted(set(policy["import"]), key=int)
         policy["export"] = sorted(set(policy["export"]), key=int)
-
     return {
         "schema": 1,
         "generation": plan["library_generation"],
-        "domain": domain,
-        "routes": sorted(routes, key=lambda route: route["value"]),
+        "domain": plan["reflector"]["domain"],
+        "routes": sorted(routes, key=lambda item: item["value"]),
         "peer_policy": policies,
     }
 
@@ -354,16 +515,13 @@ def federation_conf(plan: dict[str, Any], keys: dict[str, str]) -> str:
         "###################################################################",
         "# Generated SVXReflector federation configuration",
         "# Review before installing as svxreflector.d/Federation.conf",
-        "###################################################################",
-        "",
-        "[FEDERATION]",
+        "###################################################################", "", "[FEDERATION]",
         f"ENABLE={1 if reflector.get('enable') else 0}",
         f"DOMAIN={reflector['domain']}",
         f"REFLECTOR_ID={reflector['reflector_id']}",
         f"CALLSIGN={reflector['callsign']}",
         f"LIBRARY={reflector['library']}",
-        "PEERS=" + ",".join(peer["name"] for peer in peers),
-        "",
+        "PEERS=" + ",".join(peer["name"] for peer in peers), "",
     ]
     for peer in peers:
         lines.extend([
@@ -373,15 +531,282 @@ def federation_conf(plan: dict[str, Any], keys: dict[str, str]) -> str:
             f"PORT={peer['port']}",
             f"PROTOCOL={peer['protocol']}",
             f"AUTH_KEY={keys[peer['name']]}",
-            f"CONNECT={1 if peer.get('connect') else 0}",
-            "",
+            f"CONNECT={1 if peer.get('connect') else 0}", "",
         ])
     if peers:
         lines.append("[FEDERATION_TRUST]")
-        for peer in peers:
-            lines.append(f"{peer['trust_callsign']}={peer['name']}")
+        lines.extend(f"{peer['trust_callsign']}={peer['name']}" for peer in peers)
         lines.append("")
     return "\n".join(lines)
+
+
+def show_plan(plan: dict[str, Any]) -> None:
+    reflector = plan["reflector"]
+    print(f"\nDomain: {reflector['domain']}")
+    print(f"Reflector: {reflector['reflector_id']}")
+    print(f"Policy generation: {plan['library_generation']}")
+    print_peer_summary(plan["peers"])
+    print("\nTalkgroup policy:")
+    if not plan["talkgroups"]:
+        print("  None")
+        return
+    print("  TG       Description                    Home                 Shared with")
+    for route in sorted(plan["talkgroups"], key=lambda item: item["tg"]):
+        shared = ", ".join(route["import_from"]) or "LOCAL"
+        description = str(route["description"])[:30]
+        print(f"  {route['tg']:<8} {description:<30} "
+              f"{route['home']:<20} {shared}")
+
+
+def plan_diff(before: dict[str, Any], after: dict[str, Any]) -> str:
+    return "".join(difflib.unified_diff(
+        json_text(before).splitlines(True),
+        json_text(after).splitlines(True),
+        fromfile="current plan", tofile="proposed plan"))
+
+
+def new_plan(path: Path) -> int:
+    if path.exists():
+        print(f"ERROR: Plan already exists: {path}", file=sys.stderr)
+        print(f"Use 'edit {path}' to review or change it.", file=sys.stderr)
+        print("No file was changed.", file=sys.stderr)
+        return 1
+    reflector = ask_reflector()
+    peers = collect_peers()
+    talkgroups = collect_talkgroups(str(reflector["domain"]), peers)
+    plan = {
+        "plan_schema": PLAN_SCHEMA,
+        "library_generation": 1,
+        "reflector": reflector,
+        "peers": peers,
+        "talkgroups": talkgroups,
+    }
+    errors, warnings = validate_plan(plan)
+    print_messages(errors, warnings)
+    if errors:
+        print("Plan was not written because validation failed.", file=sys.stderr)
+        return 1
+    show_plan(plan)
+    print("\nThis new plan uses federation policy generation 1.")
+    if not ask_bool("Save this new plan", False):
+        print("No file was written.")
+        return 0
+    write_json(path, plan)
+    print(f"Plan written: {path}")
+    return 0
+
+
+def choose_talkgroup(plan: dict[str, Any]) -> dict[str, Any] | None:
+    routes = sorted(plan["talkgroups"], key=lambda item: item["tg"])
+    if not routes:
+        print("No talkgroups are configured.")
+        return None
+    selected = choose("Select a talkgroup", [
+        f"TG {route['tg']} - {route['description']}" for route in routes])
+    return routes[selected]
+
+
+def edit_talkgroups(plan: dict[str, Any]) -> None:
+    labels = ["Add a talkgroup", "Remove a talkgroup", "Change shared peers",
+              "Change description", "Change administrative ownership",
+              "Return to main menu"]
+    while True:
+        action = choose("Talkgroup policy", labels, 6)
+        if action == 5:
+            return
+        if action == 0:
+            route = ask_talkgroup(
+                plan["reflector"]["domain"], plan["peers"],
+                {int(item["tg"]) for item in plan["talkgroups"]})
+            if route:
+                plan["talkgroups"].append(route)
+            continue
+        route = choose_talkgroup(plan)
+        if route is None:
+            continue
+        if action == 1:
+            if ask_bool(f"Remove TG {route['tg']} from this plan", False):
+                plan["talkgroups"].remove(route)
+        elif action == 2:
+            distribution, shared = distribution_for_tg(plan["peers"], route["tg"])
+            route["distribution"] = distribution
+            route["import_from"] = shared
+            route["export_to"] = list(shared)
+        elif action == 3:
+            route["description"] = ask("Talkgroup description", route["description"])
+        elif action == 4:
+            ownership, home = ownership_for_tg(
+                plan["reflector"]["domain"], plan["peers"])
+            route["ownership"] = ownership
+            route["home"] = home
+
+
+def peer_snippet(peer: dict[str, Any]) -> str:
+    return "\n".join([
+        f"# Merge {peer['name']} into PEERS in [FEDERATION]", "",
+        f"[FEDERATION_PEER_{peer['name']}]",
+        f"HOST={peer['host']}",
+        f"REFLECTOR_ID={peer['reflector_id']}",
+        f"PORT={peer['port']}", "PROTOCOL=2", "AUTH_KEY=CHANGE_ME",
+        f"CONNECT={1 if peer.get('connect') else 0}", "",
+        "# Merge under [FEDERATION_TRUST]",
+        f"{peer['trust_callsign']}={peer['name']}", "",
+    ])
+
+
+def peer_removal(peer: dict[str, Any]) -> str:
+    return "\n".join([
+        f"Remove peer {peer['name']} from Federation.conf", "",
+        f"1. Remove {peer['name']} from PEERS= in [FEDERATION].", "",
+        f"2. Remove the complete [FEDERATION_PEER_{peer['name']}] section.", "",
+        "3. Remove this line from [FEDERATION_TRUST]:",
+        f"   {peer['trust_callsign']}={peer['name']}", "",
+        "4. Review and install the revised federation policy.",
+        "5. Restart SVXReflector during an agreed maintenance period.", "",
+    ])
+
+
+def edit_peers(plan: dict[str, Any], added: list[dict[str, Any]],
+               removed: list[dict[str, Any]]) -> None:
+    labels = ["Add a peer", "Remove a peer", "Change peer details",
+              "Return to main menu"]
+    while True:
+        action = choose("Peer definitions", labels, 4)
+        if action == 3:
+            return
+        if action == 0:
+            peer = ask_peer({str(item["name"]) for item in plan["peers"]})
+            if peer is not None:
+                plan["peers"].append(peer)
+                added.append(peer)
+                print("No talkgroups are shared with the new peer automatically.")
+            continue
+        if not plan["peers"]:
+            print("No peers are configured.")
+            continue
+        index = choose("Select a peer", [str(peer["name"]) for peer in plan["peers"]])
+        peer = plan["peers"][index]
+        if action == 1:
+            affected = [route for route in plan["talkgroups"]
+                        if peer["name"] in route["import_from"]]
+            if affected:
+                print("\nAffected talkgroups:")
+                for route in affected:
+                    print(f"  TG {route['tg']} - {route['description']}")
+            if not ask_bool(f"Remove peer {peer['name']} and these permissions", False):
+                continue
+            for route in affected:
+                route["import_from"].remove(peer["name"])
+                route["export_to"].remove(peer["name"])
+                if not route["import_from"]:
+                    route["distribution"] = "local"
+            plan["peers"].remove(peer)
+            removed.append(copy.deepcopy(peer))
+        elif action == 2:
+            peer["host"] = ask("Remote federation service hostname", peer["host"])
+            peer["reflector_id"] = peer["host"]
+            peer["port"] = ask_int("Remote service port", peer["port"], 1, 65535)
+            peer["connect"] = ask_bool(
+                f"Maintain an outgoing connection to {peer['name']}",
+                bool(peer.get("connect")))
+            peer["trust_callsign"] = ask(
+                f"Incoming identity used by {peer['name']}",
+                peer["trust_callsign"]).upper()
+            if peer not in added:
+                added.append(copy.deepcopy(peer))
+
+
+def edit_reflector(plan: dict[str, Any]) -> None:
+    reflector = plan["reflector"]
+    print("\nChanging these values requires corresponding changes on affected peers.")
+    reflector["domain"] = ask("Federation domain", reflector["domain"]).upper()
+    reflector["reflector_id"] = ask(
+        "Federation service hostname", reflector["reflector_id"])
+    reflector["callsign"] = ask(
+        "Outgoing federation identity", reflector["callsign"]).upper()
+    reflector["library"] = ask("Federation policy file", reflector["library"])
+    reflector["enable"] = ask_bool(
+        "Enable federation in generated configuration",
+        bool(reflector.get("enable")))
+    for route in plan["talkgroups"]:
+        if route["ownership"] == "domain":
+            route["home"] = reflector["domain"]
+
+
+def save_edited_plan(path: Path, before: dict[str, Any], after: dict[str, Any],
+                     added: list[dict[str, Any]],
+                     removed: list[dict[str, Any]], output: Path) -> int:
+    after = normalise_plan(after)
+    if after == before:
+        print("No changes were made.")
+        return 0
+    after["library_generation"] = int(before["library_generation"]) + 1
+    errors, warnings = validate_plan(after)
+    print_messages(errors, warnings)
+    if errors:
+        print("Changes were not saved.", file=sys.stderr)
+        return 1
+    print("\nProposed changes:\n")
+    print(plan_diff(before, after))
+    show_plan(after)
+    print(f"\nPolicy generation will advance from "
+          f"{before['library_generation']} to {after['library_generation']}.")
+    if not ask_bool("Save these changes and generate a candidate policy", False):
+        print("No file was changed.")
+        return 0
+
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup = path.with_name(path.name + f".{stamp}.bak")
+    write_text(backup, json_text(before), 0o644)
+    write_json(path, after, replace=True)
+    domain_dir = output / safe_name(after["reflector"]["domain"])
+    candidate = domain_dir / (
+        f"federation-generation-{after['library_generation']}.json")
+    write_json(candidate, federation_library(after))
+    for peer in added:
+        snippet = domain_dir / f"peer-{safe_name(peer['name'])}.conf"
+        write_text(snippet, peer_snippet(peer), 0o600)
+    for peer in removed:
+        checklist = domain_dir / f"remove-peer-{safe_name(peer['name'])}.txt"
+        write_text(checklist, peer_removal(peer), 0o600)
+    print(f"\nPlan saved: {path}")
+    print(f"Previous plan: {backup}")
+    print(f"Candidate policy: {candidate}")
+    print("No installed files were changed.")
+    return 0
+
+
+def edit_plan(path: Path, output: Path) -> int:
+    try:
+        original = normalise_plan(load_plan(path))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    errors, warnings = validate_plan(original)
+    print_messages(errors, warnings)
+    if errors:
+        return 1
+    proposed = copy.deepcopy(original)
+    added: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+    labels = ["Talkgroup policy", "Peer definitions", "Local reflector details",
+              "Review proposed plan", "Save and generate", "Exit without changes"]
+    while True:
+        show_plan(proposed)
+        action = choose("Edit federation plan", labels, 4)
+        if action == 0:
+            edit_talkgroups(proposed)
+        elif action == 1:
+            edit_peers(proposed, added, removed)
+        elif action == 2:
+            edit_reflector(proposed)
+        elif action == 3:
+            print("\n" + (plan_diff(original, proposed) or "No changes."))
+        elif action == 4:
+            return save_edited_plan(path, original, proposed, added, removed, output)
+        else:
+            print("No file was changed.")
+            return 0
 
 
 def check(path: Path) -> int:
@@ -400,7 +825,7 @@ def check(path: Path) -> int:
     return 0
 
 
-def build(path: Path, output_root: Path, placeholders: bool) -> int:
+def show(path: Path) -> int:
     try:
         plan = load_plan(path)
     except ValueError as exc:
@@ -410,27 +835,71 @@ def build(path: Path, output_root: Path, placeholders: bool) -> int:
     print_messages(errors, warnings)
     if errors:
         return 1
+    show_plan(plan)
+    return 0
 
+
+def build(path: Path, output: Path, placeholders: bool) -> int:
+    try:
+        plan = load_plan(path)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    errors, warnings = validate_plan(plan)
+    print_messages(errors, warnings)
+    if errors:
+        return 1
     keys: dict[str, str] = {}
     for peer in plan["peers"]:
-        name = peer["name"]
         if placeholders:
-            keys[name] = "CHANGE_ME"
-            continue
-        key = getpass.getpass(f"AUTH_KEY for outgoing connection to {name} (blank writes CHANGE_ME): ")
-        keys[name] = key or "CHANGE_ME"
-
-    domain_dir = output_root / safe_name(plan["reflector"]["domain"])
-    conf_path = domain_dir / "Federation.conf"
-    library_path = domain_dir / "federation.json"
-    write_text(conf_path, federation_conf(plan, keys), 0o600)
-    write_json(library_path, federation_library(plan), 0o644)
-    print(f"Generated: {conf_path}")
-    print(f"Generated: {library_path}")
+            keys[peer["name"]] = "CHANGE_ME"
+        else:
+            key = getpass.getpass(
+                f"AUTH_KEY for outgoing connection to {peer['name']} "
+                "(blank writes CHANGE_ME): ")
+            keys[peer["name"]] = key or "CHANGE_ME"
+    domain_dir = output / safe_name(plan["reflector"]["domain"])
+    conf = domain_dir / "Federation.conf"
+    library = domain_dir / "federation.json"
+    try:
+        if conf.exists() or library.exists():
+            existing = conf if conf.exists() else library
+            raise FileExistsError(f"File already exists: {existing}")
+        write_text(conf, federation_conf(plan, keys), 0o600)
+        write_json(library, federation_library(plan))
+    except FileExistsError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        print("Use a separate output directory. No existing file was replaced.",
+              file=sys.stderr)
+        return 1
+    print(f"Generated: {conf}")
+    print(f"Generated: {library}")
     if any(value == "CHANGE_ME" for value in keys.values()):
         print("WARNING: Federation.conf contains CHANGE_ME placeholders.")
-    if not plan["reflector"].get("enable"):
-        print("Safety state: ENABLE=0")
+    print("No installed files were changed.")
+    return 0
+
+
+def build_library(path: Path, output: Path) -> int:
+    try:
+        plan = load_plan(path)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    errors, warnings = validate_plan(plan)
+    print_messages(errors, warnings)
+    if errors:
+        return 1
+    candidate = output / safe_name(plan["reflector"]["domain"]) / (
+        f"federation-generation-{plan['library_generation']}.json")
+    try:
+        write_json(candidate, federation_library(plan))
+    except FileExistsError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        print("No existing file was replaced.", file=sys.stderr)
+        return 1
+    print(f"Candidate policy: {candidate}")
+    print("No installed files were changed.")
     return 0
 
 
@@ -438,27 +907,39 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Plan and generate native SVXReflector federation configuration")
     sub = parser.add_subparsers(dest="command", required=True)
-
-    new_parser = sub.add_parser("new", help="run the per-reflector questionnaire")
-    new_parser.add_argument("plan", type=Path, help="planning JSON to create")
-
-    check_parser = sub.add_parser("check", help="validate an existing planning JSON")
+    new_parser = sub.add_parser("new", help="create a new per-reflector plan")
+    new_parser.add_argument("plan", type=Path)
+    edit_parser = sub.add_parser("edit", help="review and change an existing plan")
+    edit_parser.add_argument("plan", type=Path)
+    edit_parser.add_argument("--output", type=Path, default=Path("generated"))
+    show_parser = sub.add_parser("show", help="display a readable plan summary")
+    show_parser.add_argument("plan", type=Path)
+    check_parser = sub.add_parser("check", help="validate an existing plan")
     check_parser.add_argument("plan", type=Path)
-
-    build_parser = sub.add_parser("build", help="generate Federation.conf and federation.json")
+    build_parser = sub.add_parser(
+        "build", help="create initial Federation.conf and federation.json")
     build_parser.add_argument("plan", type=Path)
     build_parser.add_argument("--output", type=Path, default=Path("generated"))
     build_parser.add_argument(
         "--placeholders", action="store_true",
         help="write CHANGE_ME instead of requesting authentication keys")
-
+    library_parser = sub.add_parser(
+        "library", help="generate a versioned federation policy candidate")
+    library_parser.add_argument("plan", type=Path)
+    library_parser.add_argument("--output", type=Path, default=Path("generated"))
     args = parser.parse_args()
     if args.command == "new":
         return new_plan(args.plan)
+    if args.command == "edit":
+        return edit_plan(args.plan, args.output)
+    if args.command == "show":
+        return show(args.plan)
     if args.command == "check":
         return check(args.plan)
     if args.command == "build":
         return build(args.plan, args.output, args.placeholders)
+    if args.command == "library":
+        return build_library(args.plan, args.output)
     return 2
 
 

--- a/src/svxlink/reflector/svx_federation_builder.py
+++ b/src/svxlink/reflector/svx_federation_builder.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Interactive planner and file generator for native SVXReflector federation.
+
+The planning JSON deliberately contains no authentication keys.  The build
+command requests them privately, or writes CHANGE_ME placeholders when asked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PLAN_SCHEMA = 1
+OWNERSHIP = ("domain", "peer", "network-wide")
+DISTRIBUTION = ("local", "selected-peers", "network-wide")
+
+
+def ask(prompt: str, default: str | None = None, required: bool = True) -> str:
+    suffix = f" [{default}]" if default is not None else ""
+    while True:
+        value = input(f"{prompt}{suffix}: ").strip()
+        if not value and default is not None:
+            return default
+        if value or not required:
+            return value
+        print("A value is required.")
+
+
+def ask_bool(prompt: str, default: bool = False) -> bool:
+    marker = "Y/n" if default else "y/N"
+    while True:
+        value = input(f"{prompt} [{marker}]: ").strip().lower()
+        if not value:
+            return default
+        if value in ("y", "yes", "1", "true"):
+            return True
+        if value in ("n", "no", "0", "false"):
+            return False
+        print("Please answer yes or no.")
+
+
+def ask_int(prompt: str, default: int | None = None, minimum: int = 0) -> int:
+    while True:
+        raw = ask(prompt, str(default) if default is not None else None)
+        try:
+            value = int(raw)
+        except ValueError:
+            print("Enter a whole number.")
+            continue
+        if value < minimum:
+            print(f"Enter a value of at least {minimum}.")
+            continue
+        return value
+
+
+def ask_choice(prompt: str, choices: tuple[str, ...], default: str) -> str:
+    while True:
+        value = ask(f"{prompt} ({'/'.join(choices)})", default).lower()
+        if value in choices:
+            return value
+        print("Choose one of: " + ", ".join(choices))
+
+
+def ask_csv(prompt: str, allowed: set[str], default: list[str] | None = None) -> list[str]:
+    default_text = ",".join(default or [])
+    while True:
+        raw = ask(prompt, default_text, required=False)
+        values = [item.strip() for item in raw.split(",") if item.strip()]
+        unknown = sorted(set(values) - allowed)
+        if unknown:
+            print("Unknown peer name(s): " + ", ".join(unknown))
+            continue
+        return list(dict.fromkeys(values))
+
+
+def safe_name(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-.")
+    return cleaned or "reflector"
+
+
+def write_json(path: Path, value: Any, mode: int = 0o644) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    os.chmod(temporary, mode)
+    temporary.replace(path)
+
+
+def write_text(path: Path, value: str, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(value, encoding="utf-8")
+    os.chmod(temporary, mode)
+    temporary.replace(path)
+
+
+def new_plan(path: Path) -> int:
+    print("\nSVXReflector federation plan questionnaire")
+    print("Authentication keys are not collected or stored in this plan.\n")
+
+    domain = ask("Local federation DOMAIN", "UK-TEST")
+    reflector = {
+        "domain": domain,
+        "reflector_id": ask("Stable REFLECTOR_ID"),
+        "callsign": ask("Federation access CALLSIGN/service identity"),
+        "library": ask("Installed federation library path", "/etc/svxlink/federation.json"),
+        "enable": ask_bool("Generate Federation.conf with ENABLE=1", False),
+    }
+
+    peers: list[dict[str, Any]] = []
+    print("\nEnter configured peers. Peer names must match federation policy names.")
+    while ask_bool("Add a peer", not peers):
+        name = ask("Peer name").upper()
+        peers.append({
+            "name": name,
+            "host": ask("Remote hostname or address"),
+            "reflector_id": ask("Expected remote REFLECTOR_ID"),
+            "port": ask_int("Remote TCP/UDP service port", 35300, 1),
+            "protocol": ask_int("SVXReflector client protocol", 2, 1),
+            "connect": ask_bool("Maintain an outgoing connector", True),
+            "trust_callsign": ask("Trusted incoming federation identity from this peer"),
+        })
+
+    peer_names = {peer["name"] for peer in peers}
+    talkgroups: list[dict[str, Any]] = []
+    print("\nEnter talkgroups. Leave the TG prompt blank when finished.")
+    while True:
+        raw = ask("Talkgroup number", required=False)
+        if not raw:
+            break
+        try:
+            tg = int(raw)
+        except ValueError:
+            print("Talkgroup must be a positive whole number.")
+            continue
+        if tg <= 0:
+            print("Talkgroup must be greater than zero.")
+            continue
+
+        description = ask("Service or description")
+        ownership = ask_choice("Ownership", OWNERSHIP, "domain")
+        distribution = ask_choice("Distribution", DISTRIBUTION, "local")
+
+        if ownership == "domain":
+            home_default = domain
+        elif ownership == "network-wide":
+            home_default = "NETWORK-WIDE"
+        else:
+            home_default = next(iter(peer_names), "")
+
+        home = ask("Administrative home domain or peer", home_default or None)
+        service_anchor = ask("Service anchor (blank if none)", "", required=False)
+        allstar_node = ask("Associated AllStar node (blank if none)", "", required=False)
+
+        if distribution == "local":
+            import_from: list[str] = []
+            export_to: list[str] = []
+        else:
+            defaults = sorted(peer_names) if distribution == "network-wide" else []
+            import_from = ask_csv("Permit import from peers (comma-separated)", peer_names, defaults)
+            export_to = ask_csv("Permit export to peers (comma-separated)", peer_names, defaults)
+
+        talkgroups.append({
+            "tg": tg,
+            "description": description,
+            "ownership": ownership,
+            "home": home,
+            "distribution": distribution,
+            "service_anchor": service_anchor,
+            "allstar_node": int(allstar_node) if allstar_node.isdigit() else allstar_node,
+            "import_from": import_from,
+            "export_to": export_to,
+        })
+
+    plan = {
+        "plan_schema": PLAN_SCHEMA,
+        "library_generation": ask_int("Initial library generation", 1, 1),
+        "reflector": reflector,
+        "peers": peers,
+        "talkgroups": talkgroups,
+    }
+
+    errors, warnings = validate_plan(plan)
+    print_messages(errors, warnings)
+    if errors:
+        print("Plan was not written because validation failed.", file=sys.stderr)
+        return 1
+
+    write_json(path, plan)
+    print(f"\nPlan written: {path}")
+    return 0
+
+
+def load_plan(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Plan not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError("Plan root must be a JSON object")
+    return value
+
+
+def validate_plan(plan: dict[str, Any]) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if plan.get("plan_schema") != PLAN_SCHEMA:
+        errors.append(f"plan_schema must be {PLAN_SCHEMA}")
+
+    reflector = plan.get("reflector")
+    if not isinstance(reflector, dict):
+        return ["reflector must be an object"], warnings
+    for field in ("domain", "reflector_id", "callsign", "library"):
+        if not isinstance(reflector.get(field), str) or not reflector[field].strip():
+            errors.append(f"reflector.{field} is required")
+    if reflector.get("library") and not str(reflector["library"]).startswith("/"):
+        warnings.append("reflector.library is normally an absolute path")
+
+    peers = plan.get("peers", [])
+    if not isinstance(peers, list):
+        return errors + ["peers must be an array"], warnings
+    peer_names: list[str] = []
+    peer_ids: list[str] = []
+    trust_ids: list[str] = []
+    for index, peer in enumerate(peers):
+        label = f"peers[{index}]"
+        if not isinstance(peer, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        for field in ("name", "host", "reflector_id", "trust_callsign"):
+            if not isinstance(peer.get(field), str) or not peer[field].strip():
+                errors.append(f"{label}.{field} is required")
+        name = str(peer.get("name", ""))
+        if name:
+            peer_names.append(name)
+        peer_ids.append(str(peer.get("reflector_id", "")))
+        trust_ids.append(str(peer.get("trust_callsign", "")))
+        port = peer.get("port")
+        if not isinstance(port, int) or not 1 <= port <= 65535:
+            errors.append(f"{label}.port must be between 1 and 65535")
+        if peer.get("protocol") != 2:
+            warnings.append(f"{label}.protocol is not the currently documented value 2")
+
+    for values, label in ((peer_names, "peer name"), (peer_ids, "peer reflector_id"), (trust_ids, "trust identity")):
+        duplicates = sorted({item for item in values if item and values.count(item) > 1})
+        if duplicates:
+            errors.append(f"Duplicate {label}(s): {', '.join(duplicates)}")
+
+    peer_set = set(peer_names)
+    talkgroups = plan.get("talkgroups", [])
+    if not isinstance(talkgroups, list):
+        return errors + ["talkgroups must be an array"], warnings
+    seen_tgs: set[int] = set()
+    for index, route in enumerate(talkgroups):
+        label = f"talkgroups[{index}]"
+        if not isinstance(route, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        tg = route.get("tg")
+        if not isinstance(tg, int) or tg <= 0:
+            errors.append(f"{label}.tg must be a positive whole number")
+        elif tg in seen_tgs:
+            errors.append(f"Duplicate talkgroup: {tg}")
+        else:
+            seen_tgs.add(tg)
+        if route.get("ownership") not in OWNERSHIP:
+            errors.append(f"{label}.ownership must be one of {', '.join(OWNERSHIP)}")
+        distribution = route.get("distribution")
+        if distribution not in DISTRIBUTION:
+            errors.append(f"{label}.distribution must be one of {', '.join(DISTRIBUTION)}")
+        if not isinstance(route.get("home"), str) or not route["home"].strip():
+            errors.append(f"{label}.home is required")
+        for field in ("import_from", "export_to"):
+            values = route.get(field, [])
+            if not isinstance(values, list) or any(not isinstance(item, str) for item in values):
+                errors.append(f"{label}.{field} must be an array of peer names")
+                continue
+            unknown = sorted(set(values) - peer_set)
+            if unknown:
+                errors.append(f"{label}.{field} contains unknown peers: {', '.join(unknown)}")
+        if distribution == "local" and (route.get("import_from") or route.get("export_to")):
+            errors.append(f"{label} is local but has peer permissions")
+        if distribution != "local" and not (route.get("import_from") or route.get("export_to")):
+            warnings.append(f"TG {tg} is federated but has no peer permissions")
+        if route.get("ownership") == "network-wide" and not route.get("service_anchor"):
+            warnings.append(f"Network-wide TG {tg} has no service anchor yet")
+
+    generation = plan.get("library_generation")
+    if not isinstance(generation, int) or generation < 1:
+        errors.append("library_generation must be a positive whole number")
+    return errors, warnings
+
+
+def print_messages(errors: list[str], warnings: list[str]) -> None:
+    for warning in warnings:
+        print(f"WARNING: {warning}")
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+
+
+def federation_library(plan: dict[str, Any]) -> dict[str, Any]:
+    domain = plan["reflector"]["domain"]
+    routes: list[dict[str, Any]] = []
+    policies: dict[str, dict[str, list[str]]] = {
+        peer["name"]: {"import": [], "export": []}
+        for peer in plan["peers"]
+    }
+
+    for tg in plan["talkgroups"]:
+        if tg["distribution"] == "local":
+            continue
+        route: dict[str, Any] = {
+            "type": "exact",
+            "value": tg["tg"],
+            "home": tg["home"],
+            "scope": "family",
+            "description": tg["description"],
+        }
+        if tg.get("service_anchor"):
+            route["service_anchor"] = tg["service_anchor"]
+        routes.append(route)
+        value = str(tg["tg"])
+        for peer in tg.get("import_from", []):
+            policies[peer]["import"].append(value)
+        for peer in tg.get("export_to", []):
+            policies[peer]["export"].append(value)
+
+    for policy in policies.values():
+        policy["import"] = sorted(set(policy["import"]), key=int)
+        policy["export"] = sorted(set(policy["export"]), key=int)
+
+    return {
+        "schema": 1,
+        "generation": plan["library_generation"],
+        "domain": domain,
+        "routes": sorted(routes, key=lambda route: route["value"]),
+        "peer_policy": policies,
+    }
+
+
+def federation_conf(plan: dict[str, Any], keys: dict[str, str]) -> str:
+    reflector = plan["reflector"]
+    peers = plan["peers"]
+    lines = [
+        "###################################################################",
+        "# Generated SVXReflector federation configuration",
+        "# Review before installing as svxreflector.d/Federation.conf",
+        "###################################################################",
+        "",
+        "[FEDERATION]",
+        f"ENABLE={1 if reflector.get('enable') else 0}",
+        f"DOMAIN={reflector['domain']}",
+        f"REFLECTOR_ID={reflector['reflector_id']}",
+        f"CALLSIGN={reflector['callsign']}",
+        f"LIBRARY={reflector['library']}",
+        "PEERS=" + ",".join(peer["name"] for peer in peers),
+        "",
+    ]
+    for peer in peers:
+        lines.extend([
+            f"[FEDERATION_PEER_{peer['name']}]",
+            f"HOST={peer['host']}",
+            f"REFLECTOR_ID={peer['reflector_id']}",
+            f"PORT={peer['port']}",
+            f"PROTOCOL={peer['protocol']}",
+            f"AUTH_KEY={keys[peer['name']]}",
+            f"CONNECT={1 if peer.get('connect') else 0}",
+            "",
+        ])
+    if peers:
+        lines.append("[FEDERATION_TRUST]")
+        for peer in peers:
+            lines.append(f"{peer['trust_callsign']}={peer['name']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def check(path: Path) -> int:
+    try:
+        plan = load_plan(path)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    errors, warnings = validate_plan(plan)
+    print_messages(errors, warnings)
+    if errors:
+        return 1
+    print(f"Plan is valid: {path}")
+    print(f"Peers: {len(plan['peers'])}; talkgroups: {len(plan['talkgroups'])}")
+    print(f"Federated routes emitted: {len(federation_library(plan)['routes'])}")
+    return 0
+
+
+def build(path: Path, output_root: Path, placeholders: bool) -> int:
+    try:
+        plan = load_plan(path)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    errors, warnings = validate_plan(plan)
+    print_messages(errors, warnings)
+    if errors:
+        return 1
+
+    keys: dict[str, str] = {}
+    for peer in plan["peers"]:
+        name = peer["name"]
+        if placeholders:
+            keys[name] = "CHANGE_ME"
+            continue
+        key = getpass.getpass(f"AUTH_KEY for outgoing connection to {name} (blank writes CHANGE_ME): ")
+        keys[name] = key or "CHANGE_ME"
+
+    domain_dir = output_root / safe_name(plan["reflector"]["domain"])
+    conf_path = domain_dir / "Federation.conf"
+    library_path = domain_dir / "federation.json"
+    write_text(conf_path, federation_conf(plan, keys), 0o600)
+    write_json(library_path, federation_library(plan), 0o644)
+    print(f"Generated: {conf_path}")
+    print(f"Generated: {library_path}")
+    if any(value == "CHANGE_ME" for value in keys.values()):
+        print("WARNING: Federation.conf contains CHANGE_ME placeholders.")
+    if not plan["reflector"].get("enable"):
+        print("Safety state: ENABLE=0")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Plan and generate native SVXReflector federation configuration")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    new_parser = sub.add_parser("new", help="run the per-reflector questionnaire")
+    new_parser.add_argument("plan", type=Path, help="planning JSON to create")
+
+    check_parser = sub.add_parser("check", help="validate an existing planning JSON")
+    check_parser.add_argument("plan", type=Path)
+
+    build_parser = sub.add_parser("build", help="generate Federation.conf and federation.json")
+    build_parser.add_argument("plan", type=Path)
+    build_parser.add_argument("--output", type=Path, default=Path("generated"))
+    build_parser.add_argument(
+        "--placeholders", action="store_true",
+        help="write CHANGE_ME instead of requesting authentication keys")
+
+    args = parser.parse_args()
+    if args.command == "new":
+        return new_plan(args.plan)
+    if args.command == "check":
+        return check(args.plan)
+    if args.command == "build":
+        return build(args.plan, args.output, args.placeholders)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/svxlink/reflector/svxreflector.conf.in
+++ b/src/svxlink/reflector/svxreflector.conf.in
@@ -5,7 +5,7 @@
 ###################################################################
 
 [GLOBAL]
-#CFG_DIR=svxreflector.d
+CFG_DIR=svxreflector.d
 TIMESTAMP_FORMAT="%c"
 LISTEN_PORT=5300
 #SQL_TIMEOUT=600


### PR DESCRIPTION
## Summary

This pull request adds native federation support to SVXReflector. It allows independently administered reflectors to exchange selected talkgroup streams while retaining their existing local users, talkgroup handling, authentication and operational control.

## Meaning of federation

In this implementation, **federation** means a controlled association of separate, independently administered SVXReflectors.

Each reflector remains an autonomous system with its own users, access rules, talkgroups, configuration and administrator. Federation does not combine the reflectors into one central server, create a shared user database or automatically distribute every talkgroup.

Instead, participating reflectors establish authenticated peer connections and exchange only those talkgroup streams that their administrators have explicitly permitted through local import and export policy. Each reflector may decide which peers it trusts, which talkgroups it contributes and which incoming talkgroups it accepts.

The purpose is therefore selective cooperation between independent SVXReflectors, rather than centralised control or unrestricted linking.

Federation is disabled by default and must be explicitly configured by each reflector administrator.

## Intended changes

The implementation adds:

* authenticated federation peer sessions;
* configurable peer identities and trust mappings;
* explicit federation hello and acknowledgement messages;
* incoming and outgoing stream control;
* OPUS-only federation audio transport;
* UDP registration, sequencing and heartbeat handling;
* buffering of local audio while a remote stream request is awaiting acceptance;
* import and export policy for individual peers and talkgroups;
* routing based on an external JSON federation library;
* local notification of imported talker start and stop events;
* cleanup of local and imported streams following flush, disconnect or timeout;
* protection against re-exporting imported federation audio;
* independently maintained connections in each direction;
* an example `Federation.conf` installed under `svxreflector.d`;
* design, configuration and operational documentation in `ReflectorFederation.md`.

The implementation uses the existing SVXReflector access and transport infrastructure. Federation peers authenticate using administrator-issued service identities, which must be authorised through the receiving reflector’s normal callsign and access-registration mechanism and then mapped to a configured peer using `[FEDERATION_TRUST]`.

Talkgroups and ordinary client audio handling remain unchanged. Federation only exports talkgroups that are explicitly permitted by local policy.

## Configuration and compatibility

Federation is disabled unless the following is explicitly configured:

```ini
[FEDERATION]
ENABLE=1
```

Installing the modified SVXReflector therefore does not automatically join a reflector to a federation or alter its existing talkgroup operation.

Existing `svxreflector.conf` and `Federation.conf` files are protected by the existing install-if-not-present behaviour. Peer connections, trust identities, routing policy and import/export permissions remain under the control of each local administrator.

The current implementation supports OPUS federation streams only.

## Development and testing

The work was developed incrementally from the official `sm0svx/svxlink` source tree and is based on the existing SVXReflector message, client, authentication, TCP and UDP infrastructure.

Testing has included:

* configuration and policy validation;
* authenticated peer connection and reconnection;
* federation hello negotiation;
* confirmed UDP registration and heartbeat handling;
* incoming and outgoing stream acceptance;
* queued audio while stream acceptance is pending;
* OPUS audio delivery between two local reflectors;
* stream flush and stop handling;
* cleanup following an ordinary client disconnect without a flush;
* local talker start, audio, flush and talker stop delivery for imported streams;
* one-way and bilateral UK/North America test configurations;
* complete Debian 12 builds with documentation;
* installation to the normal `/usr` and `/etc/svxlink` locations.

The tests used purpose-built local configurations, clients and lifecycle harnesses. Federation was exercised alongside ordinary V2 client connections and the existing SVXReflector talkgroup handling.

## Provenance and independent development

This implementation was developed solely from the official SVXReflector source and protocol structures contained in the `sm0svx/svxlink` repository, together with operational requirements and tests derived from the G4NAB reflector environment.

No 'GeuReflector' source code, patches, documentation, protocol definitions, architecture or implementation details were consulted, copied, adapted, translated or used as a reference when designing or implementing this change. No part of this pull request is derived from or contributed by that separate project.

'GeuReflector' is mentioned here only to make the independent provenance of this implementation unambiguous.

## Status

The implementation has passed controlled local federation and lifecycle testing. Protocol and configuration compatibility are not yet declared stable, and review of the design and implementation is welcomed before production deployment.

##Addendum:
This change includes svx_federation_builder.py, an installed administrative utility for creating and validating per-reflector planning JSON and generating the corresponding Federation.conf and federation.json. Authentication keys are deliberately excluded from planning files and are requested privately during generation. The federation documentation now provides the complete planning, validation, generation, review and installation workflow.